### PR TITLE
docs: flip ADR-0004 and ADR-0005 to Accepted

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,13 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-07-21 — The paperwork catches up again
+
+- ADR-0004 and ADR-0005 flip from Proposed to Accepted. Both decisions were
+  already load-bearing — #18 is vendoring against ADR-0004's ingestion
+  mechanism and #17 is the audit ADR-0005 mandated — the status line was just
+  the last one to find out.
+
 ## 2026-07-21 — The FlorisBoard spike files its exit interview
 
 - Ran the full capture-to-commit loop on a real IME (FlorisBoard, throwaway

--- a/docs/adr/0004-vendored-snapshot-ingestion.md
+++ b/docs/adr/0004-vendored-snapshot-ingestion.md
@@ -1,9 +1,9 @@
 # ADR-0004: Ingest AnySoftKeyboard as a vendored snapshot
 
-**Status:** Proposed (2026-07-21) — the first build-phase ADR after
+**Status:** Accepted (2026-07-21) — the first build-phase ADR after
 [ADR-0003](0003-fork-anysoftkeyboard-apache.md) picked the base. Decides *how*
 AnySoftKeyboard's source physically enters this repo, before a single line of it
-is grafted. Merging this PR records it as Accepted.
+is grafted.
 
 ## Context
 

--- a/docs/adr/0005-privacy-posture-fork-audit.md
+++ b/docs/adr/0005-privacy-posture-fork-audit.md
@@ -1,8 +1,8 @@
 # ADR-0005: Privacy posture for the fork — default-private, audit-gated
 
-**Status:** Proposed (2026-07-21) — moves the privacy posture, so it gets an ADR
-(AGENTS.md). Records the decision; the inventory it mandates is follow-up work.
-Merging this PR records it as Accepted.
+**Status:** Accepted (2026-07-21) — moves the privacy posture, so it gets an ADR
+(AGENTS.md). Records the decision; the inventory it mandates is follow-up work,
+tracked in PR #17.
 
 ## Context
 


### PR DESCRIPTION
## What

Status line on ADR-0004 (vendored-snapshot ingestion) and ADR-0005 (privacy
posture) flips from `Proposed` to `Accepted`.

## Why

Both decisions are already load-bearing on open work: #18 vendors ASK
against the mechanism ADR-0004 decided, and #17 is the audit ADR-0005
mandated. The paperwork was the only part still pretending these were open
questions. Same housekeeping pattern PR #12 used to close out ADR-0003.

## Evidence

Docs-only, 2-line diff per file. `git diff --stat`: 3 files, +12/−5.

## Grading

Not yet graded by a non-author — docs-only status flip, no code path.
Flagging the skip per the DoD.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BmubhbkLvzkCeYVuJ26rCS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the architecture decision records for snapshot ingestion and privacy-focused fork auditing from **Proposed** to **Accepted**.
  * Added a new dated changelog entry (newest-first) documenting the accepted decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->