### PR TITLE
feat(app): build the six settings screens

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,38 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-07-21 — Six rooms furnished, hallway intact
+
+- The six settings routes — home, persona browser, persona detail, AI
+  providers, rewrite behaviour, privacy — are no longer placeholders reading
+  "not yet built". They are real Compose screens with the dark theme, the
+  glass cards, the teal accents, and the ⌘ wordmark bar the mockups drew. The
+  route contract in `Routes.kt` is untouched; only the `Placeholder` calls
+  were swapped out. The onboarding placeholders stand untouched — that hallway
+  belongs to a different worker.
+- The persona browser is a two-column bento of four sample personas (Jeeves
+  wears the "Default" pill); a card opens its detail screen with the nav arg
+  the foundation already promised. Detail renders hero, speech patterns,
+  vocabulary pills, and sample lines, with a graceful "not found" panel if the
+  id is bogus.
+- Icons are mostly glyphs. The mockups use Material Symbols Outlined; the app
+  pulls only `compose.material3` and `material-icons-core`, and `Close` lives
+  in the extended set we don't ship. Glyphs match the emoji-forward mockup
+  aesthetic anyway and skip a chunky new dependency. A `✕` closes a screen as
+  well as a vector does.
+- State is local and forgetful. Toggles, the rewrite-behaviour radio, and the
+  masked API-key field are held in `remember` only — wiring them to real prefs
+  and the keystore is a follow-up, not this slice.
+- **Privacy screen, plainly:** the mockup's headline — "What we store:
+  Nothing." — is not shipped. ADR-0005 finds that copy unsafe for a fork that
+  now includes a predictive keyboard; the storage and security posture has not
+  been audited end to end. The screen that landed says, specifically, that
+  your text goes to the provider you chose (we run no servers), your key is
+  stored on-device without a hardware-backed claim we can't yet back, the
+  keyboard keeps learned words and persona choice locally, and telemetry is
+  off in this build with no stronger claim until the audit finishes. This
+  paragraph is intentionally not funny.
+
 ## 2026-07-21 — The hallway, before the rooms
 
 - The `:app` module has walls now: a Compose theme built from DESIGN.md's

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/components/PersonaSpeakTopBar.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/components/PersonaSpeakTopBar.kt
@@ -1,0 +1,92 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.components
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * Sticky brand bar that sits across the top of every settings screen.
+ * Left slot: the ⌘ glyph + "PersonaSpeak" wordmark in primary teal (matches
+ * the mockups' command-key brand treatment). Optional [leading] and [trailing]
+ * slots absorb per-screen affordances — close (X) on detail/privacy, search on
+ * home/browser, help on AI providers.
+ */
+@Composable
+fun PersonaSpeakTopBar(
+    modifier: Modifier = Modifier,
+    showWordmark: Boolean = true,
+    leading: @Composable (RowScope.() -> Unit)? = null,
+    trailing: @Composable (RowScope.() -> Unit)? = null,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f),
+        shadowElevation = 0.dp,
+        tonalElevation = 0.dp,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+            ),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (leading != null) leading()
+                if (showWordmark) {
+                    Text(
+                        text = "⌘",
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.headlineMedium,
+                        modifier = Modifier.padding(end = 6.dp, start = 4.dp),
+                    )
+                    Text(
+                        text = "PersonaSpeak",
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+            if (trailing != null) {
+                Row(verticalAlignment = Alignment.CenterVertically) { trailing() }
+            } else {
+                androidx.compose.foundation.layout.Spacer(Modifier.size(48.dp))
+            }
+        }
+    }
+}
+
+/** Close affordance for sub-screens (detail, privacy). Uses a text glyph so we
+ * don't pull material-icons-extended for a single icon. */
+@Composable
+fun TopBarCloseAction(onClick: () -> Unit) {
+    Text(
+        text = "✕",
+        color = MaterialTheme.colorScheme.onSurface,
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    )
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/components/SectionLabel.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/components/SectionLabel.kt
@@ -1,0 +1,59 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Uppercase tracking-wider section label used to head grouped sections across
+ * the settings screens. Fills width so the heading aligns to the section's
+ * card edge when padded by the same horizontal inset as the content.
+ */
+@Composable
+fun SectionLabel(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        fontWeight = FontWeight.SemiBold,
+        letterSpacing = 1.2.sp,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+    )
+}
+
+/**
+ * A reusable glass-card container: surface at the design-system container tone
+ * with a subtle outline, rounded at the medium radius. Screens put their own
+ * content inside.
+ */
+@Composable
+fun GlassCard(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    androidx.compose.material3.Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.92f),
+        shape = MaterialTheme.shapes.medium,
+        border = androidx.compose.foundation.BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+        ),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Box(Modifier.padding(0.dp)) {
+            content()
+        }
+    }
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/components/SettingsListRow.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/components/SettingsListRow.kt
@@ -1,0 +1,93 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+/**
+ * A glass-style settings list row: leading emoji glyph on a tinted disc,
+ * title + subtitle stacked, trailing chevron. The whole row is clickable and
+ * meets the 48dp minimum touch target.
+ */
+@Composable
+fun SettingsListRow(
+    title: String,
+    subtitle: String,
+    glyph: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    trailing: @Composable (() -> Unit)? = null,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Surface(
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+            shape = CircleShape,
+            modifier = Modifier.size(36.dp),
+        ) {
+            androidx.compose.foundation.layout.Box(
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = glyph,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+        }
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 14.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (subtitle.isNotEmpty()) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        if (trailing != null) {
+            trailing()
+        } else {
+            Icon(
+                imageVector = Icons.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/data/SamplePersonas.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/data/SamplePersonas.kt
@@ -1,0 +1,132 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.data
+
+import biz.pixelperfectstudios.personaspeak.personas.Persona
+
+/**
+ * Hardcoded sample list backing the settings persona browser/detail screens
+ * until the real YAML loader pipeline is wired in. Keeps [Persona] (pure
+ * Kotlin, :core-personas) untouched; this file owns only the UI display
+ * metadata the core type deliberately doesn't carry — emoji, marketing
+ * tagline, and a URL-safe id for nav arguments.
+ */
+data class PersonaDisplay(
+    val id: String,
+    val emoji: String,
+    val tagline: String,
+    val isDefault: Boolean = false,
+    val persona: Persona,
+)
+
+object SamplePersonas {
+
+    val all: List<PersonaDisplay> = listOf(
+        PersonaDisplay(
+            id = "jeeves",
+            emoji = "🎩",
+            tagline = "The impeccable valet. Provides meticulous assistance with a focus on etiquette and proactive service.",
+            isDefault = true,
+            persona = Persona(
+                name = "Jeeves",
+                context = "The impeccably composed valet from P.G. Wodehouse's Jeeves and Wooster stories.",
+                speechPatterns = listOf(
+                    "Formal — stately traditional syntax with unwavering etiquette.",
+                    "Efficient — economical with words, prioritizing clarity and service.",
+                    "Resourceful — possessing a solution for every social predicament.",
+                ),
+                vocabulary = listOf(
+                    "if I may say so",
+                    "quite so",
+                    "I rather fancy",
+                    "endeavour",
+                    "satisfactory",
+                ),
+                sampleLines = listOf(
+                    "If I may venture a suggestion, sir, the grey suit would be the more prudent choice this morning.",
+                    "I have taken the liberty of preparing tea, sir. I believe you will find it satisfactory.",
+                    "Quite so, sir. I shall endeavor to resolve the matter directly.",
+                ),
+            ),
+        ),
+        PersonaDisplay(
+            id = "sir-humphrey",
+            emoji = "🏛️",
+            tagline = "Master of bureaucratic circumlocution. Excellent for obfuscating intent while remaining technically correct.",
+            persona = Persona(
+                name = "Sir Humphrey",
+                context = "The permanent secretary from Yes Minister, whose sentences only appear to end.",
+                speechPatterns = listOf(
+                    "Circumspect — never confirming or denying where a nod would do.",
+                    "Bureaucratic — favoring the long, conditional, and unimpeachable.",
+                    "Courteous — disagreement delivered as apology.",
+                ),
+                vocabulary = listOf(
+                    "if I may be so bold",
+                    "with the greatest respect",
+                    "I wonder whether the minister might consider",
+                    "in principle, yes",
+                    "courageous",
+                ),
+                sampleLines = listOf(
+                    "With the greatest respect, Minister, I wonder whether the department might not regard that as a somewhat courageous decision.",
+                    "In principle, yes. In practice, one or two minor administrative difficulties do arise.",
+                    "If I may be so bold, that would be a bold policy indeed.",
+                ),
+            ),
+        ),
+        PersonaDisplay(
+            id = "dr-schultz",
+            emoji = "🤠",
+            tagline = "Eloquent, courteous bounty hunter. Precise, articulate, and dangerously polite in every interaction.",
+            persona = Persona(
+                name = "Dr. Schultz",
+                context = "The well-spoken dentist turned bounty hunter from Django Unchained.",
+                speechPatterns = listOf(
+                    "Mellifluous — every syllable attended to.",
+                    "Courteous — unfailingly polite, even while at a disadvantage.",
+                    "Precise — choosing the mot juste with German care.",
+                ),
+                vocabulary = listOf(
+                    "if I may make so bold",
+                    "it would appear",
+                    "my curiosity has gotten the better of me",
+                    "permit me",
+                    "charmed",
+                ),
+                sampleLines = listOf(
+                    "Allow me to introduce myself. I am Dr. King Schultz, and it is a genuine pleasure to make your acquaintance.",
+                    "Permit me a moment of your time, sir — I believe we may do profitable business together.",
+                    "Charmed, I'm sure. Now, you will forgive my curiosity, but it has gotten the better of me.",
+                ),
+            ),
+        ),
+        PersonaDisplay(
+            id = "bachchan",
+            emoji = "🎬",
+            tagline = "Every reply to a full house. Larger-than-life delivery, dramatic pauses, and cinematic gravitas.",
+            persona = Persona(
+                name = "Bachchan",
+                context = "A voice in the tradition of Hindi cinema's towering leading men.",
+                speechPatterns = listOf(
+                    "Grand — delivered as though to a packed auditorium.",
+                    "Deliberate — comfortable with silence and the dramatic pause.",
+                    "Gravitas — baritone authority lent to the smallest remark.",
+                ),
+                vocabulary = listOf(
+                    "dekhiye",
+                    "hum",
+                    "yeh zamaana",
+                    "parampara",
+                    "theek hai",
+                ),
+                sampleLines = listOf(
+                    "Dekhiye. Yeh zamaana bahut ajeeb hai — lekin hum yahan hain, aur hum yeh task poori karenge.",
+                    "Parampara kaunsee? Woh jeevan ka dhaar hai, dost.",
+                    "Hum kabhi haar nahi maante. Yeh — theek hai — humara tareeqa hai.",
+                ),
+            ),
+        ),
+    )
+
+    /** Find one by nav id; null lets the detail screen render a fallback. */
+    fun byId(id: String): PersonaDisplay? = all.firstOrNull { it.id == id }
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/data/SampleProviders.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/data/SampleProviders.kt
@@ -1,0 +1,69 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.data
+
+/**
+ * Hardcoded provider display list for the AI providers settings screen. The
+ * real provider registry lives in :core-providers; this is the UI-facing
+ * projection with just the display names and statuses the mockups carry.
+ */
+data class ProviderDisplay(
+    val id: String,
+    val name: String,
+    val shortName: String,
+    val status: String,
+    val description: String,
+    val isActive: Boolean = false,
+    val isLocal: Boolean = false,
+    val isConfigured: Boolean = false,
+    val action: String,
+)
+
+object SampleProviders {
+
+    val all: List<ProviderDisplay> = listOf(
+        ProviderDisplay(
+            id = "gemini",
+            name = "Gemini",
+            shortName = "G",
+            status = "Active",
+            description = "Using Google's most capable multimodal models.",
+            isActive = true,
+            isConfigured = true,
+            action = "Active",
+        ),
+        ProviderDisplay(
+            id = "claude",
+            name = "Claude",
+            shortName = "Anthropic",
+            status = "Not configured",
+            description = "Anthropic's Claude family, strong for long-form reasoning.",
+            action = "Setup",
+        ),
+        ProviderDisplay(
+            id = "openai",
+            name = "OpenAI",
+            shortName = "GPT-4o",
+            status = "Not configured",
+            description = "GPT-4o and friends, for general-purpose rewriting.",
+            action = "Setup",
+        ),
+        ProviderDisplay(
+            id = "openrouter",
+            name = "OpenRouter",
+            shortName = "Many models",
+            status = "Not configured",
+            description = "One key, many providers — route between them.",
+            action = "Setup",
+        ),
+        ProviderDisplay(
+            id = "local",
+            name = "Local Instance",
+            shortName = "Self-host",
+            status = "Advanced users",
+            description = "Run a model on your own hardware. No cloud, no key.",
+            isLocal = true,
+            action = "Connect",
+        ),
+    )
+
+    val active: ProviderDisplay? get() = all.firstOrNull { it.isActive }
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/nav/PersonaSpeakNavHost.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/nav/PersonaSpeakNavHost.kt
@@ -29,17 +29,46 @@ fun PersonaSpeakNavHost(navController: NavHostController) {
         composable(Screen.OnboardingApiKey.route) { Placeholder(Screen.OnboardingApiKey) }
         composable(Screen.OnboardingDemo.route) { Placeholder(Screen.OnboardingDemo) }
 
-        composable(Screen.SettingsHome.route) { Placeholder(Screen.SettingsHome) }
-        composable(Screen.PersonaBrowser.route) { Placeholder(Screen.PersonaBrowser) }
+        composable(Screen.SettingsHome.route) {
+            biz.pixelperfectstudios.personaspeak.app.ui.screens.settings.SettingsHomeScreen(
+                onNavigatePersonas = { navController.navigate(Screen.PersonaBrowser.route) },
+                onNavigateAiProviders = { navController.navigate(Screen.AiProviders.route) },
+                onNavigateRewriteBehaviour = { navController.navigate(Screen.RewriteBehaviour.route) },
+                onNavigatePrivacy = { navController.navigate(Screen.Privacy.route) },
+            )
+        }
+        composable(Screen.PersonaBrowser.route) {
+            biz.pixelperfectstudios.personaspeak.app.ui.screens.settings.PersonaBrowserScreen(
+                onPersonaSelected = { personaId ->
+                    navController.navigate(Screen.personaDetail(personaId))
+                },
+                onClose = { navController.popBackStack() },
+            )
+        }
         composable(
             route = Screen.PersonaDetail.route,
             arguments = listOf(navArgument(Screen.PERSONA_ID_ARG) { type = NavType.StringType }),
         ) { entry ->
-            Placeholder(Screen.PersonaDetail, entry.arguments?.getString(Screen.PERSONA_ID_ARG))
+            biz.pixelperfectstudios.personaspeak.app.ui.screens.settings.PersonaDetailScreen(
+                personaId = entry.arguments?.getString(Screen.PERSONA_ID_ARG),
+                onClose = { navController.popBackStack() },
+            )
         }
-        composable(Screen.AiProviders.route) { Placeholder(Screen.AiProviders) }
-        composable(Screen.RewriteBehaviour.route) { Placeholder(Screen.RewriteBehaviour) }
-        composable(Screen.Privacy.route) { Placeholder(Screen.Privacy) }
+        composable(Screen.AiProviders.route) {
+            biz.pixelperfectstudios.personaspeak.app.ui.screens.settings.AiProvidersScreen(
+                onClose = { navController.popBackStack() },
+            )
+        }
+        composable(Screen.RewriteBehaviour.route) {
+            biz.pixelperfectstudios.personaspeak.app.ui.screens.settings.RewriteBehaviourScreen(
+                onClose = { navController.popBackStack() },
+            )
+        }
+        composable(Screen.Privacy.route) {
+            biz.pixelperfectstudios.personaspeak.app.ui.screens.settings.PrivacyScreen(
+                onClose = { navController.popBackStack() },
+            )
+        }
     }
 }
 

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/screens/settings/AiProvidersScreen.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/screens/settings/AiProvidersScreen.kt
@@ -1,0 +1,379 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.screens.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+import biz.pixelperfectstudios.personaspeak.app.ui.components.PersonaSpeakTopBar
+import biz.pixelperfectstudios.personaspeak.app.ui.components.SectionLabel
+import biz.pixelperfectstudios.personaspeak.app.ui.data.SampleProviders
+import biz.pixelperfectstudios.personaspeak.app.ui.theme.PillShape
+import biz.pixelperfectstudios.personaspeak.app.ui.theme.TechnicalTextStyle
+
+/**
+ * AI provider configuration. Lists the active provider, an API-credentials
+ * field, the other available providers, and a couple of global toggles. All
+ * state here is local and unsaved — wiring to the real provider registry and
+ * Keystore is out of scope for the settings-screens slice.
+ */
+@Composable
+fun AiProvidersScreen(onClose: () -> Unit) {
+    var autoRetry by remember { mutableStateOf(true) }
+    var contextWindow by remember { mutableStateOf(false) }
+
+    Surface(
+        color = MaterialTheme.colorScheme.background,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            PersonaSpeakTopBar(
+                leading = {
+                    Text(
+                        text = "✕",
+                        color = MaterialTheme.colorScheme.onSurface,
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier
+                            .clickable(onClick = onClose)
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                    )
+                },
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(vertical = 16.dp),
+            ) {
+                // Breadcrumb
+                Text(
+                    text = "Settings › AI Providers",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+
+                Text(
+                    text = "Configuration",
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+                Text(
+                    text = "Manage your LLM engines and API credentials.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+
+                Spacer(Modifier.height(16.dp))
+
+                SampleProviders.active?.let { ActiveProviderCard(it.name) }
+
+                SectionLabel("API credentials")
+                ApiCredentialsCard(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+
+                SectionLabel("Available providers")
+                Column(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    SampleProviders.all.filter { !it.isActive }.forEach { provider ->
+                        AvailableProviderRow(provider)
+                    }
+                }
+
+                SectionLabel("Global controls")
+                GlobalControlsCard(
+                    autoRetry = autoRetry,
+                    onAutoRetryChange = { autoRetry = it },
+                    contextWindow = contextWindow,
+                    onContextWindowChange = { contextWindow = it },
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActiveProviderCard(name: String) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.92f),
+        shape = MaterialTheme.shapes.medium,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                ProviderIconBox(name.first().toString())
+                Spacer(Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = name,
+                            style = MaterialTheme.typography.headlineMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Surface(
+                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                            shape = PillShape,
+                        ) {
+                            Text(
+                                text = "Free",
+                                color = MaterialTheme.colorScheme.primary,
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                            )
+                        }
+                    }
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            modifier = Modifier
+                                .size(8.dp)
+                                .background(MaterialTheme.colorScheme.primary, CircleShape),
+                        )
+                        Spacer(Modifier.width(6.dp))
+                        Text(
+                            text = "Active",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = "Using Google's most capable multimodal models.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(12.dp))
+            Button(
+                onClick = { /* test connection — out of scope */ },
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+                shape = MaterialTheme.shapes.small,
+            ) {
+                Text("Test connection")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ApiCredentialsCard(modifier: Modifier = Modifier) {
+    var visible by remember { mutableStateOf(false) }
+    val masked = "••••••••••••••••••••"
+    Surface(
+        color = Color(0xFF2D333B),
+        shape = MaterialTheme.shapes.medium,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 18.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(text = "🔑", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = if (visible) "AIzaSY_sample_key_redacted" else masked,
+                style = TechnicalTextStyle,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = if (visible) "🙈" else "👁",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .clickable { visible = !visible }
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+            Text(
+                text = "🗑",
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier
+                    .clickable { /* delete — out of scope */ }
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AvailableProviderRow(
+    provider: biz.pixelperfectstudios.personaspeak.app.ui.data.ProviderDisplay,
+) {
+    val isLocal = provider.isLocal
+    Surface(
+        color = if (isLocal) MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = 0.6f)
+        else MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.92f),
+        shape = MaterialTheme.shapes.medium,
+        border = BorderStroke(
+            1.dp,
+            if (isLocal) MaterialTheme.colorScheme.outlineVariant
+            else MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+        ),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ProviderIconBox(provider.name.first().toString())
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = provider.name,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text = "(${provider.shortName})",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    text = provider.status,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            OutlinedButton(
+                onClick = { /* setup/connect — out of scope */ },
+                shape = MaterialTheme.shapes.small,
+            ) {
+                Text(provider.action)
+            }
+        }
+    }
+}
+
+@Composable
+private fun GlobalControlsCard(
+    autoRetry: Boolean,
+    onAutoRetryChange: (Boolean) -> Unit,
+    contextWindow: Boolean,
+    onContextWindowChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.92f),
+        shape = MaterialTheme.shapes.medium,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column {
+            ToggleRow(
+                title = "Auto-retry on failure",
+                description = "Switch to backup provider if primary fails.",
+                checked = autoRetry,
+                onCheckedChange = onAutoRetryChange,
+            )
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+            ToggleRow(
+                title = "Context window management",
+                description = "Optimize token usage for long conversations.",
+                checked = contextWindow,
+                onCheckedChange = onContextWindowChange,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ToggleRow(
+    title: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+@Composable
+private fun ProviderIconBox(glyph: String) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        shape = RoundedCornerShape(8.dp),
+        modifier = Modifier.size(40.dp),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = glyph,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/screens/settings/PersonaBrowserScreen.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/screens/settings/PersonaBrowserScreen.kt
@@ -1,0 +1,204 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.screens.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import biz.pixelperfectstudios.personaspeak.app.ui.components.PersonaSpeakTopBar
+import biz.pixelperfectstudios.personaspeak.app.ui.data.PersonaDisplay
+import biz.pixelperfectstudios.personaspeak.app.ui.data.SamplePersonas
+import biz.pixelperfectstudios.personaspeak.app.ui.theme.PillShape
+
+/**
+ * Two-column bento grid of installed personas. Selecting a card navigates to
+ * the persona-detail route with that persona's id. The default persona wears
+ * a teal "Default" pill badge (Jeeves in the sample set).
+ */
+@Composable
+fun PersonaBrowserScreen(
+    onPersonaSelected: (personaId: String) -> Unit,
+    onClose: () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.background,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            PersonaSpeakTopBar(
+                leading = { BrowserCloseButton(onClose) },
+                trailing = {
+                    IconButton(onClick = { /* search — out of scope */ }) {
+                        Icon(
+                            imageVector = Icons.Filled.Search,
+                            contentDescription = "Search",
+                            tint = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                },
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp, vertical = 16.dp),
+            ) {
+                Text(
+                    text = "Select Persona",
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "Choose your AI's conversational archetype to transform your writing style with precision and flair.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(24.dp))
+
+                // Two-column bento grid, laid out manually so we don't nest a
+                // lazy grid inside the vertical scroll.
+                SamplePersonas.all.chunked(2).forEach { rowItems ->
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        rowItems.forEach { persona ->
+                            PersonaBentoCard(
+                                persona = persona,
+                                onClick = { onPersonaSelected(persona.id) },
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                        if (rowItems.size == 1) {
+                            Spacer(Modifier.weight(1f))
+                        }
+                    }
+                    Spacer(Modifier.height(12.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PersonaBentoCard(
+    persona: PersonaDisplay,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.92f),
+        shape = MaterialTheme.shapes.medium,
+        border = androidx.compose.foundation.BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+        ),
+        modifier = modifier
+            .clickable(onClick = onClick)
+            .height(180.dp),
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            // Teal glow blob, top-right — matches the mockup's accent.
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(8.dp)
+                    .size(56.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f),
+                        shape = CircleShape,
+                    ),
+            )
+
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = persona.emoji,
+                    style = MaterialTheme.typography.headlineLarge,
+                )
+                Spacer(Modifier.height(6.dp))
+                if (persona.isDefault) {
+                    DefaultBadge()
+                    Spacer(Modifier.height(4.dp))
+                }
+                Text(
+                    text = persona.persona.name,
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = persona.tagline,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 4,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DefaultBadge() {
+    Surface(
+        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f),
+        shape = PillShape,
+        border = androidx.compose.foundation.BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.40f),
+        ),
+    ) {
+        Text(
+            text = "Default",
+            color = MaterialTheme.colorScheme.primary,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun BrowserCloseButton(onClose: () -> Unit) {
+    Text(
+        text = "✕",
+        color = MaterialTheme.colorScheme.onSurface,
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier
+            .clickable(onClick = onClose)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    )
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/screens/settings/PersonaDetailScreen.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/screens/settings/PersonaDetailScreen.kt
@@ -1,0 +1,337 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.screens.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import biz.pixelperfectstudios.personaspeak.app.ui.components.PersonaSpeakTopBar
+import biz.pixelperfectstudios.personaspeak.app.ui.components.SectionLabel
+import biz.pixelperfectstudios.personaspeak.app.ui.data.PersonaDisplay
+import biz.pixelperfectstudios.personaspeak.app.ui.data.SamplePersonas
+import biz.pixelperfectstudios.personaspeak.app.ui.theme.PillShape
+
+/**
+ * Per-persona detail. Reads the [personaId] nav arg, looks it up in the
+ * sample set, and renders hero + speech patterns + vocabulary pills + sample
+ * lines. Unknown ids render a small not-found panel rather than crashing.
+ */
+@Composable
+fun PersonaDetailScreen(
+    personaId: String?,
+    onClose: () -> Unit,
+) {
+    val persona = personaId?.let { SamplePersonas.byId(it) }
+
+    Surface(
+        color = MaterialTheme.colorScheme.background,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            PersonaSpeakTopBar(
+                leading = {
+                    Text(
+                        text = "✕",
+                        color = MaterialTheme.colorScheme.onSurface,
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier
+                            .clickable(onClick = onClose)
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                    )
+                },
+            )
+
+            if (persona == null) {
+                NotFoundState(personaId)
+                return@Column
+            }
+
+            Column(modifier = Modifier.weight(1f).verticalScroll(rememberScrollState())) {
+                PersonaHero(persona)
+                SpeechPatternsSection(persona)
+                VocabularySection(persona)
+                SampleLinesSection(persona)
+                Spacer(Modifier.height(80.dp))
+            }
+
+            DetailFooter()
+        }
+    }
+}
+
+@Composable
+private fun PersonaHero(persona: PersonaDisplay) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            modifier = Modifier.size(112.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            // Primary-tinted glow behind the emoji.
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f),
+                        shape = CircleShape,
+                    ),
+            )
+            Text(
+                text = persona.emoji,
+                style = MaterialTheme.typography.displayMedium,
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = persona.persona.name,
+            style = MaterialTheme.typography.headlineLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.ExtraBold,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = persona.persona.context,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontStyle = FontStyle.Italic,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .width(280.dp)
+                .padding(horizontal = 8.dp),
+        )
+    }
+}
+
+@Composable
+private fun SpeechPatternsSection(persona: PersonaDisplay) {
+    SectionLabel("Speech patterns")
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.92f),
+        shape = MaterialTheme.shapes.medium,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Column {
+            persona.persona.speechPatterns.forEachIndexed { index, pattern ->
+                if (index > 0) {
+                    androidx.compose.material3.HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+                    )
+                }
+                SpeechPatternRow(pattern)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SpeechPatternRow(pattern: String) {
+    // Patterns in the sample data are formatted "Title — description". Split
+    // gracefully if the em-dash separator isn't there.
+    val (title, desc) = pattern.split(" — ", limit = 2)
+        .let { parts ->
+            if (parts.size == 2) parts[0] to parts[1] else pattern to ""
+        }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+            shape = RoundedCornerShape(8.dp),
+            modifier = Modifier.size(32.dp),
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Text(text = "▸", color = MaterialTheme.colorScheme.primary)
+            }
+        }
+        Column(modifier = Modifier.padding(start = 12.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Bold,
+            )
+            if (desc.isNotEmpty()) {
+                Text(
+                    text = desc,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun VocabularySection(persona: PersonaDisplay) {
+    if (persona.persona.vocabulary.isEmpty()) return
+    SectionLabel("Vocabulary")
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Spacer(Modifier.width(16.dp))
+        persona.persona.vocabulary.forEach { word ->
+            Surface(
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                shape = PillShape,
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)),
+            ) {
+                Text(
+                    text = word,
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                )
+            }
+        }
+        Spacer(Modifier.width(16.dp))
+    }
+}
+
+@Composable
+private fun SampleLinesSection(persona: PersonaDisplay) {
+    if (persona.persona.sampleLines.isEmpty()) return
+    SectionLabel("Sample lines")
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.92f),
+        shape = MaterialTheme.shapes.medium,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            persona.persona.sampleLines.forEach { line ->
+                Row(modifier = Modifier.padding(vertical = 6.dp)) {
+                    Box(
+                        modifier = Modifier
+                            .width(3.dp)
+                            .height(40.dp)
+                            .background(
+                                MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
+                                RoundedCornerShape(2.dp),
+                            ),
+                    )
+                    Spacer(Modifier.width(12.dp))
+                    Text(
+                        text = line,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontStyle = FontStyle.Italic,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailFooter() {
+    val tealBrush = Brush.horizontalGradient(
+        listOf(MaterialTheme.colorScheme.primary, MaterialTheme.colorScheme.secondaryContainer),
+    )
+    Surface(
+        color = MaterialTheme.colorScheme.background.copy(alpha = 0.95f),
+        tonalElevation = 0.dp,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Button(
+                onClick = { /* try persona — out of scope */ },
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+                shape = MaterialTheme.shapes.small,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = "Try this persona",
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            OutlinedButton(
+                onClick = { /* set default — out of scope */ },
+                enabled = false,
+                shape = MaterialTheme.shapes.small,
+            ) {
+                Text("Set as default")
+            }
+        }
+    }
+}
+
+@Composable
+private fun NotFoundState(personaId: String?) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = "🤷",
+                style = MaterialTheme.typography.displaySmall,
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = "Persona not found",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = if (personaId != null) "No persona matches \"$personaId\"." else "No persona selected.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/screens/settings/PrivacyScreen.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/screens/settings/PrivacyScreen.kt
@@ -1,0 +1,204 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.screens.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import biz.pixelperfectstudios.personaspeak.app.ui.components.PersonaSpeakTopBar
+
+/**
+ * Privacy / data-handling disclosure.
+ *
+ * The mockup's headline here ("What we store: Nothing.") is deliberately NOT
+ * shipped. ADR-0005 (privacy-posture fork-audit, Proposed→Accepted on merge)
+ * finds that copy unsafe for the fork: AnySoftKeyboard now ships in the tree,
+ * and a predictive keyboard stores data by design. Until the vendored keyboard
+ * tree is audited end to end, every claim on this screen stays specific and
+ * verifiable — vaguer-but-true beats a crisp line we can't back up. This is
+ * load-bearing plain text per VOICE.md rule 6: no jokes, no flourish.
+ */
+@Composable
+fun PrivacyScreen(onClose: () -> Unit) {
+    Surface(
+        color = MaterialTheme.colorScheme.background,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            PersonaSpeakTopBar(
+                leading = {
+                    Text(
+                        text = "✕",
+                        color = MaterialTheme.colorScheme.onSurface,
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier
+                            .clickable(onClick = onClose)
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                    )
+                },
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = "Where your text goes",
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "A short, honest account of what this app does with what you type. " +
+                        "We will tighten or correct these statements as the keyboard audit (ADR-0005) completes.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(20.dp))
+
+                PrivacyRow(
+                    glyph = "💬",
+                    tint = MaterialTheme.colorScheme.primary,
+                    title = "Your text",
+                    body = "When you tap rewrite, the selected text is sent to the AI provider " +
+                        "you picked. It is not routed through our own servers; we do not run any. " +
+                        "What your provider retains after that is governed by their policy — read it.",
+                )
+                PrivacyRow(
+                    glyph = "🔑",
+                    tint = MaterialTheme.colorScheme.secondary,
+                    title = "Your API key",
+                    body = "Stored on this device. We use Android's standard app storage. We have " +
+                        "not yet audited whether the hardware-backed keystore is in use, so we will " +
+                        "not claim hardware-level security here until we have checked.",
+                )
+                PrivacyRow(
+                    glyph = "🧠",
+                    tint = MaterialTheme.colorScheme.tertiary,
+                    title = "On-device data",
+                    body = "The keyboard keeps what it needs to work: learned words, your selected " +
+                        "persona and mood, and these settings. It stays on your phone. You will be " +
+                        "able to clear it from this screen once clearing is wired up (it is not in " +
+                        "this build).",
+                )
+                PrivacyRow(
+                    glyph = "🚫",
+                    tint = MaterialTheme.colorScheme.error,
+                    title = "Telemetry & analytics",
+                    body = "Off in this build. Because the keyboard codebase is still being audited, " +
+                        "we will not make a stronger 'no tracking, ever' claim until that audit is " +
+                        "complete.",
+                )
+
+                Spacer(Modifier.height(8.dp))
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = 0.6f),
+                    shape = MaterialTheme.shapes.medium,
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = "Note: like any Android app, anything written to the system log " +
+                            "(logcat) can be read by other apps that hold the READ_LOGS permission, " +
+                            "which Android restricts to system or rooted access. We avoid logging " +
+                            "personal data.",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(12.dp),
+                    )
+                }
+
+                Spacer(Modifier.height(20.dp))
+                Button(
+                    onClick = { /* open repo — out of scope */ },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary,
+                    ),
+                    shape = MaterialTheme.shapes.small,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = "Read the code yourself",
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PrivacyRow(
+    glyph: String,
+    tint: androidx.compose.ui.graphics.Color,
+    title: String,
+    body: String,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.92f),
+        shape = MaterialTheme.shapes.medium,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Surface(
+                color = tint.copy(alpha = 0.12f),
+                shape = RoundedCornerShape(10.dp),
+                modifier = Modifier.size(40.dp),
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Text(text = glyph, style = MaterialTheme.typography.titleMedium)
+                }
+            }
+            Spacer(Modifier.width(14.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = body,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/screens/settings/RewriteBehaviourScreen.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/screens/settings/RewriteBehaviourScreen.kt
@@ -1,0 +1,154 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.screens.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import biz.pixelperfectstudios.personaspeak.app.ui.components.PersonaSpeakTopBar
+
+/**
+ * Rewrite behaviour radio group. Selection is held in local state only —
+ * persisting it alongside the rest of the keyboard prefs is out of scope for
+ * this slice and noted as a deviation.
+ *
+ * No mockup exists for this screen; the two options come straight from the
+ * settings-home row subtitle ("Ask before replacing") and its implied opposite.
+ */
+@Composable
+fun RewriteBehaviourScreen(onClose: () -> Unit) {
+    // "Ask before replacing" is the documented default.
+    var askFirst by remember { mutableStateOf(true) }
+
+    Surface(
+        color = MaterialTheme.colorScheme.background,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            PersonaSpeakTopBar(
+                leading = {
+                    Text(
+                        text = "✕",
+                        color = MaterialTheme.colorScheme.onSurface,
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier
+                            .clickable(onClick = onClose)
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                    )
+                },
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+            ) {
+                Text(
+                    text = "Rewrite behaviour",
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "When a persona rewrites your text, decide how it lands in the field.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(20.dp))
+
+                RewriteOptionCard(
+                    title = "Ask before replacing",
+                    description = "Show the rewrite in a preview. You choose whether to insert it.",
+                    selected = askFirst,
+                    onSelect = { askFirst = true },
+                )
+                Spacer(Modifier.height(12.dp))
+                RewriteOptionCard(
+                    title = "Replace immediately",
+                    description = "Insert the rewrite straight into the field. Faster, but irreversible without undo.",
+                    selected = !askFirst,
+                    onSelect = { askFirst = false },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RewriteOptionCard(
+    title: String,
+    description: String,
+    selected: Boolean,
+    onSelect: () -> Unit,
+) {
+    val borderColor = if (selected) {
+        MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+    } else {
+        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
+    }
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.92f),
+        shape = MaterialTheme.shapes.medium,
+        border = BorderStroke(1.dp, borderColor),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onSelect),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            RadioButton(
+                selected = selected,
+                onClick = onSelect,
+                colors = RadioButtonDefaults.colors(
+                    selectedColor = MaterialTheme.colorScheme.primary,
+                    unselectedColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                ),
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/screens/settings/SettingsHomeScreen.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/screens/settings/SettingsHomeScreen.kt
@@ -1,0 +1,161 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.screens.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import biz.pixelperfectstudios.personaspeak.app.ui.components.GlassCard
+import biz.pixelperfectstudios.personaspeak.app.ui.components.PersonaSpeakTopBar
+import biz.pixelperfectstudios.personaspeak.app.ui.components.SectionLabel
+import biz.pixelperfectstudios.personaspeak.app.ui.components.SettingsListRow
+import biz.pixelperfectstudios.personaspeak.app.ui.data.SamplePersonas
+import biz.pixelperfectstudios.personaspeak.app.ui.data.SampleProviders
+
+/**
+ * Settings root. Per the task scope, only the four rows that map to routes this
+ * screen owns are surfaced (Personas, AI provider, Rewrite behaviour, Privacy).
+ * The mockup's other rows — default mood, API key, usage, languages, glide
+ * typing, autocorrect, theme, height, read-the-source — belong to the keyboard
+ * fork (no routes exist for them yet) and are intentionally omitted here.
+ */
+@Composable
+fun SettingsHomeScreen(
+    onNavigatePersonas: () -> Unit,
+    onNavigateAiProviders: () -> Unit,
+    onNavigateRewriteBehaviour: () -> Unit,
+    onNavigatePrivacy: () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.background,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            PersonaSpeakTopBar(
+                trailing = {
+                    IconButton(onClick = { /* search — out of scope */ }) {
+                        Icon(
+                            imageVector = Icons.Filled.Search,
+                            contentDescription = "Search",
+                            tint = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                },
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(bottom = 32.dp),
+            ) {
+                Spacer(Modifier.height(16.dp))
+
+                DefaultKeyboardBanner()
+
+                SectionLabel("Characters")
+                GlassCard(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                    Column {
+                        SettingsListRow(
+                            title = "Personas",
+                            subtitle = "${SamplePersonas.all.size} installed",
+                            glyph = "🎭",
+                            onClick = onNavigatePersonas,
+                        )
+                        Divider()
+                        SettingsListRow(
+                            title = "Rewrite behaviour",
+                            subtitle = "Ask before replacing",
+                            glyph = "✍️",
+                            onClick = onNavigateRewriteBehaviour,
+                        )
+                    }
+                }
+
+                SectionLabel("The brain")
+                GlassCard(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                    SettingsListRow(
+                        title = "AI provider",
+                        subtitle = SampleProviders.active?.name ?: "None",
+                        glyph = "🧠",
+                        onClick = onNavigateAiProviders,
+                    )
+                }
+
+                SectionLabel("Privacy")
+                GlassCard(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                    SettingsListRow(
+                        title = "What we store",
+                        subtitle = "Read the honest answer",
+                        glyph = "🔒",
+                        onClick = onNavigatePrivacy,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DefaultKeyboardBanner() {
+    // Mockup reads "PersonaSpeak is your default keyboard" as a confirmed
+    // state. We can't verify default-keyboard status from this screen yet, so
+    // the banner stays a true brand line rather than an unverifiable claim.
+    Surface(
+        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+        shape = RoundedCornerShape(12.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "✓",
+                color = MaterialTheme.colorScheme.primary,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = "PersonaSpeak — your persona-driven keyboard.",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+    }
+}
+
+@Composable
+private fun Divider() {
+    androidx.compose.material3.HorizontalDivider(
+        modifier = Modifier.padding(start = 64.dp),
+        thickness = 1.dp,
+        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+    )
+}

--- a/docs/superpowers/specs/2026-07-21-settings-screens-report.md
+++ b/docs/superpowers/specs/2026-07-21-settings-screens-report.md
@@ -1,0 +1,82 @@
+# Settings screens report — six real Compose screens
+
+**Branch:** `feat/settings-screens` (forked from `feat/graft-foundation`)
+**Date:** 2026-07-21
+**Scope:** the six settings routes in `:app` go from placeholders to real Compose screens: `SettingsHome`, `PersonaBrowser`, `PersonaDetail`, `AiProviders`, `RewriteBehaviour`, `Privacy`. No routes were added, renamed, or re-argued; the contract in `Routes.kt` is untouched. Onboarding routes, `android/keyboard/`, and everything outside `app/` are deliberately untouched.
+
+## What landed
+
+All new code lives under `android/app/src/main/kotlin/.../app/ui/`:
+
+- **`data/SamplePersonas.kt`** — a hardcoded `List<PersonaDisplay>` of the four sample personas (Jeeves default, Sir Humphrey, Dr. Schultz, Bachchan), each pairing a pure-Kotlin `Persona` (from `:core-personas`, left untouched per module law) with UI display metadata: nav id, emoji, tagline, default flag. `byId(id)` powers the detail screen.
+- **`data/SampleProviders.kt`** — a hardcoded `List<ProviderDisplay>` (Gemini active, Claude/OpenAI/OpenRouter unconfigured, Local Instance) plus an `active` accessor. UI-facing projection only; the real registry lives in `:core-providers`.
+- **`components/PersonaSpeakTopBar.kt`** — the sticky brand bar (⌘ + "PersonaSpeak" wordmark in primary) with optional `leading`/`trailing` slots and a `TopBarCloseAction` glyph.
+- **`components/SettingsListRow.kt`** — glass-style settings row: leading emoji on a primary-tinted disc, title + subtitle, trailing chevron.
+- **`components/SectionLabel.kt`** — the uppercase tracking-wider section header, plus a reusable `GlassCard` container.
+- **`screens/settings/SettingsHomeScreen.kt`** — the four navigable rows (Personas, Rewrite behaviour, AI provider, Privacy), grouped under section labels.
+- **`screens/settings/PersonaBrowserScreen.kt`** — two-column bento grid of persona cards with teal glow accents and a "Default" pill on Jeeves; cards navigate to `personaDetail(id)`.
+- **`screens/settings/PersonaDetailScreen.kt`** — hero (emoji + name + context), speech-patterns list, vocabulary pills (horizontal scroll), sample lines, fixed footer ("Try this persona" / "Set as default"). Unknown `personaId` renders a not-found panel instead of crashing.
+- **`screens/settings/AiProvidersScreen.kt`** — active-provider card, masked API-key field (charcoal `#2D333B`, monospace), available-providers list, two global toggle rows.
+- **`screens/settings/RewriteBehaviourScreen.kt`** — radio group: "Ask before replacing" (default) vs "Replace immediately".
+- **`screens/settings/PrivacyScreen.kt`** — data-handling disclosure. **Deviation — see below.**
+
+### Wiring
+
+`PersonaSpeakNavHost.kt` — the six settings `composable(...)` entries now call the real screen composables instead of `Placeholder`. The `personaId` arg is read from `entry.arguments?.getString(Screen.PERSONA_ID_ARG)` exactly as the placeholder did; no `SavedStateHandle` introduced. `Placeholder` is retained for the five onboarding routes, which are out of scope.
+
+## Deviations from the mockups
+
+These are intentional and called out so a reviewer can disagree precisely.
+
+1. **Privacy screen (load-bearing).** The mockup headline is "What we store / Nothing." with four crisply-true claims including "Encrypted in Android Keystore. Hardware-level security ensures we can never see or extract your credentials." ADR-0005 (`docs/adr/0005-privacy-posture-fork-audit.md`, Proposed→Accepted on merge) finds that copy unsafe for the fork: AnySoftKeyboard now ships in the tree, a predictive keyboard that stores data by design, and the storage/security posture has not been audited end to end. Per ADR-0005 and VOICE.md rule 6, the privacy screen ships **honest, specific, vaguer-but-true copy** instead:
+   - Headline is "Where your text goes", not "Nothing."
+   - "Your text" — sent to the chosen provider on request; we run no servers; provider retention is the provider's policy.
+   - "Your API key" — stored on-device via standard app storage; we do **not** claim hardware-backed keystore until that is audited.
+   - "On-device data" — acknowledges the keyboard keeps learned words/persona/settings locally; stays on device; clearing is not yet wired.
+   - "Telemetry & analytics" — off in this build; no stronger "no tracking, ever" claim until the audit completes.
+   - A logcat disclosure note covers on-device observability by system/root READ_LOGS holders.
+
+   No jokes on this screen; it is load-bearing plain text.
+
+2. **Settings home scope.** The mockup home shows ~11 rows across five sections. Only four map to routes this slice owns (Personas, AI provider, Rewrite behaviour, Privacy). The rest (default mood, API key, usage, languages, glide typing, autocorrect, theme, height, read-the-source) are keyboard-fork concerns with no nav routes; they are omitted rather than drawn dead. The home banner's mockup line ("PersonaSpeak is your default keyboard") is also softened to a true brand line because default-keyboard status can't be verified from this screen yet.
+
+3. **Icons.** The mockups use Material Symbols Outlined; `:app` depends only on `compose.material3` (no `material-icons-extended`). Where a core icon was unavailable (`Icons.Filled.Close`), the affordance uses a Unicode glyph instead (e.g. `✕`). This matches the emoji-forward mockup aesthetic and avoids a new dependency.
+
+4. **State is local, not persisted.** Toggles (auto-retry, context-window), radio selection (rewrite behaviour), and API-key visibility are held in `remember { mutableStateOf }` only. Wiring them to real prefs/keystore/registry is out of scope for the screens slice.
+
+5. **Persona-detail footer and "Set as default".** "Set as default" renders disabled (no persistence wired); "Try this persona" is a no-op button. The footer is laid out below the scroll rather than Scaffold-pinned, since no Scaffold exists in the activity yet.
+
+## Build proof
+
+From `android/`:
+
+```
+./gradlew :app:assembleDebug --no-daemon --console=plain \
+    -Porg.gradle.java.installations.paths=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
+```
+
+(`jvmToolchain(17)` requires JDK 17; the keg-only Homebrew install is not auto-detected, so the installations path is supplied explicitly.)
+
+Result (final iteration):
+
+```
+> Task :app:compileDebugKotlin
+> Task :app:assembleDebug
+BUILD SUCCESSFUL in 15s
+45 actionable tasks: 6 executed, 39 up-to-date
+```
+
+Two compile errors were hit and fixed during the build: `Icons.Filled.Close` is not in `material-icons-core` (swapped for a glyph), and `Modifier.clickable(onSelect)` resolved against the wrong overload (changed to `clickable(onClick = onSelect)`).
+
+## Verification not performed
+
+- **No device run.** A green debug build is the agreed proof for this slice; the screens were not exercised on an emulator or via `createAndroidComposeRule`.
+- **No UI tests.** The `:app` module has no test infrastructure (`testImplementation`/`androidTestImplementation` are absent from `app/build.gradle.kts`). Adding a Compose UI test harness is a separate concern; flagged as a follow-up.
+
+## Follow-ups (not blocking)
+
+1. **Persisted settings state.** Rewrite-behaviour choice and the two provider toggles want a real prefs store; today they reset on process death.
+2. **Real persona loading.** `SamplePersonas` is a placeholder for the `Persona.fromYaml` pipeline; swap when the loader is wired.
+3. **Real provider registry + keystore.** `SampleProviders` and the masked key field are UI scaffolding; the API-key field should read/write through `:core-providers` and Android's keystore once audited (ADR-0005).
+4. **Scaffold + edge-to-edge.** The status-bar seam noted in the foundation report still applies; adding a `Scaffold` would also let the detail footer pin properly.
+5. **Material icons.** If the design wants the real Material Symbols set rather than glyphs, add `material-icons-extended` (it's a large artifact; worth a deliberate decision).


### PR DESCRIPTION
## What

Replaces all six settings-route placeholders with real Compose screens:
Settings Home, Persona Browser, Persona Detail, AI Providers, Rewrite
Behaviour, Privacy. Built against the nav contract and theme from
`feat/graft-foundation` — no routes added/renamed, only `Placeholder` calls
swapped for real screens. Full detail in
`docs/superpowers/specs/2026-07-21-settings-screens-report.md`.

Base is `feat/graft-foundation` (not `main`) since this stacks on the
theme/nav/IME-stub foundation, not on PR #18's full vendoring diff.

## Why

Per the gap analysis (PR #20), Settings/Onboarding were "not built in
prototype" — Set 4 entirely missing. This is Set 4, using the Stitch mockup
spec (PR #22) as the reference an engineer builds from.

## Notable judgment call

The mockup's privacy screen headline is "What we store: Nothing." — the
worker (GLM, background-delegated) caught that this contradicts ADR-0005's
own findings (AnySoftKeyboard stores data by design; storage/security posture
isn't audited yet) and shipped honest, specific, "vaguer-but-true" copy
instead of the mockup's crisp-but-wrong line. Load-bearing per VOICE.md rule
6 — no jokes on that screen. Full reasoning in the report's "Deviations"
section; worth a careful read since it's a privacy-copy call, not just a
styling one.

Other deviations (settings-home scope trimmed to routes that exist, glyphs
instead of Material Symbols Outlined to avoid a new dependency, all state
held in `remember` with no persistence yet) are in the same report.

## Evidence

`./gradlew :app:assembleDebug --no-daemon` — `BUILD SUCCESSFUL`, verified
independently (not just the worker's own claim) before this PR was opened.
No device run or UI tests yet — flagged as follow-ups, not silently skipped.

## Grading

Not yet graded by a non-author — worker-authored, reviewed by this session
(build re-verified, privacy-copy reasoning checked against ADR-0005) before
opening. Flagging the skip per the DoD.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BmubhbkLvzkCeYVuJ26rCS