### PR TITLE
docs: ADR-0005 — privacy posture for the fork (default-private, audit-gated)

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,20 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-07-21 — Reading our own privacy promise back to ourselves
+
+- ADR-0005 catches a claim that quietly stopped being true: "Nothing is stored,
+  logged" was honest for the thin IME we owned entirely, and is an overclaim for
+  a forked predictive keyboard that keeps a learned-words dictionary to do its
+  job. The fix is not to store less than a keyboard must — it is to stop
+  conflating "stays on your phone" with "does not exist," and to say which is
+  which.
+- The privacy copy is now frozen until an inventory of what the vendored ASK tree
+  actually stores and sends is done on-device — default posture: anything that
+  leaves the phone is off, and proven off. No accusation against ASK; it is a
+  keyboard doing keyboard things. The overpromise was ours.
+- This is load-bearing text, so the entry above is the only joke you get.
+
 ## 2026-07-21 — Deciding how to move a keyboard into the house
 
 - ADR-0004 settles how AnySoftKeyboard's tree enters the repo: a **vendored

--- a/docs/adr/0005-privacy-posture-fork-audit.md
+++ b/docs/adr/0005-privacy-posture-fork-audit.md
@@ -32,24 +32,34 @@ we inherited and have not yet audited.
 
 **The privacy claim is audit-gated, and the posture is default-private.**
 
-1. **Two categories, stated separately, never conflated:**
+1. **Three kinds of data, stated separately, never conflated:**
    - **On-device local state** the keyboard keeps to function (learned words,
      user dictionary, next-word data, clipboard). This may exist, but it stays
      on the device and is user-clearable. The honest claim is "it never leaves
      your phone," not "it does not exist."
-   - **Anything that leaves the device** — network calls, crash/analytics
-     telemetry, cloud/settings backup, verbose logs. Default posture: **off, and
-     proven off.** Message text leaves only to the user's chosen provider, only
-     on request — that half of the claim we keep and must verify still holds
-     through the fork.
+   - **Anything that leaves the device** — any network call from *anywhere in the
+     app's UID*, not just the keyboard process (settings, onboarding, workers,
+     backup agents, inherited components all count); crash/analytics telemetry;
+     cloud or settings backup. Default posture: **off, and proven off.** Message
+     text leaves only to the user's chosen provider, only on request — that half
+     of the claim we keep and must verify still holds through the fork.
+   - **On-device disclosure surfaces** — logcat, and anything that writes typed
+     text where another app, a bug report, or `adb` could read it. These do not
+     *leave* the device, but they leak all the same. Release builds must not log
+     draft text; this is a separate boundary from egress and audited as one.
 
 2. **The current README/onboarding privacy copy does not ship as-is.** It is
-   rewritten to be *true and specific* — distinguishing the two categories above
-   — only after the inventory below is complete. Until then it is knowingly
-   inaccurate for the fork and must not be repeated in new surfaces (onboarding
-   screen 2, the settings PRIVACY group).
+   rewritten to be *true and specific* — distinguishing the three kinds above —
+   only after the inventory below is complete. Until then it is knowingly
+   inaccurate for the fork and must not be reused or shipped in any surface,
+   including onboarding screen 2 and the settings PRIVACY group.
 
-3. **A privacy inventory of the vendored ASK tree is required**, run against the
+3. **The audit gates public distribution, not development.** No public/store
+   release of the fork ships before the inventory is done and the copy is
+   rewritten. Internal `FakeProvider` demos and development builds proceed
+   without it — the graft is not blocked, only the shipped privacy claim is.
+
+4. **A privacy inventory of the vendored ASK tree is required**, run against the
    snapshot from [ADR-0004](0004-vendored-snapshot-ingestion.md). It answers, per
    item: does it exist, where does the data live, does anything leave the device,
    is it default-on, and can the user clear/disable it. Minimum categories:
@@ -59,10 +69,12 @@ we inherited and have not yet audited.
    - Android auto-backup and any settings export/cloud sync
    - crash reporting, analytics, or telemetry (ASK has shipped optional
      reporting historically — verify what the pinned snapshot actually does)
-   - any outbound network call from the keyboard process
-   - logcat verbosity that could echo typed text in release builds
+   - any outbound network call from *anywhere in the app's UID*, not only the
+     keyboard process
+   - logcat verbosity that could echo typed text in release builds (a disclosure
+     surface, audited alongside egress but not the same boundary)
 
-4. **The verification bar is on-device, not a reading of the code alone.** The
+5. **The verification bar is on-device, not a reading of the code alone.** The
    claim is backed by an on-device check — network capture showing no unexpected
    egress, storage inspection showing where local data sits — consistent with
    ADR-0003's rule that pure-logic tests miss what the device reveals.
@@ -84,9 +96,10 @@ we inherited and have not yet audited.
 
 - **The privacy copy is blocked until the inventory lands.** README's "Privacy,
   briefly", onboarding screen 2, and the settings PRIVACY group ("What we store:
-  Nothing. Here's the proof.") are frozen in their current wording for the fork
-  and rewritten together, once, against the findings. Shipping the fork with the
-  old copy unaudited is the failure this ADR exists to prevent.
+  Nothing. Here's the proof.") must not be shipped or reused in their current
+  wording once the fork is the product; they are rewritten together, once,
+  against the findings. Shipping the fork with the old copy unaudited is the
+  failure this ADR exists to prevent.
 - **Some inherited defaults will need neutralizing.** If the audit finds any
   default-on egress (telemetry, backup of the dictionary to cloud), turning it
   off is part of satisfying this ADR, and each such change is a tracked upstream

--- a/docs/adr/0005-privacy-posture-fork-audit.md
+++ b/docs/adr/0005-privacy-posture-fork-audit.md
@@ -1,0 +1,101 @@
+# ADR-0005: Privacy posture for the fork — default-private, audit-gated
+
+**Status:** Proposed (2026-07-21) — moves the privacy posture, so it gets an ADR
+(AGENTS.md). Records the decision; the inventory it mandates is follow-up work.
+Merging this PR records it as Accepted.
+
+## Context
+
+The README makes a blanket, load-bearing claim:
+
+> Your API keys live in Android's Keystore. Message text goes only to the
+> provider *you* configured, only when you ask for a rewrite. **Nothing is
+> stored, logged, or "used to improve our services."**
+
+That paragraph was written for [ADR-0001](0001-thin-ime-over-keyboard-fork.md)'s
+thin IME, where we owned every line and the keyboard genuinely stored nothing.
+
+[ADR-0003](0003-fork-anysoftkeyboard-apache.md) changed the premise: we now ship
+a forked full keyboard (AnySoftKeyboard). A predictive daily-driver keyboard
+stores things **by design** — it has to, to predict. The moment the fork ships,
+the unqualified "nothing is stored, logged" is at risk of being false, and a
+false privacy claim is worse than no claim. This was flagged in an external
+strategy review (codex, 2026-07-21) and is exactly the AGENTS.md offense
+"storing anything a user typed / making the privacy story more complicated to
+explain."
+
+This is not an accusation against AnySoftKeyboard — it is a normal keyboard doing
+normal keyboard things. The problem is ours: our copy over-promises against code
+we inherited and have not yet audited.
+
+## Decision
+
+**The privacy claim is audit-gated, and the posture is default-private.**
+
+1. **Two categories, stated separately, never conflated:**
+   - **On-device local state** the keyboard keeps to function (learned words,
+     user dictionary, next-word data, clipboard). This may exist, but it stays
+     on the device and is user-clearable. The honest claim is "it never leaves
+     your phone," not "it does not exist."
+   - **Anything that leaves the device** — network calls, crash/analytics
+     telemetry, cloud/settings backup, verbose logs. Default posture: **off, and
+     proven off.** Message text leaves only to the user's chosen provider, only
+     on request — that half of the claim we keep and must verify still holds
+     through the fork.
+
+2. **The current README/onboarding privacy copy does not ship as-is.** It is
+   rewritten to be *true and specific* — distinguishing the two categories above
+   — only after the inventory below is complete. Until then it is knowingly
+   inaccurate for the fork and must not be repeated in new surfaces (onboarding
+   screen 2, the settings PRIVACY group).
+
+3. **A privacy inventory of the vendored ASK tree is required**, run against the
+   snapshot from [ADR-0004](0004-vendored-snapshot-ingestion.md). It answers, per
+   item: does it exist, where does the data live, does anything leave the device,
+   is it default-on, and can the user clear/disable it. Minimum categories:
+   - learned words / user (personal) dictionary
+   - next-word / prediction model state
+   - clipboard history, if any
+   - Android auto-backup and any settings export/cloud sync
+   - crash reporting, analytics, or telemetry (ASK has shipped optional
+     reporting historically — verify what the pinned snapshot actually does)
+   - any outbound network call from the keyboard process
+   - logcat verbosity that could echo typed text in release builds
+
+4. **The verification bar is on-device, not a reading of the code alone.** The
+   claim is backed by an on-device check — network capture showing no unexpected
+   egress, storage inspection showing where local data sits — consistent with
+   ADR-0003's rule that pure-logic tests miss what the device reveals.
+
+## Because
+
+- **A false privacy claim is a worse liability than an honest limitation.** "We
+  store nothing" from a keyboard that keeps a learned-words dictionary is the
+  kind of overclaim that ends a trust-based project. Better to say precisely what
+  stays on the device and what never leaves it.
+- **Default-private is the only posture consistent with the project's pitch.**
+  "This repo is public so you don't have to trust that paragraph" only works if
+  the paragraph is true; the audit is what makes it true rather than aspirational.
+- **The audit needs the vendored tree to exist**, which is why this follows
+  ADR-0004 and gates the privacy *copy*, not the graft itself. The keyboard can
+  be built and demoed with `FakeProvider` before the copy is finalized.
+
+## Consequences
+
+- **The privacy copy is blocked until the inventory lands.** README's "Privacy,
+  briefly", onboarding screen 2, and the settings PRIVACY group ("What we store:
+  Nothing. Here's the proof.") are frozen in their current wording for the fork
+  and rewritten together, once, against the findings. Shipping the fork with the
+  old copy unaudited is the failure this ADR exists to prevent.
+- **Some inherited defaults will need neutralizing.** If the audit finds any
+  default-on egress (telemetry, backup of the dictionary to cloud), turning it
+  off is part of satisfying this ADR, and each such change is a tracked upstream
+  modification per ADR-0004's manifest.
+- **The inventory is executable work, filed separately.** This ADR is the
+  decision and the checklist; the audit itself is an issue against the vendored
+  snapshot, with the on-device evidence attached, and it gates the privacy copy
+  PR.
+- **Phase 2 inherits a stricter version of this.** Suggested replies (reading
+  notifications) raise the stakes; the same default-private, audit-gated posture
+  applies, and the ROADMAP already commits to a Phase 2 privacy page. This ADR is
+  the general rule that page will cite.


### PR DESCRIPTION
## What

Catches a load-bearing claim that quietly stopped being true when ADR-0003 turned us from a thin IME into a forked predictive keyboard.

README today:
> **Nothing is stored, logged, or "used to improve our services."**

That was honest when we owned every line. A daily-driver keyboard stores things **by design** — a learned-words dictionary, next-word state — to predict at all. The unqualified claim is an overclaim for the fork, and a false privacy claim is worse than none.

**Decision:** the privacy claim is **audit-gated** and the posture is **default-private**:
- Split **on-device local state** (dictionaries — "never leaves your phone," user-clearable) from **anything that leaves the device** (network, telemetry, cloud backup, logs — **off, and proven off**).
- The current README/onboarding/settings privacy copy **does not ship as-is** — frozen until an inventory of the vendored ASK tree (ADR-0004) is done **on-device**, then rewritten once, true and specific.
- Lists the inventory categories (dictionary, prediction state, clipboard, auto-backup, crash/analytics/telemetry, outbound network, logcat verbosity).

## Why now

External strategy review (codex, gpt-5.6) flagged this as the sharpest gap in the post-ADR-0003 plan: the "we store nothing" copy is on the README *now* and an ASK fork with default dictionaries on makes it untrue. It's the AGENTS.md offense "storing anything a user typed / making the privacy story harder to explain."

## Scope

This ADR is the **decision + checklist**. The inventory itself is executable work against the vendored snapshot (filed separately, on-device evidence attached) and gates the privacy-copy rewrite PR. Not an accusation against ASK — it's a keyboard doing keyboard things; the overpromise was ours.

## Evidence

Docs-only, new file + one PATCHNOTES line. Quotes the actual README claim (lines 55–57) verbatim. Load-bearing prose kept plain per VOICE.md rule 6.

## Grading

Not graded by a non-author yet — but this ADR *is* the product of acting on a different-family (codex) review, which is the separation-of-duties spirit even if not the letter. Flagging loudly. A human privacy read before accepting is worth more here than a model pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated privacy messaging to correct earlier “nothing is stored/logged” claims and clarify learned-words storage.
  * Reworked wording to clearly distinguish on-device local state from data that may leave the device (including telemetry/analytics, backups, and all network egress).
  * Added an audit-gated privacy-inventory approach requiring on-device verification (e.g., storage inspection and network monitoring).
  * “Frozen” public privacy copy until the required inventory and evidence-based checks are complete; Phase 2 aligned to the same posture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->