### PR TITLE
docs: ADR-0004 — ingest AnySoftKeyboard as a vendored snapshot

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,21 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-07-21 — Deciding how to move a keyboard into the house
+
+- ADR-0004 settles how AnySoftKeyboard's tree enters the repo: a **vendored
+  snapshot** at a pinned tag, edited in place, with the upstream diff kept as a
+  hand-written manifest. Not a submodule (it fights the fact that we edit
+  upstream files), and — after a reviewer caught the first draft's reasoning —
+  not a subtree either, because our squash-merge plus linear-history policy
+  flattens the merge ancestry that `git subtree pull --squash` needs, so its one
+  trick works exactly once.
+- The point of the manifest is the rent ledger: regenerate the pristine tree,
+  diff it against ours, and "lines modified are rent paid forever" becomes a
+  checklist instead of an excavation.
+- No code moved yet — this decides the mechanism so the graft PR doesn't have to
+  argue with itself mid-move.
+
 ## 2026-07-21 — The records catch up to the decision
 
 - ADR-0003 merged, so the paperwork stopped lying: its status is now Accepted,

--- a/docs/adr/0004-vendored-snapshot-ingestion.md
+++ b/docs/adr/0004-vendored-snapshot-ingestion.md
@@ -1,0 +1,117 @@
+# ADR-0004: Ingest AnySoftKeyboard as a vendored snapshot
+
+**Status:** Proposed (2026-07-21) — the first build-phase ADR after
+[ADR-0003](0003-fork-anysoftkeyboard-apache.md) picked the base. Decides *how*
+AnySoftKeyboard's source physically enters this repo, before a single line of it
+is grafted. Merging this PR records it as Accepted.
+
+## Context
+
+ADR-0003 chose the base (AnySoftKeyboard) and the license (Apache-2.0). It did
+not say how ASK's ~8,870-commit, Java-primary tree gets into `apexcloudwise/personaspeak`
+so our Gradle can build it and our persona strip can live in it. That is this
+ADR, and it is a one-way-ish door: the ingestion mechanism sets how much the
+"upstream-merge subscription" costs for the life of the fork, so it is worth
+ten minutes now rather than a reorg later.
+
+The Android build is under `android/` (Gradle project `personaboard`); the
+`:keyboard` module is a thin stub the fork replaces. Two facts from the
+[fork spike](../superpowers/specs/2026-07-20-fork-spike-results.md) constrain the
+choice:
+
+1. **We modify upstream files in place.** The ASK graft touched **5 pre-existing
+   files** (`settings.gradle`, `gradle/libs.versions.toml`, `ime/app/build.gradle`,
+   `main_keyboard_layout.xml`, `.gitignore`) to wire in the vendored modules and
+   the strip. A mechanism that forbids editing upstream-tracked files does not
+   fit what the graft actually does.
+2. **ASK moves slowly.** Latest stable is `1.13-r1` (Feb 2026). The upstream we
+   are subscribing to publishes on the order of once a year, not once a week.
+
+Mechanisms considered:
+
+- **A. git submodule** — ASK stays its own repo at a pinned SHA; our changes
+  live as an overlay/patches.
+- **B. git subtree** — ASK merged into a subdirectory, upstream history preserved,
+  `git subtree pull` to update.
+- **C. Vendored snapshot** — ASK's source copied in at a pinned revision, its
+  history dropped, tracked thereafter as files in our tree.
+
+## Decision
+
+**Vendor a snapshot of AnySoftKeyboard at a pinned upstream revision, edited in
+place, with the upstream diff tracked in a manifest.**
+
+Concretely:
+
+- The ASK tree lands under `android/keyboard/` — the module slot the stub
+  already reserves — at tag `1.13-r1`, commit
+  `8c1db51c8f23d1923d0eb05f70f1bb41d614fb6d` (the spike's pin).
+- The snapshot is copied in as a single, message-tagged import commit. Upstream
+  git history is **not** imported.
+- ASK's `LICENSE`, `NOTICE`, and per-file Apache headers are preserved verbatim.
+  A top-level `android/keyboard/UPSTREAM.md` records the source repo, the pinned
+  tag + SHA, the date, and the re-vendor procedure.
+- Our modifications to upstream-tracked files are listed in
+  `android/keyboard/UPSTREAM-MODIFIED.md` — one line per touched file, with the
+  reason. This is the rent ledger, kept by hand and small on purpose.
+- PersonaSpeak code lives in **new** files under
+  `biz.pixelperfectstudios.personaspeak.*` packages, never edited into ASK's own
+  files beyond the wiring seam the manifest tracks.
+
+The exact Gradle module composition (nesting ASK's `:ime:*` modules under our
+`settings.gradle`, the Java↔Kotlin adapter) is left to the graft PR that follows;
+this ADR fixes the mechanism and the discipline, not the build wiring.
+
+## Because
+
+- **A submodule fights fact 1.** The graft edits upstream-tracked files, and you
+  cannot commit changes to a submodule's files from the superproject without
+  maintaining a *separate* hard fork of ASK as the submodule — which is a
+  vendored snapshot again, plus a second repo to run and a `--recursive` clone
+  every contributor must remember. It buys clean separation we do not need and
+  charges ergonomics we do.
+- **A subtree overpays for fact 2.** `git subtree pull` is genuinely nicer *when
+  you update often*. We update roughly yearly, and importing 8,870 commits of
+  someone else's history to save a once-a-year manual merge is a bad trade —
+  permanent repo bloat for occasional convenience, plus subtree's own
+  merge-conflict sharp edges.
+- **A snapshot makes the rent visible.** Our entire diff from upstream is
+  `git diff` against one import commit, and the modified-file manifest states it
+  in prose. "Upstream lines modified are rent paid forever" (ADR-0003) is only
+  enforceable if the modified lines are easy to count; a snapshot plus a manifest
+  makes them a checklist, not an archaeology dig.
+- **It is the simplest thing that builds.** Normal clone, normal Gradle, no
+  submodule init, no subtree tooling. The house rule prefers 30 lines over a
+  dependency; here it prefers a documented copy over a git subsystem.
+
+We reject a patch-series-on-pristine-snapshot variant (keep the vendored tree
+byte-identical to upstream, carry our changes as applied patches) for the same
+reason: a 5-file diff does not earn a patch toolchain and a build-time apply
+step. If the modified-file count ever grows past what a manifest can hold
+legibly, that is the signal to revisit — and also a signal the graft has gone
+wrong.
+
+## Consequences
+
+- **Re-vendoring is a manual, documented procedure, not a command.** Updating to
+  a future ASK release means: fetch the new tag, replay the manifest's file list,
+  re-resolve each, bump `UPSTREAM.md`. The slow cadence makes this rare; the
+  small manifest makes it bounded. This cost was accepted in ADR-0003 when we
+  took on the "upstream-merge subscription."
+- **The manifest is load-bearing and reviewed like code.** A PR that modifies an
+  upstream ASK file without adding a `UPSTREAM-MODIFIED.md` line has hidden rent,
+  and gets returned. Keeping our code in new files under our own packages is what
+  keeps that list short.
+- **License compliance is a checklist item, not a vibe.** Apache-2.0 requires the
+  retained `LICENSE`/`NOTICE` and preserved headers; the app's own license
+  (ADR-0003) and ASK's attribution coexist, and `UPSTREAM.md` is where a
+  downstream reader finds the provenance. This is plain, load-bearing text — no
+  jokes in the attribution.
+- **`core-personas` and `core-providers` stay outside the vendored tree.** They
+  are ours and pure; the vendored snapshot depends on them, never the reverse.
+  Platform seams the graft needs — editor identity, commit authority, Keystore —
+  are ports in our modules with adapters in the vendored/Android layer, so
+  vendoring ASK does not leak `android.*` back into the pure core.
+- **The stub `:keyboard` module is deleted in the graft PR, not this one.** This
+  ADR is docs-only; the code lands next, behind the walking-skeleton discipline
+  (ADR-0003's release gate: the keyboard must not crash).

--- a/docs/adr/0004-vendored-snapshot-ingestion.md
+++ b/docs/adr/0004-vendored-snapshot-ingestion.md
@@ -24,15 +24,23 @@ choice:
    `main_keyboard_layout.xml`, `.gitignore`) to wire in the vendored modules and
    the strip. A mechanism that forbids editing upstream-tracked files does not
    fit what the graft actually does.
-2. **ASK moves slowly.** Latest stable is `1.13-r1` (Feb 2026). The upstream we
-   are subscribing to publishes on the order of once a year, not once a week.
+2. **ASK moves slowly.** The selected stable release as of 2026-07-21 is
+   `1.13-r1` (published Feb 2026). The upstream we are subscribing to publishes
+   on the order of once a year, not once a week.
+
+And one fact about *our* repo, which turns out to decide the question:
+
+3. **`main` enforces `required_linear_history` and we squash-merge PRs.**
+   (Confirmed against the `nomain` ruleset.) No merge commit ever survives on
+   `main`; every PR lands as one squashed commit.
 
 Mechanisms considered:
 
 - **A. git submodule** — ASK stays its own repo at a pinned SHA; our changes
   live as an overlay/patches.
-- **B. git subtree** — ASK merged into a subdirectory, upstream history preserved,
-  `git subtree pull` to update.
+- **B. git subtree (`--squash`)** — ASK merged into a subdirectory as a single
+  squashed commit (not its full history), updated with `git subtree pull
+  --squash`, which 3-way-merges new upstream against our edits.
 - **C. Vendored snapshot** — ASK's source copied in at a pinned revision, its
   history dropped, tracked thereafter as files in our tree.
 
@@ -46,14 +54,24 @@ Concretely:
 - The ASK tree lands under `android/keyboard/` — the module slot the stub
   already reserves — at tag `1.13-r1`, commit
   `8c1db51c8f23d1923d0eb05f70f1bb41d614fb6d` (the spike's pin).
-- The snapshot is copied in as a single, message-tagged import commit. Upstream
-  git history is **not** imported.
+- The snapshot is produced reproducibly: `git archive` of the pinned tag from
+  the upstream repo, extracted into `android/keyboard/`, excluding upstream CI
+  and repo-management dirs (`.git`, `.github/`, upstream `fastlane/` metadata) —
+  the exclusion list itself recorded in `UPSTREAM.md`. Anyone can regenerate the
+  identical pristine tree from the recorded tag + exclusion list and `git diff`
+  it against our import to see exactly our changes. Committed as a single,
+  message-tagged import commit; upstream git history is **not** imported.
 - ASK's `LICENSE`, `NOTICE`, and per-file Apache headers are preserved verbatim.
   A top-level `android/keyboard/UPSTREAM.md` records the source repo, the pinned
-  tag + SHA, the date, and the re-vendor procedure.
+  tag + SHA, the date, the exclusion list, and the re-vendor procedure.
 - Our modifications to upstream-tracked files are listed in
   `android/keyboard/UPSTREAM-MODIFIED.md` — one line per touched file, with the
-  reason. This is the rent ledger, kept by hand and small on purpose.
+  reason. It describes the **current** delta from the vendored base, not a
+  changelog: a file edited several times still has one entry (its net diff), and
+  a file whose edit we later revert to pristine has its entry **removed**. The
+  invariant the manifest asserts: `git diff <pristine tag> -- android/keyboard/`
+  touches exactly the files it lists, no more. This is the rent ledger, kept by
+  hand and small on purpose.
 - PersonaSpeak code lives in **new** files under
   `biz.pixelperfectstudios.personaspeak.*` packages, never edited into ASK's own
   files beyond the wiring seam the manifest tracks.
@@ -70,11 +88,20 @@ this ADR fixes the mechanism and the discipline, not the build wiring.
   vendored snapshot again, plus a second repo to run and a `--recursive` clone
   every contributor must remember. It buys clean separation we do not need and
   charges ergonomics we do.
-- **A subtree overpays for fact 2.** `git subtree pull` is genuinely nicer *when
-  you update often*. We update roughly yearly, and importing 8,870 commits of
-  someone else's history to save a once-a-year manual merge is a bad trade —
-  permanent repo bloat for occasional convenience, plus subtree's own
-  merge-conflict sharp edges.
+- **A subtree's update model fights our merge policy — and that, not history
+  bloat, is the reason.** An earlier draft of this ADR rejected subtree for
+  "importing ~8,870 commits of history." That was wrong, and the non-author
+  review (codex) caught it: `git subtree add --squash` collapses upstream to a
+  single commit, exactly as vendoring does. The genuine problem is downstream.
+  `git subtree pull --squash` computes its 3-way merge base by finding the
+  *previous* subtree commit in history — and by fact 3, that commit never
+  survives. Every subtree merge is flattened when its PR squash-merges into a
+  linear `main`, destroying the ancestry the next `pull` needs. subtree would
+  work exactly once, at the initial add, then lose its own thread; its headline
+  benefit, the auto-merging pull, does not survive our workflow. We would take on
+  subtree's arcana (root-only invocation, exact `--prefix`, confusing merge
+  conflicts) for none of its payoff. A vendored snapshot depends on no history
+  shape at all, so the squash-merge policy costs it nothing.
 - **A snapshot makes the rent visible.** Our entire diff from upstream is
   `git diff` against one import commit, and the modified-file manifest states it
   in prose. "Upstream lines modified are rent paid forever" (ADR-0003) is only

--- a/docs/adr/0004-vendored-snapshot-ingestion.md
+++ b/docs/adr/0004-vendored-snapshot-ingestion.md
@@ -69,9 +69,13 @@ Concretely:
   reason. It describes the **current** delta from the vendored base, not a
   changelog: a file edited several times still has one entry (its net diff), and
   a file whose edit we later revert to pristine has its entry **removed**. The
-  invariant the manifest asserts: `git diff <pristine tag> -- android/keyboard/`
-  touches exactly the files it lists, no more. This is the rent ledger, kept by
-  hand and small on purpose.
+  invariant the manifest asserts: regenerate the pristine tree (the recorded
+  `git archive` + exclusion list into a scratch dir) and
+  `git diff --no-index <scratch> android/keyboard/` touches exactly the files it
+  lists, no more. A bare `git diff <tag>` will not do this — upstream's tree is
+  rooted where ours is relocated under `android/keyboard/`, so the comparison
+  must be prefix-aware (`--no-index` against the regenerated tree, or an
+  equivalent). This is the rent ledger, kept by hand and small on purpose.
 - PersonaSpeak code lives in **new** files under
   `biz.pixelperfectstudios.personaspeak.*` packages, never edited into ASK's own
   files beyond the wiring seam the manifest tracks.


### PR DESCRIPTION
## What

The first build-phase ADR after ADR-0003 picked the base. Decides **how** AnySoftKeyboard's source physically enters the repo, before the graft touches anything.

**Decision: vendored snapshot** at pinned tag `1.13-r1` (`8c1db51…`), edited in place, with the upstream diff tracked in a hand-written `UPSTREAM-MODIFIED.md` manifest.

- **Not a submodule** — the graft edits 5 upstream-tracked files, and a submodule can't take in-place edits without maintaining a separate hard fork (a vendored snapshot again, plus a second repo and `--recursive` clones).
- **Not a subtree** — ASK ships ~yearly; importing ~8,870 commits of history to save an occasional manual merge is permanent bloat for rare convenience.
- Keeps the "rent paid forever" rule *enforceable*: our whole diff from upstream is one `git diff` + one short manifest.

Scope: fixes the mechanism and the rent-ledger discipline. The Gradle module wiring and the Java↔Kotlin adapter are left to the graft PR that follows.

## Why now

Codex sequencing consult put ingestion (C0) as the gate before the walking-skeleton graft and before locking the UX inside the real ASK tree. Nothing starts until ASK is in the tree in an agreed shape.

## Consequences worth a second look

- Re-vendoring becomes a documented manual procedure (accepted in ADR-0003's "upstream-merge subscription").
- The modified-file manifest is reviewed like code — an untracked upstream edit is hidden rent and gets returned.
- License compliance (retained `LICENSE`/`NOTICE`, preserved headers, `UPSTREAM.md` provenance) is stated plainly — load-bearing, no jokes in the attribution.
- Platform seams (editor identity, commit authority, Keystore) stay as ports in our pure modules with adapters in the vendored/Android layer, so vendoring doesn't leak `android.*` into the core.

## Evidence

Docs-only, new file + one PATCHNOTES line. No build change. Grounded in the actual `android/` Gradle layout (`:keyboard` stub is the slot ASK replaces) and the spike's pinned commit.

## Grading

Not yet graded by a non-author. This ADR *is* partly acting on a codex (gpt-5.6) consult, but that consulted the strategy, not this diff — flagging the review skip loudly per the DoD. Worth a different-family pass on the submodule-vs-subtree-vs-snapshot reasoning before it's accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR-0004 describing a reproducible vendored snapshot workflow for integrating AnySoftKeyboard via a pinned upstream revision and diff/manifest procedure.
  * Documented requirements to preserve licensing/NOTICE and per-file Apache headers, plus validation rules for regenerating the pristine import and tracking upstream edits.
  * Updated patch notes to announce the planned ingestion approach (no functional code changes yet), with Gradle wiring deferred to a follow-up graft effort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->