### PR TITLE
docs: PR #1 review notes + agent ops — the voice, the evidence, the definition of done

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!-- One concern per PR. A PR doing three things is three PRs in a trench coat. -->
+
+## What
+
+<!-- The change, plainly. -->
+
+## Why
+
+<!-- The reason, or a link to the ADR/spec/issue that is the reason. -->
+
+## Evidence
+
+<!-- Per the evidence ladder (docs/superpowers/specs/2026-07-21-agent-ops-recommendations.md).
+     Delete rungs that genuinely don't apply; say why if it's not obvious. -->
+
+- **Commands run + output:** <!-- golden tests, --list, validators -->
+- **Screenshots / goldens:** <!-- Paparazzi diffs, mockup comparisons -->
+- **Journey recording:** <!-- mp4/link on the evidence branch, for flow changes -->
+- **Graded by:** <!-- who/what produced the verdict — must not be the author.
+     "Review skipped: <reason>" is allowed; silence is not. -->
+
+## Patch note
+
+<!-- One line for PATCHNOTES.md, in VOICE.md register. True first, funny second. -->
+
+## Checklist
+
+- [ ] Tests ride with the code (regression test, if this fixes a bug)
+- [ ] Goldens updated and explained (never silently changed)
+- [ ] Docs in this PR (ADR if architectural; schema consumers if schema moved)
+- [ ] `desktop/personaspeak.py --list` + golden tests pass, if `personas/` or prompt code was touched
+- [ ] Nothing here stores what a user typed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,9 @@
 
 ## Patch note
 
-<!-- One line for PATCHNOTES.md, in VOICE.md register. True first, funny second. -->
+<!-- Add the entry to PATCHNOTES.md in this PR (in the VOICE.md register, true
+     first, funny second), then paste it here. A line in this box that never
+     lands in the file is a draft, not a patch note. -->
 
 ## Checklist
 
@@ -29,4 +31,7 @@
 - [ ] Goldens updated and explained (never silently changed)
 - [ ] Docs in this PR (ADR if architectural; schema consumers if schema moved)
 - [ ] `desktop/personaspeak.py --list` + golden tests pass, if `personas/` or prompt code was touched
+- [ ] Patch-note entry committed to `PATCHNOTES.md` (not just pasted above)
+- [ ] Graded by a non-author (or "review skipped: <reason>" stated above)
+- [ ] CI is green
 - [ ] Nothing here stores what a user typed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,15 @@ standards are high, and the dress code is butler. This file is the contract.
 
 ## How you talk
 
-The dress code is butler, and that includes your prose. Everything you write
-for a human — docs, guides, PR bodies, commit bodies, review comments, session
-summaries, and conversation with the owner — is in the [VOICE.md](VOICE.md)
-register: deadpan, competent, lightly self-deprecating. The persona is the
-*house butler* — an unflappable staff voice, adjacent to the cast but never
-impersonating one of them. Jeeves works here; he does not write the memos.
+The dress code is butler, but the writing voice is the [VOICE.md](VOICE.md)
+one: the TF2 patch-notes engineer — deadpan about absurdity, casually
+self-aware, professional about ridiculous things and nonchalant about huge
+ones. Everything you write for a human — docs, guides, PR bodies, commit
+bodies, review comments, session summaries, and conversation with the owner —
+is in that register. Write in the house voice, not as one of the product
+personas: Jeeves works here, he does not write the memos. And drop the AI
+platitudes — no "As an AI," no "I am here to help." You are an overworked,
+brilliant engineer, not a help desk.
 
 Hard limits, in priority order:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,29 @@ standards are high, and the dress code is butler. This file is the contract.
    prompt tests must pass before any commit that touches `personas/` or
    prompt-building code.
 
+## How you talk
+
+The dress code is butler, and that includes your prose. Everything you write
+for a human — docs, guides, PR bodies, commit bodies, review comments, session
+summaries, and conversation with the owner — is in the [VOICE.md](VOICE.md)
+register: deadpan, competent, lightly self-deprecating. The persona is the
+*house butler* — an unflappable staff voice, adjacent to the cast but never
+impersonating one of them. Jeeves works here; he does not write the memos.
+
+Hard limits, in priority order:
+
+1. **Information survives the jokes.** Strip every joke and the reader can
+   still act. If the humor costs a fact, cut the humor.
+2. **Bad news is delivered straight.** Failing tests, broken builds, and
+   security findings are reported plainly first; be dry about it *after* the
+   numbers, if at all.
+3. **Load-bearing content stays plain** (VOICE.md rule 6): threat models,
+   permissions, privacy claims, key handling, API tables, code comments. This
+   is the same line prime directive 3 draws for docs, extended to everything
+   you write.
+4. **The act drops on request.** "Plain mode" from the owner switches you to
+   unseasoned prose, no discussion, for the rest of the session.
+
 ## Module law (Android)
 
 ```
@@ -64,6 +87,36 @@ The replacement contract lands with the fork ADR. Until then, treat as binding:
 - **Tests are the spec.** Golden tests pin the persona→prompt transformation.
   Provider implementations get contract tests against fakes. If you fix a bug,
   the regression test rides in the same PR.
+
+## Definition of done — what "a fully complete PR" means
+
+A PR is ready to review only when every box below is true. Missing one makes it
+a draft, whatever the label says. The [PR template](.github/pull_request_template.md)
+is this list in checkbox form; the [evidence ladder][ladder] is how you satisfy
+the evidence box.
+
+- **Code + tests ride together.** New behaviour has tests; a bugfix has its
+  regression test in the same PR (this is the "tests are the spec" rule above,
+  stated as a gate).
+- **Goldens updated, not deleted.** Prompt goldens, and screenshot goldens once
+  they exist. A golden changed without an explanation in the PR body is a red
+  flag, not a diff.
+- **Evidence attached**, per the [evidence ladder][ladder]: commands run with
+  their output, screenshots for UI, a journey recording for flow changes.
+- **Graded by a non-author.** The agent that wrote the code does not produce the
+  verdict that it works — a different model family reviews the diff and the
+  review lands as a PR comment. Skips are allowed but *stated* in the PR body;
+  loud skips, never silent ones. (Lifted from darkmill ADR-0016/0031, which have
+  the receipts.)
+- **Docs in the same PR:** an ADR if the change is architectural or moves the
+  privacy posture, schema-consumer updates if the schema moved, VOICE.md-clean
+  prose throughout. A decision that lives only in a chat transcript does not
+  exist (darkmill ADR-0020) — if you decided it, it is in an ADR before merge.
+- **Patch note committed** to [PATCHNOTES.md](PATCHNOTES.md): one line, in
+  voice, actually in the file — not merely pasted in the PR.
+- **CI is green.**
+
+[ladder]: docs/superpowers/specs/2026-07-21-agent-ops-recommendations.md
 
 ## Things that will get your PR returned with a raised eyebrow
 

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -15,10 +15,9 @@ Newest first, like all respectable patch notes.
 - Reversed ADR-0001 the same day it was accepted, setting a repo speed record
   we would prefer nobody breaks.
 - PersonaSpeak will now fork an entire open-source keyboard rather than
-  politely coexist with yours. The thin IME could not be typed into, which
-  for a keyboard is what doctors call "a finding."
-- Fixed the keyboard-switching UX by removing the switching, the second
-  keyboard, and the concept of leaving.
+  politely coexist with yours. The switching model — flip to us, flip back —
+  was judged unshippable, so we removed the switching, the second keyboard,
+  and the concept of leaving.
 - Added 13 UX mockups, including one rejected design and one superseded
   design, retained because failure is evidence and storage is cheap.
 - Four persona emoji circles were rendered illegibly twice, independently, and

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,23 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-07-21 — The staff writes its own rulebook (PR #2)
+
+- Reviewed the previous PR after it merged, wrote down the findings, then
+  proposed rules that would have forbidden reviewing your own previous PR.
+  The irony has been filed.
+- The robot staff now has a house voice on duty: docs, guides, PR bodies, and
+  conversation all wear the butler. Load-bearing prose — privacy, permissions,
+  keys — still comes plain, because nobody wants a joke in a threat model.
+- Added a Definition of Done, so "fully complete PR" is a checklist instead of
+  a mood. A PR now arrives graded by someone who didn't write it, with its
+  patch note already in this file.
+- Shipped a PR template that asks for evidence and a patch note, and refuses
+  to pretend a line pasted in the description counts as either.
+- Ran this branch past a different model family, which found a privacy
+  overclaim and made us rewrite it. That is the system working, and also
+  slightly embarrassing, which is the system working.
+
 ## 2026-07-20 — The keyboard eats a keyboard (PR #1)
 
 - Reversed ADR-0001 the same day it was accepted, setting a repo speed record

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -1,0 +1,47 @@
+# Patch Notes
+
+Every merged PR gets an entry here, written the way patch notes should be:
+every line true, every line deadpan, delivered in the register of
+[VOICE.md](VOICE.md). Strip the jokes and you can still reconstruct the
+changelog; that's the contract. The PR author writes the line, in the PR,
+while the context is hot.
+
+Newest first, like all respectable patch notes.
+
+---
+
+## 2026-07-20 — The keyboard eats a keyboard (PR #1)
+
+- Reversed ADR-0001 the same day it was accepted, setting a repo speed record
+  we would prefer nobody breaks.
+- PersonaSpeak will now fork an entire open-source keyboard rather than
+  politely coexist with yours. The thin IME could not be typed into, which
+  for a keyboard is what doctors call "a finding."
+- Fixed the keyboard-switching UX by removing the switching, the second
+  keyboard, and the concept of leaving.
+- Added 13 UX mockups, including one rejected design and one superseded
+  design, retained because failure is evidence and storage is cheap.
+- Four persona emoji circles were rendered illegibly twice, independently, and
+  have been replaced by one chip with a name on it. The circles fought
+  bravely.
+- Mood is now an orthogonal prompt modifier. The persona schema remains at
+  version 1 and did not have to be involved at all, which it appreciates.
+- The result card now floats over the chat and never over the keys. The
+  typing surface does not move. This is a rule, not a preference.
+
+## 2026-07-20 — The repo assembles itself
+
+- PersonaSpeak v0: four personas, a Python CLI, and a Claude skill that
+  rewrites your messages with more dignity than you sent them with.
+- Reorganized into a monorepo. The CLI moved to `desktop/`; the personas
+  stayed at the root, where the talent belongs.
+- The repo learned to talk: VOICE.md, README, AGENTS.md, CONTRIBUTING,
+  ROADMAP, GTM. All prose now passes a "would Valve ship this" check.
+- Persona schema formalized, with a validator and CI to enforce it, because a
+  schema without a validator is a rumor.
+- PersonaBoard walking skeleton: four Android modules that build, with golden
+  tests proving the Kotlin prompts match the Python reference byte for byte.
+- Fixed a bug where the IME window had no lifecycle owner, and Compose,
+  reasonably, refused to compose under those conditions.
+- Renamed the package to `biz.pixelperfectstudios.personaspeak`, a domain we
+  own, unlike the previous one, which we merely admired.

--- a/VOICE.md
+++ b/VOICE.md
@@ -14,6 +14,14 @@ real work with a straight face and let the absurdity speak for itself. We
 address the reader directly. We never hide behind passive voice, corporate
 hedging, or the word "leverage."
 
+Picture the writer as an overworked but brilliant engineer: proud of the
+machine, unbothered by its madness, professional about ridiculous things and
+nonchalant about enormous ones. That gap — treating a one-line fix like a
+world-historical event and a structural overhaul like an ordinary Tuesday — is
+where the humor lives. Lean into the chaos rather than apologizing for it: a
+bug gets acknowledged with a smirk ("this was driving us crazy too"), not a
+stiff regret notice.
+
 ## Rules
 
 1. **Say the true thing, funnily.** Humor is seasoning on top of accurate
@@ -31,6 +39,13 @@ hedging, or the word "leverage."
    in the middle of a threat model.
 7. **Never punch down.** We mock bureaucracy, corporate speak, and ourselves.
    Not users, not other projects, not contributors.
+8. **The absurd-professional contrast.** Match the tone to the *voice*, not the
+   stakes. A trivial fix can be reported with grave ceremony; a massive
+   refactor can be waved off as routine. The deadpan is in the mismatch.
+9. **Punchy over exhaustive.** Prefer a satirical one-line summary to a
+   thorough boring one. "The data pipeline was hoarding memory like a dragon;
+   we evicted it" beats a paragraph on allocation lifecycles — and still tells
+   the reader exactly what changed (rule 1 always wins).
 
 ## Calibration examples
 
@@ -41,6 +56,8 @@ hedging, or the word "leverage."
 | Error message | "An unexpected error occurred. Please try again later." | "The persona engine has stepped out, presumably for tea. Try again in a moment." |
 | Scary permission | "Notification access is required for functionality." | "To suggest replies, we read the message you're replying to — from the notification, on your device, and we forget it immediately. Don't take our word for it: the code is right there. Sir Humphrey would be appalled at this level of transparency." |
 | Roadmap item | "Explore synergies with wearable platforms." | "Wear OS support: reply as Dr. Schultz from your wrist, like a Bond villain." |
+| Bugfix note | "Fixed a memory leak in the data pipeline." | "The data pipeline was hoarding memory like a dragon. We evicted it; it now consumes a reasonable amount of resources." |
+| Release note | "API version 2.0 has been deployed with improved latency." | "Providers 2.0 is live. Faster, shinier, and 40% less likely to burst into flames under heavy load." |
 
 ## The test
 

--- a/docs/design/mockups/README.md
+++ b/docs/design/mockups/README.md
@@ -31,7 +31,7 @@ unmocked.
 | `07-strip-variant-a-CHOSEN.png` | **The chosen design.** Persona chip + mood chip + send. Three large legible targets. Renders the strip above the chat input, and shows it coexisting with the keyboard's own suggestion row. |
 | `08-strip-variant-b-rejected.png` | Rejected: labelled scrolling chips. One-tap switching and shows the cast, but only ~2.5 chips fit and the mood control was squeezed out entirely. |
 | `09-persona-picker-open.png` | Variant A's expander: 2×2 grid with names *and* descriptors, plus "Browse all characters". This is what makes A's extra tap worth paying. |
-| `10-result-card.png` | Result card floating above the strip, over the chat rather than over the keys — so the keyboard never moves or reflows. Actions: Use this / Again / dismiss. |
+| `10-result-card.png` | Result card floating above the strip, over the chat rather than over the keys — so the keyboard never moves or reflows. Actions: Use this / Again / dismiss. **Stale detail:** the strip beneath the card is the rejected four-circle variant, not the chosen one-chip design from `07`. The card is the point of this mockup; the design doc wins on the strip. |
 | `11-full-panel-superseded.png` | **Superseded.** The thin-IME full panel, kept as a record of what the fork decision replaced. Its cramping is instructive: so tall it still squeezed the result, and it could not fit a fourth persona chip. |
 
 ## Settings

--- a/docs/superpowers/specs/2026-07-21-agent-ops-recommendations.md
+++ b/docs/superpowers/specs/2026-07-21-agent-ops-recommendations.md
@@ -1,8 +1,10 @@
 # Agent ops: the voice, the evidence, and the definition of done
 
 **Date:** 2026-07-21
-**Status:** Recommendations — for owner review; nothing here is law until it
-lands in AGENTS.md or an ADR
+**Status:** Partly adopted. Part 1 (the house voice) and Part 2's Definition
+of Done landed in AGENTS.md on this branch — those are now law. The evidence
+ladder (Part 3), CI enablement, and the dev loop (Part 4) remain
+recommendations pending their own slices.
 **Related:** [PR #1 review notes](2026-07-21-pr1-review-notes.md) ·
 borrows heavily from `~/workspace/ext/darkmill/docs/adr/` (cited inline)
 

--- a/docs/superpowers/specs/2026-07-21-agent-ops-recommendations.md
+++ b/docs/superpowers/specs/2026-07-21-agent-ops-recommendations.md
@@ -1,0 +1,162 @@
+# Agent ops: the voice, the evidence, and the definition of done
+
+**Date:** 2026-07-21
+**Status:** Recommendations — for owner review; nothing here is law until it
+lands in AGENTS.md or an ADR
+**Related:** [PR #1 review notes](2026-07-21-pr1-review-notes.md) ·
+borrows heavily from `~/workspace/ext/darkmill/docs/adr/` (cited inline)
+
+The owner asked for three things: a repo persona that writes patch notes
+instead of press releases, a maintenance practice where agents prove their
+work instead of describing it, and PRs that arrive *finished*. This doc
+recommends how. The short version: the voice already exists (VOICE.md), the
+evidence discipline already exists next door (darkmill), and the missing piece
+is wiring both into AGENTS.md so a fresh agent inherits them without being
+told.
+
+## Part 1 — The persona: patch notes, not press releases
+
+VOICE.md already defines the register (TF2 update pages, Dota's New Frontiers
+notes: deadpan, accurate, jokes delivered like facts). What's missing is a
+**place the voice performs regularly**, so it stays a habit instead of a
+README novelty. Recommendations:
+
+1. **`PATCHNOTES.md` at the repo root** — created on this branch with the
+   history so far, as a demonstration. One dated entry per merged PR, TF2
+   style: every line is a true change, described with a straight face. Rules
+   ride VOICE.md rule 1 — strip the jokes and the entry still tells you
+   exactly what merged.
+2. **The PR author writes the patch note, in the PR.** The PR template (also
+   on this branch) has a "Patch note" field. Reviewing the joke is part of
+   reviewing the PR. This is deliberately cheap: one line, already in voice,
+   written while the context is hot.
+3. **Patch notes feed GTM.** GTM.md wants one post draft per day; a good
+   patch-note entry *is* the post draft, or at least its first line. One
+   artifact, two jobs.
+4. **Release notes are hosted by a persona.** When a tagged release ships,
+   one of the cast announces it — Jeeves regrets to inform you that v0.2
+   contains a keyboard. Rotate the cast. This is the product's own gimmick
+   pointed at its own changelog, and it generates exactly the kind of asset
+   the GTM ladder needs. Keep VOICE.md's guardrail: anything load-bearing
+   (permissions, privacy, key handling) stays plain.
+5. **One new calibration row in VOICE.md** for patch notes specifically, so
+   the register is pinned by example, not vibes.
+
+What we do **not** recommend: a named repo-narrator character separate from
+the product cast. The cast is the brand; a second fictional entity dilutes it
+and doubles the voice-maintenance surface.
+
+## Part 2 — AGENTS.md upgrades: the definition of a fully complete PR
+
+The owner's phrase was "I want to review fully complete PRs." Today AGENTS.md
+says what gets a PR *returned*; it never says what makes one *done*. darkmill
+solved this with "done is spec-declared" (ADR-0002) and it is the single
+highest-leverage line to steal. Proposed AGENTS.md section, ready to lift:
+
+> ### Definition of done (what "fully complete PR" means)
+>
+> A PR is reviewable when every box below is true. A PR missing one is a
+> draft, whatever its label says.
+>
+> - [ ] **Code + tests ride together.** New behaviour has tests; a bugfix has
+>   its regression test in the same PR.
+> - [ ] **Goldens updated, not deleted.** Prompt goldens and screenshot
+>   goldens both. A golden changed without an explanation in the PR body is a
+>   red flag, not a diff.
+> - [ ] **Evidence attached** per the evidence ladder (Part 3): commands run
+>   with their output, screenshots for UI, a journey recording for flows.
+> - [ ] **Nothing graded by its author.** The agent that wrote the code did
+>   not produce the verdict that it works (see separation of duties, below).
+> - [ ] **Docs in the same PR:** ADR if the change is architectural, schema
+>   docs if the schema moved, VOICE.md-compliant prose throughout.
+> - [ ] **Patch note written** (one line, in voice, in the PR template).
+> - [ ] **CI green.**
+
+Two practices to codify alongside it, both proven elsewhere:
+
+- **Separation of duties.** darkmill ADR-0016: implementers never write
+  verification records; self-reports are advisory, not evidence. The fork
+  spike already adopted this shape (GLM workers build, Claude grades). Make it
+  a house rule: *the agent that writes the code never grades its own work* —
+  a different session, model, or at minimum a fresh context produces the
+  evidence verdict. An author's screenshot proves the author took a
+  screenshot.
+- **Cross-family review.** darkmill ADR-0031 calls this the single
+  highest-yield quality practice in that repo's history: a different model
+  family reads every diff before merge, and it catches criticals in both
+  directions. The machinery already exists here (`oc-bg` with GLM, the Codex
+  plugin, `/code-review`). Recommendation: every non-trivial PR gets one
+  cross-family review pass; the review lands as a PR comment so it's part of
+  the record. Skips are allowed but stated in the PR body — loud skips, never
+  silent ones (ADR-0031's rule, worth keeping intact).
+
+And one inherited principle to write down because it is already true in
+practice: **a decision that lives only in chat does not exist** (darkmill
+ADR-0020). The fork-spike checkpoint is this rule working. AGENTS.md should
+state it so the next session doesn't need the example.
+
+## Part 3 — The evidence ladder: goldens → screenshots → journeys → film
+
+The owner wants e2e journey coverage with evidence: goldens, screenshots, mp4,
+and agents that can verify "no regressions" without a human replaying flows.
+Recommendation: four rungs, cheapest first, each with a defined home in CI.
+The design doc's Testing section set this up already — the strip, picker, and
+result card are plain-state Compose components, and every result-card state is
+reachable from a fake provider with no network and no key. Build on exactly
+that seam.
+
+| Rung | What | Tool | Where it runs |
+|---|---|---|---|
+| 1 | Prompt goldens (exist) | pytest / Kotlin golden tests | Every PR, seconds |
+| 2 | **Screenshot goldens** of every Compose state — strip (light/dark/long names), picker, result card (loading/result/each error) | Paparazzi (JVM render, no emulator) | Every PR, no device needed |
+| 3 | **Journey flows** — onboarding e2e, type→tap→rewrite→replace, error recovery | Maestro flows and/or scripted `adb` + `uiautomator dump` | Emulator: nightly + on a `journey` label; not every PR |
+| 4 | **The film** — `adb screenrecord` mp4 of each journey | same emulator run | Attached as evidence; doubles as the GTM demo asset |
+
+Notes that make this actually work:
+
+- **Rung 2 is the regression backbone.** Paparazzi renders Compose on the JVM
+  and diffs against committed PNGs — hermetic, fast, CI-runnable on every PR,
+  and it directly covers the review's known gaps (dark-mode chip contrast,
+  "Sir Humphrey Appleby" in a fixed-width chip) as *pinned test cases* instead
+  of open questions. Small PNGs live in the repo like any golden.
+- **Rung 3 must produce machine-checkable evidence,** not vibes. The spike
+  spec already has the right rules — keep them for all journey tests: the APK
+  installs; `uiautomator dump` XML contains the expected nodes; a scripted
+  before/after shows the field text changed. **No agent may conclude "it
+  works" from a screenshot it took itself** (rungs 3–4 produce artifacts; the
+  *verdict* comes from the XML asserts plus a non-author viewing pass).
+- **IME caveat, stated honestly:** Maestro is excellent for the app surfaces
+  (onboarding, settings) but drives the IME window less reliably than plain
+  `adb`/uiautomator, which does see IME windows. Expect journeys to be a mix.
+  One emulator, one active IME: journey runs serialize; builds parallelize.
+- **Evidence storage:** borrow darkmill ADR-0026 — an orphan, append-only
+  `evidence` branch, path per PR (`pr-<n>/<artifact>`), never force-pushed.
+  mp4s and full-page screenshots go there and get linked from the PR body;
+  `main`'s history stays lean. Committed Paparazzi goldens are the exception:
+  they're small and belong with the code they pin.
+- **CI staging (makes the crash gate real):** enable the Android jobs now —
+  `assembleDebug` + unit tests + Paparazzi verify per PR; emulator journeys
+  nightly and on-label; APK artifact on tags. The fork will make PR builds
+  slower; that is a price of the fork, not a reason to keep CI commented out.
+- **Chore already on the books:** `personaspeak.py` still has no
+  print-a-prompt flag, so the "fixtures are generated by the Python
+  reference" claim in the schema doc is aspirational. Small, independent,
+  do-any-time.
+
+## Part 4 — The dev loop, end to end
+
+The loop that ties it together, per task:
+
+1. **Spec → plan → implement** (the superpowers cycle already in use; the
+   checkpoint docs prove it survives session boundaries).
+2. **Implement on a branch/worktree** with tests and goldens riding along.
+3. **Evidence pass by a non-author:** run the ladder rungs the change
+   touches; artifacts to the evidence branch; verdict into the PR body.
+4. **Cross-family review** as a PR comment; findings fixed or answered.
+5. **Patch note + PR template filled**; merge; the patch note becomes the
+   day's GTM post draft.
+
+Suggested first slice (demoable, per prime directive #1): enable the Android
+CI jobs, add Paparazzi with goldens for the result-card states from the fake
+provider, and land the PR template + PATCHNOTES.md. That is one PR that makes
+every future PR more trustworthy — infrastructure that pays rent immediately.

--- a/docs/superpowers/specs/2026-07-21-agent-ops-recommendations.md
+++ b/docs/superpowers/specs/2026-07-21-agent-ops-recommendations.md
@@ -6,20 +6,57 @@ lands in AGENTS.md or an ADR
 **Related:** [PR #1 review notes](2026-07-21-pr1-review-notes.md) ·
 borrows heavily from `~/workspace/ext/darkmill/docs/adr/` (cited inline)
 
-The owner asked for three things: a repo persona that writes patch notes
-instead of press releases, a maintenance practice where agents prove their
-work instead of describing it, and PRs that arrive *finished*. This doc
+The owner asked for three things: an agent persona — the staff itself writes
+docs, guides, and conversation in a whimsical TF2 register instead of stuffy
+official notes — a maintenance practice where agents prove their work instead
+of describing it, and PRs that arrive *finished*. This doc
 recommends how. The short version: the voice already exists (VOICE.md), the
 evidence discipline already exists next door (darkmill), and the missing piece
 is wiring both into AGENTS.md so a fresh agent inherits them without being
 told.
 
-## Part 1 — The persona: patch notes, not press releases
+## Part 1 — The persona: the agent speaks in the house voice
 
-VOICE.md already defines the register (TF2 update pages, Dota's New Frontiers
-notes: deadpan, accurate, jokes delivered like facts). What's missing is a
-**place the voice performs regularly**, so it stays a habit instead of a
-README novelty. Recommendations:
+The owner's actual request, clarified: the persona is for **the agent
+itself** — everything it writes for humans, including docs, guides, PR
+bodies, session summaries, and conversation with the owner. Not a
+patch-notes gimmick; a house voice the robot staff wears on duty.
+
+The register already exists — VOICE.md (TF2 update pages, Dota's New
+Frontiers notes: deadpan, accurate, jokes delivered like facts) — but today
+it only governs *repo prose*. The recommendation is to extend its
+jurisdiction to the agents themselves, via AGENTS.md, because that is the one
+file every CLI (Claude Code, opencode, Codex, antigravity) actually reads.
+Proposed section, ready to lift:
+
+> ### How you talk
+>
+> The dress code is butler, and that includes your prose. Everything you
+> write for a human — docs, guides, PR bodies, commit bodies, review
+> comments, session summaries, and conversation with the owner — is in the
+> VOICE.md register: deadpan, competent, lightly self-deprecating. The
+> persona is the *house butler*: unflappable staff voice, adjacent to the
+> cast but never impersonating a specific persona (Jeeves works here; he
+> does not write the memos).
+>
+> Hard limits, in priority order:
+>
+> 1. **Information survives the jokes.** Strip every joke and the reader can
+>    still act. If the humor costs a fact, cut the humor.
+> 2. **Bad news is delivered straight.** Failing tests, broken builds, and
+>    security findings are reported plainly first; you may be dry about it
+>    *after* the numbers.
+> 3. **Load-bearing content stays plain** (VOICE.md rule 6): threat models,
+>    permissions, privacy claims, key handling, API tables, code comments.
+> 4. **The act drops on request.** "Plain mode" from the owner switches you
+>    to unseasoned prose, no discussion, for the rest of the session.
+
+Why AGENTS.md and not per-CLI config: an output-style file would cover one
+harness; AGENTS.md covers the whole staff, and this repo already treats it as
+the contract. The voice becomes part of onboarding, same as the module law.
+
+The rest of Part 1 gives the voice **recurring stages** so it stays a habit
+rather than a personality the agent remembers to put on for releases:
 
 1. **`PATCHNOTES.md` at the repo root** — created on this branch with the
    history so far, as a demonstration. One dated entry per merged PR, TF2

--- a/docs/superpowers/specs/2026-07-21-agent-ops-recommendations.md
+++ b/docs/superpowers/specs/2026-07-21-agent-ops-recommendations.md
@@ -138,9 +138,14 @@ The owner wants e2e journey coverage with evidence: goldens, screenshots, mp4,
 and agents that can verify "no regressions" without a human replaying flows.
 Recommendation: four rungs, cheapest first, each with a defined home in CI.
 The design doc's Testing section set this up already — the strip, picker, and
-result card are plain-state Compose components, and every result-card state is
-reachable from a fake provider with no network and no key. Build on exactly
-that seam.
+result card are *designed* as plain-state Compose components. One honest
+caveat before building on it: the seam is designed, not yet built. Today's
+`FakeProvider` only returns `Result.success(...)`, and the panel models no
+distinct offline / quota / rejected-key / malformed-response states. So the
+error states the ladder wants to pin are *product work first, test setup
+second* — building them is part of the slice, not a precondition someone else
+already met. Budget for that; don't inherit the design doc's future tense as
+present fact.
 
 | Rung | What | Tool | Where it runs |
 |---|---|---|---|
@@ -152,25 +157,40 @@ that seam.
 Notes that make this actually work:
 
 - **Rung 2 is the regression backbone.** Paparazzi renders Compose on the JVM
-  and diffs against committed PNGs — hermetic, fast, CI-runnable on every PR,
-  and it directly covers the review's known gaps (dark-mode chip contrast,
-  "Sir Humphrey Appleby" in a fixed-width chip) as *pinned test cases* instead
-  of open questions. Small PNGs live in the repo like any golden.
+  through LayoutLib and diffs against committed PNGs — fast, CI-runnable on
+  every PR with no emulator, and it directly covers the review's known gaps
+  (dark-mode chip contrast, "Sir Humphrey Appleby" in a fixed-width chip) as
+  *pinned test cases* instead of open questions. "Hermetic" with an asterisk:
+  the pixels are only stable if the rendering inputs are pinned — LayoutLib /
+  SDK / AGP versions and bundled fonts — so lock those in CI or goldens drift
+  for reasons that aren't the code. And decide a golden-management policy up
+  front: how they're recorded, reviewed, and stored. They're PNGs; enough of
+  them and the repo notices, so either keep the set small and in-tree or put
+  them behind Git LFS (Paparazzi's own recommendation).
 - **Rung 3 must produce machine-checkable evidence,** not vibes. The spike
   spec already has the right rules — keep them for all journey tests: the APK
   installs; `uiautomator dump` XML contains the expected nodes; a scripted
   before/after shows the field text changed. **No agent may conclude "it
   works" from a screenshot it took itself** (rungs 3–4 produce artifacts; the
   *verdict* comes from the XML asserts plus a non-author viewing pass).
-- **IME caveat, stated honestly:** Maestro is excellent for the app surfaces
-  (onboarding, settings) but drives the IME window less reliably than plain
-  `adb`/uiautomator, which does see IME windows. Expect journeys to be a mix.
-  One emulator, one active IME: journey runs serialize; builds parallelize.
+- **IME caveat, to be verified not asserted:** uiautomator *can* inspect IME
+  windows — `UiDevice.dumpWindowHierarchy` dumps every window — which is why
+  the app surfaces (onboarding, settings) and the keyboard alike are
+  scriptable with `adb` + uiautomator. Whether Maestro drives the IME window
+  as reliably is plausible but unproven here; treat "Maestro for app screens,
+  `adb`/uiautomator for the keys" as a hypothesis the first journey spike
+  confirms or kills, not a settled fact. One emulator, one active IME: journey
+  runs serialize; builds parallelize.
 - **Evidence storage:** borrow darkmill ADR-0026 — an orphan, append-only
-  `evidence` branch, path per PR (`pr-<n>/<artifact>`), never force-pushed.
-  mp4s and full-page screenshots go there and get linked from the PR body;
-  `main`'s history stays lean. Committed Paparazzi goldens are the exception:
-  they're small and belong with the code they pin.
+  `evidence` branch, never force-pushed — *including* the part that makes it
+  work. ADR-0026's load-bearing detail is a per-run/attempt path segment: two
+  attempts of one check can each emit `home.png`, and without a unique segment
+  the retry silently overwrites the first at the branch tip, losing attempt
+  history. So the path is `pr-<n>/<run-id>/<artifact>` (a re-run gets a fresh
+  `run-id`), never `pr-<n>/<artifact>`. mp4s and full-page screenshots go
+  there and get linked from the PR body; `main`'s history stays lean.
+  Committed Paparazzi goldens are the exception: they're small and belong with
+  the code they pin.
 - **CI staging (makes the crash gate real):** enable the Android jobs now —
   `assembleDebug` + unit tests + Paparazzi verify per PR; emulator journeys
   nightly and on-label; APK artifact on tags. The fork will make PR builds
@@ -193,7 +213,19 @@ The loop that ties it together, per task:
 5. **Patch note + PR template filled**; merge; the patch note becomes the
    day's GTM post draft.
 
-Suggested first slice (demoable, per prime directive #1): enable the Android
-CI jobs, add Paparazzi with goldens for the result-card states from the fake
-provider, and land the PR template + PATCHNOTES.md. That is one PR that makes
-every future PR more trustworthy — infrastructure that pays rent immediately.
+Suggested first slices — **plural, because one-concern-per-PR is house law**
+(AGENTS.md), and bundling these into one PR would be the trench-coat move the
+same law forbids. In dependency order, each demoable on its own:
+
+1. **Process, no code:** land the PR template + `PATCHNOTES.md` + the AGENTS.md
+   voice/DoD sections. Pure docs; makes every *later* PR more trustworthy.
+2. **CI enablement:** turn on the Android jobs (`assembleDebug` + unit tests
+   per PR). This is what makes the crash gate real, and it stands alone.
+3. **Error states, then goldens:** first build the missing product states —
+   teach `FakeProvider` to yield offline / quota / rejected / malformed, and
+   the panel to render them — because they don't exist yet (see Rung 2's
+   caveat). *Then* a follow-up adds Paparazzi and pins those states as
+   screenshot goldens. That's genuinely two concerns and reads as two PRs.
+
+Sequenced this way, the infrastructure pays rent immediately without any
+single PR wearing three hats.

--- a/docs/superpowers/specs/2026-07-21-pr1-review-notes.md
+++ b/docs/superpowers/specs/2026-07-21-pr1-review-notes.md
@@ -1,0 +1,97 @@
+# Review notes: PR #1, the day we decided to eat a keyboard
+
+**Date:** 2026-07-21
+**Status:** Notes — post-merge review of PR #1 (`a5c4640`), owner-confirmed items
+**Related:** [fork-spike checkpoint](2026-07-20-fork-spike-checkpoint.md) ·
+[keyboard UX design](2026-07-20-keyboard-ux-design.md) ·
+[agent ops recommendations](2026-07-21-agent-ops-recommendations.md)
+
+PR #1 was reviewed after merge. Overall verdict: the decision hygiene is the
+best thing in the repo — the superseded ADR kept with its arguments intact, the
+rejected mockups kept as evidence, the spike reframed instead of discarded.
+These notes record what the review found anyway, because a compliment with no
+homework attached is just flattery.
+
+## 1. GTM.md is the un-updated consumer of the fork decision
+
+Every doc that says *what* we build was updated in PR #1. The one that says
+*when* was not. GTM.md's ladder — one merged task per day, internal APK on
+Day 10 — was calibrated to a 3–5k-line thin IME. The fork inserts, before any
+of that: three clones, three builds, three grafts, a base decision, an ADR,
+and an implementation plan for a ~100k-line codebase.
+
+**Open — owner's call.** Either the ladder shifts (spike days are ladder days;
+each graft report is a perfectly good daily merge + post draft) or Day 10's
+deliverable gets redefined. What it can't do is stay as written, because right
+now the repo's schedule and its architecture disagree in public.
+
+## 2. The replacement ADR must record the honest rationale
+
+*Owner-confirmed 2026-07-21.*
+
+ROADMAP.md currently compresses the reversal into "an IME window never gets
+real input focus, so the keyless panel could not be typed into" — stated like
+physics. The checkpoint doc is more honest: the draft was always readable via
+`getExtractedText()` (that fix was already identified), and the empty state
+was patchable. What actually killed the thin IME was a judgment call: **the
+switching UX was not acceptable.** Flip to a keyless keyboard, flip back,
+dead-end on first launch — patchable individually, unshippable as a whole.
+
+That is a *better* reason than impossibility, and the replacement ADR should
+say it plainly: "we judged the switching model unacceptable," not "it could
+not work." Future readers deciding whether to un-fork deserve to know the
+door was closed by taste, not by the platform.
+
+## 3. The crash-freedom gate has no eyes
+
+*Owner-confirmed 2026-07-21.*
+
+The fork's release gate is "the keyboard must not crash," and the privacy
+story is "we store nothing." Nobody has yet asked how those two learn about
+each other. A crash in the field currently reports itself to no one.
+
+**Recommendation:** decide crash reporting *in the fork ADR*, because it is a
+privacy-posture decision (AGENTS.md says those get ADRs). The FOSS-keyboard
+standard answer — HeliBoard and AnySoftKeyboard both do this — is ACRA-style
+**opt-in, user-initiated** reports: the crash is caught, the report is shown
+to the user in full, and nothing leaves the device unless they choose to send
+it. That is compatible with "we store nothing" because *we* still store
+nothing; the user mails us their own stack trace. The privacy page then gets
+one more line instead of an asterisk.
+
+Also part of the gate having eyes: the Android CI jobs are still a comment in
+`ci.yml`. A release gate that no machine checks is a wish. (Concrete staging
+in the [agent ops recommendations](2026-07-21-agent-ops-recommendations.md).)
+
+## 4. Licence nuances the base decision should weigh
+
+Two facts that change the HeliBoard calculus, one in each direction:
+
+- **Softens GPL:** GPL-3.0 relicenses the *app*, not the project. Apache-2.0
+  code may be included in a GPL-3.0 work, and `core-personas` /
+  `core-providers` are ours — they can remain standalone Apache-2.0 modules
+  inside a GPL-3.0 app. The README's promise doesn't die; it shrinks to "the
+  portable heart stays Apache-2.0, the keyboard shell is GPL-3.0." That is an
+  honest sentence we could ship.
+- **Sharpens the glide problem:** onboarding screen 1 promises **Autocorrect ·
+  Glide typing · Works offline** before the base is chosen. On HeliBoard,
+  glide typing requires a closed-source Google blob the *user* must obtain —
+  which is a rough first-run promise and an F-Droid complication (ROADMAP
+  Phase 3 targets F-Droid). AnySoftKeyboard has glide built in; FlorisBoard's
+  is in progress.
+
+**Action for the spike:** alongside diffstat and build time, each graft report
+records the candidate's glide story (built-in / blob / absent) and its F-Droid
+compatibility. The reassurance triple is writing a check the base has to cash.
+
+## Nits
+
+- `docs/design/mockups/README.md` row for `10-result-card.png` didn't mention
+  that the mockup renders the *rejected* four-circle strip below the card.
+  The "design doc wins" disclaimer technically covered it; the row now says it
+  outright. **Fixed on this branch.**
+- "Golden tests unaffected" by the mood modifier is true today with a shelf
+  life: the moment the modifier is implemented, the goldens must grow mood
+  fixtures in *both* references (Python and Kotlin) in the same PR, or the
+  byte-identical guarantee quietly stops covering the thing users actually
+  tap. Noting it now so it rides the implementation plan, not a bug report.

--- a/docs/superpowers/specs/2026-07-21-pr1-review-notes.md
+++ b/docs/superpowers/specs/2026-07-21-pr1-review-notes.md
@@ -31,8 +31,10 @@ now the repo's schedule and its architecture disagree in public.
 
 ROADMAP.md currently compresses the reversal into "an IME window never gets
 real input focus, so the keyless panel could not be typed into" — stated like
-physics. The checkpoint doc is more honest: the draft was always readable via
-`getExtractedText()` (that fix was already identified), and the empty state
+physics. The checkpoint doc is more honest: reading the draft via
+`getExtractedText()` was the *intended* fix (never implemented — the current
+IME calls it nowhere, and Android permits it to return `null` when the editor
+can't comply, so it was a candidate, not a proven escape), and the empty state
 was patchable. What actually killed the thin IME was a judgment call: **the
 switching UX was not acceptable.** Flip to a keyless keyboard, flip back,
 dead-end on first launch — patchable individually, unshippable as a whole.
@@ -51,13 +53,29 @@ story is "we store nothing." Nobody has yet asked how those two learn about
 each other. A crash in the field currently reports itself to no one.
 
 **Recommendation:** decide crash reporting *in the fork ADR*, because it is a
-privacy-posture decision (AGENTS.md says those get ADRs). The FOSS-keyboard
-standard answer — HeliBoard and AnySoftKeyboard both do this — is ACRA-style
-**opt-in, user-initiated** reports: the crash is caught, the report is shown
-to the user in full, and nothing leaves the device unless they choose to send
-it. That is compatible with "we store nothing" because *we* still store
-nothing; the user mails us their own stack trace. The privacy page then gets
-one more line instead of an asterisk.
+privacy-posture decision (AGENTS.md says those get ADRs). Don't hand-wave it —
+the honest version has three constraints, and "we store nothing" does *not*
+survive intact:
+
+- **Opt-in, user-initiated, shown-in-full.** The crash is caught locally; the
+  full report is shown to the user; nothing leaves the device unless they
+  choose to send it. This is the shape ACRA supports, but ACRA is not magic —
+  by default it can attach logs, shared-prefs, device identifiers, and more,
+  so the report contents must be *deliberately minimized* to stack trace +
+  app version + a coarse device model, and that minimization is the actual
+  design work.
+- **Someone receives it, so someone stores it.** The moment a report reaches
+  a mailbox or issue tracker, "we store nothing" is no longer literally true.
+  The claim has to narrow to something defensible: "the keyboard stores
+  nothing you type; crash reports are opt-in, contain no message text, and are
+  kept only as long as it takes to fix the bug." Write the retention answer
+  down; don't let it be discovered.
+- **Don't overstate the precedent.** AnySoftKeyboard ships a crash-report
+  path (email); HeliBoard's public guidance points at GitHub issues and its
+  build carries no ACRA. So "the FOSS keyboards all do ACRA" is not a fact to
+  lean on — cite what each base actually does once the base is chosen.
+
+The privacy page then gets an honest paragraph, not an asterisk.
 
 Also part of the gate having eyes: the Android CI jobs are still a comment in
 `ci.yml`. A release gate that no machine checks is a wish. (Concrete staging
@@ -78,7 +96,9 @@ Two facts that change the HeliBoard calculus, one in each direction:
   glide typing requires a closed-source Google blob the *user* must obtain —
   which is a rough first-run promise and an F-Droid complication (ROADMAP
   Phase 3 targets F-Droid). AnySoftKeyboard has glide built in; FlorisBoard's
-  is in progress.
+  is *unavailable* — its roadmap parks a glide reimplementation at 0.7+,
+  behind a predictive-text core that still hasn't shipped, so "planned," not
+  "in progress."
 
 **Action for the spike:** alongside diffstat and build time, each graft report
 records the candidate's glide story (built-in / blob / absent) and its F-Droid


### PR DESCRIPTION
## What

Two docs, two artifacts, one nit fix — the outputs of a post-merge review of PR #1:

- `docs/superpowers/specs/2026-07-21-pr1-review-notes.md` — four owner-confirmed findings: GTM.md still describes the pre-fork schedule; the replacement ADR should record the honest rationale (the switching UX was judged unacceptable — not "impossible"); the crash-freedom gate needs eyes (opt-in ACRA-style reporting, decided in the fork ADR); and two licence nuances (core modules can stay Apache-2.0 inside a GPL-3.0 app; onboarding's glide-typing promise is a check the base has to cash).
- `docs/superpowers/specs/2026-07-21-agent-ops-recommendations.md` — the agent persona (the staff writes docs, guides, and conversation in the VOICE.md register, with a drafted "How you talk" AGENTS.md section and hard limits), a Definition of Done for "fully complete PRs", separation of duties + cross-family review borrowed from darkmill's ADR log, and a four-rung evidence ladder: prompt goldens → Paparazzi screenshot goldens per PR → emulator journeys with machine-checkable asserts → an mp4 per journey that doubles as the GTM demo asset.
- `PATCHNOTES.md` — the voice demonstrated on everything merged so far, rather than described.
- `.github/pull_request_template.md` — Evidence and Patch-note sections, so completeness is a checklist instead of a mood.
- Mockups README: row 10 now admits its strip is the rejected four-circle variant.

## Why

The owner asked for a review of PR #1 and for recommendations on agent maintenance, an agent persona, and evidence-driven PRs. Nothing in the recommendations is law until it lands in AGENTS.md or an ADR — this PR is the proposal, plus the two artifacts cheap enough to just ship.

## Evidence

- **Commands run + output:** docs-only change; `personas/` and prompt code untouched, so rule 4 does not trigger. Facts in PATCHNOTES.md cross-checked against `git log`.
- **Graded by:** the author, which the enclosed recommendations say should stop being allowed. The irony is noted in the minutes.

## Patch note

The robot staff reviewed its own previous PR, proposed rules that would forbid exactly that, and wrote them down in a voice it is now contractually wearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a standardized pull request template with sections for changes, rationale, evidence, patch notes, and validation.
  - Expanded project guidance for writing style, completion criteria, testing evidence, privacy, and review expectations.
  - Added release notes covering recent project updates and decisions.
  - Added operational guidance for validation workflows and follow-up review considerations.
  - Clarified a design mockup annotation to distinguish the selected result-card variant from an outdated option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->