### PR TITLE
docs: reconcile decision records with merged ADR-0003

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,18 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-07-21 — The records catch up to the decision
+
+- ADR-0003 merged, so the paperwork stopped lying: its status is now Accepted,
+  ROADMAP admits the base is AnySoftKeyboard and the licence is Apache-2.0, and
+  the UX doc's fork-base and licence open-questions are struck through.
+- Left one gate honestly open — the stale-field race guard still has to be
+  implemented before a real provider touches anybody's draft — because closing a
+  ticket is not the same as writing the code, and the roadmap should not pretend
+  otherwise.
+- No behaviour changed; the next agent just stops taking orders from a map that
+  predates the territory.
+
 ## 2026-07-21 — We picked a keyboard (PR #11)
 
 - ADR-0003 lands the decision the whole fork spike was evidence for: fork

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,10 +13,11 @@ decisions — including the one we later reversed, which is the useful kind.
 - [x] VOICE.md, README.md, AGENTS.md, CONTRIBUTING.md, ROADMAP.md, GTM.md
 - [x] docs/persona-schema.md + schema validator in CI
 - [x] ADR-0001 (thin IME over fork), ADR-0002 (provider registry)
-- [ ] Pick licenses (leaning Apache-2.0 code / CC-BY personas) — **now
-      constrained by the fork base.** HeliBoard is GPL-3.0 and would relicense
-      the whole app; AnySoftKeyboard and FlorisBoard are Apache-2.0. Decide
-      this *with* the base, not after.
+- [x] Pick licenses — **decided in
+      [ADR-0003](docs/adr/0003-fork-anysoftkeyboard-apache.md):** the app is
+      **Apache-2.0**, following the AnySoftKeyboard base; personas stay CC-BY as
+      planned. GPL-3.0 (HeliBoard) was ruled out precisely because it would have
+      relicensed the whole app.
 
 ## Phase 1 — PersonaBoard MVP 🚧
 
@@ -35,9 +36,16 @@ persona strip above the keys that rewrites what you've typed.
       (byte-identical prompts to `desktop/personaspeak.py` — verified)
 - [x] UX design: strip, persona picker, result card, onboarding, settings
       (`docs/superpowers/specs/2026-07-20-keyboard-ux-design.md`)
-- [ ] **Fork base decided** — HeliBoard / AnySoftKeyboard / FlorisBoard, via
-      the graft spike. Decides the licence; see Phase 0.
-- [ ] ADR superseding ADR-0001, with the spike evidence attached
+- [x] **Fork base decided** — **AnySoftKeyboard**, via the graft spike
+      ([ADR-0003](docs/adr/0003-fork-anysoftkeyboard-apache.md)). Decides the
+      licence; see Phase 0.
+- [x] ADR superseding ADR-0001, with the spike evidence attached — ADR-0003.
+- [ ] **Ingest ASK** (ADR-0004): pin an upstream revision, reproducible
+      unmodified build, package/license baseline, documented update procedure.
+      Gates the graft.
+- [ ] **Privacy audit** of what an ASK fork stores/sends by default (learned
+      words, dictionaries, clipboard, backups, diagnostics) — its own ADR,
+      before the "we store nothing" copy can ship.
 - [ ] Persona strip grafted onto the chosen base: persona chip + mood chip +
       transform, reading the draft and replacing it in place
 - [ ] core-providers: `CompletionProvider` interface; Gemini free tier

--- a/docs/adr/0003-fork-anysoftkeyboard-apache.md
+++ b/docs/adr/0003-fork-anysoftkeyboard-apache.md
@@ -1,9 +1,12 @@
 # ADR-0003: Fork AnySoftKeyboard, under Apache-2.0
 
-**Status:** Proposed (2026-07-21) — the replacement ADR that
+**Status:** Accepted (2026-07-21) — the replacement ADR that
 [ADR-0001](0001-thin-ime-over-keyboard-fork.md) said was pending the fork-base
-spike. Base adoption is **provisional**, pending the two conditions in
-Consequences. Merging this PR records it as Accepted.
+spike. Base adoption remains **provisional** on one open gate: the stale-field
+race guard (see Consequences) must be implemented before any real provider
+replaces `FakeProvider`. The typing sanity check (#5) was closed as the
+non-blocker this ADR declared it; the race-guard design (#6) is specced and
+merged, and its implementation is the remaining gate.
 
 ## Context
 

--- a/docs/superpowers/specs/2026-07-20-keyboard-ux-design.md
+++ b/docs/superpowers/specs/2026-07-20-keyboard-ux-design.md
@@ -166,15 +166,17 @@ deciding whether to trust a keyboard deserves a straight answer.
 
 ## Open questions
 
-1. **Fork base** — HeliBoard / AnySoftKeyboard / FlorisBoard. Decides the
-   licence. Spike specced in the checkpoint doc.
-2. **Strip vs the base's suggestion row** — vertical budget, resolved with the
-   base.
+1. ~~**Fork base**~~ — **resolved: AnySoftKeyboard**
+   ([ADR-0003](../../adr/0003-fork-anysoftkeyboard-apache.md)).
+2. **Strip vs the base's suggestion row** — vertical budget. Now *answerable*:
+   the spike found ASK's strips **stack** (persona row above the candidate row),
+   they don't merge. Deciding merge/collapse/accept is track-A work against the
+   real ASK tree.
 3. **Dark-mode selected state** for the persona chip.
 4. **Long persona names** ("Sir Humphrey Appleby") in a fixed-width chip.
 5. **Mood list contents** — the working set is polite / witty / blunt /
    apologetic / formal, unvalidated with real personas.
-6. **Licence** — follows from (1); README currently promises Apache-2.0.
+6. ~~**Licence**~~ — **resolved: Apache-2.0** (follows from 1; ADR-0003).
 
 ## Decisions this design records
 


### PR DESCRIPTION
## What

Housekeeping. ADR-0003 (fork AnySoftKeyboard, Apache-2.0) merged, but three documents were left describing the world as it was *before* that merge. This syncs them:

- **`docs/adr/0003-...`** — status `Proposed` → **`Accepted`**. Kept one gate honestly open: the stale-field race guard still has to be *implemented* (the #6 design is merged) before a real provider replaces `FakeProvider`. Closing a ticket isn't writing the code.
- **`ROADMAP.md`** — checked the now-decided boxes (fork base = ASK, licence = Apache-2.0, superseding ADR). Added two forward pointers that fall out of the codex sequencing consult: the **ingestion ADR-0004** (pin ASK, reproducible unmodified build) and a **privacy-audit ADR** (what an ASK fork stores/sends by default, before the "we store nothing" copy can ship).
- **`docs/superpowers/specs/2026-07-20-keyboard-ux-design.md`** — struck through open-questions #1 (fork base) and #6 (licence) as resolved; annotated #2 (strip vs suggestion row) as now *answerable* against the real ASK tree — the spike found ASK's strips stack.

## Why

"Robots are famously literal when handed archaeology" — the next agent should not take orders from records that predate the decision. Surfaced by a `codex exec` strategy consult on how to proceed post-ADR-0003.

## Evidence

No behaviour change; docs-only. `git diff --stat`: 4 files, +40/−15. The PATCHNOTES gate is satisfied by this PR's own entry.

## Grading

Not yet graded by a non-author — docs-only reconciliation, no code. Flagging the skip loudly per the DoD; happy to route it to a different family if you want the second pair of eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Finalized the fork-base decision: AnySoftKeyboard under Apache-2.0 licensing.
  * Updated roadmap and ADR documentation to reflect the accepted decision and supporting evidence.
  * Resolved UX documentation questions about the fork base and licensing.
  * Documented stacking behavior for the suggestion row.
  * Added upcoming requirements for reproducible builds and a privacy audit.
  * Noted that a stale-field race guard remains before production provider integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->