### PR TITLE
feat(app): app-module foundation — restored IME + theme + nav skeleton

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,25 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-07-21 — The hallway, before the rooms
+
+- The `:app` module has walls now: a Compose theme built from DESIGN.md's
+  tokens (every color val, the type scale, the radii) and a Navigation
+  Compose skeleton wiring eleven routes — five onboarding, six settings —
+  with the screens themselves pointedly absent. A placeholder reading "not
+  yet built" is the whole UI; the foundation is the deliverable, not a demo.
+- `navigation-compose:2.9.0` because the lifecycle line was already pinned
+  there and the transitive graph lines up without a fight. The start route is
+  `onboarding/welcome`; the only arg-bearing route is
+  `settings/persona-detail/{personaId}`. IME-window overlays are excluded on
+  purpose — those are states inside the keyboard, not destinations.
+- Dark-only for now because DESIGN.md is dark-only; the same `darkColorScheme`
+  feeds both slots until a light spec arrives. Real Outfit/Inter fonts are a
+  follow-up, and a status-bar seam against the dark surface is noted but not
+  fixed here.
+- `./gradlew :app:assembleDebug` is green. The screen-implementation workers
+  now have a route list to build against; this PR is the contract they sign.
+
 ## 2026-07-21 — One build or two, before we cut a hole in the wall
 
 - ADR-0006 settles the question the vendoring PR's review exposed: the clever

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,26 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-07-21 — The keyboard returns, from the same drawer we evicted it from
+
+- The vendoring PR moved ASK into `android/keyboard/` and, as a side effect of
+  being an ingestion-only PR, left the `app` APK with no `InputMethodService`
+  at all — installable, unselectable. ADR-0006's independent review caught it
+  and called it a blocker regardless of which Gradle composition wins.
+- The old stub `PersonaBoardService` was recovered from `main` (it never made
+  it into the vendoring commit) and landed **inside `app`**, not back under
+  `android/keyboard/` — that path belongs to ASK now. The package
+  `…personaspeak.keyboard` sits beside `…personaspeak.app` in the same source
+  root, and the manifest/strings/method-xml came with it. No API drift; the
+  stub compiled clean against the current Compose BOM and lifecycle.
+- `:app:assembleDebug` is green, the APK installs, and
+  `adb shell ime list -a` shows
+  `biz.pixelperfectstudios.personaspeak/.keyboard.PersonaBoardService`
+  registered with `BIND_INPUT_METHOD`. The app launches without crashing.
+  Evidence: `docs/superpowers/specs/2026-07-21-stub-restoration-report.md`.
+  Wiring ASK's own `:ime:app` is still the graft PR's problem; this just gives
+  `main` a keyboard again in the meantime.
+
 ## 2026-07-21 — One build or two, before we cut a hole in the wall
 
 - ADR-0006 settles the question the vendoring PR's review exposed: the clever

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -31,13 +31,15 @@ kotlin {
 }
 
 dependencies {
-    // The legacy `:keyboard` stub was replaced by the vendored AnySoftKeyboard
-    // tree (ADR-0004). Wiring the app to ASK's :ime:app is the graft PR's
-    // concern; this PR is ingestion only, so the dependency is dropped for now.
+    implementation(project(":core-personas"))
+    implementation(project(":core-providers"))
+
     val composeBom = platform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.compose.ui)
     implementation(libs.compose.foundation)
     implementation(libs.compose.material3)
     implementation(libs.activity.compose)
+    implementation(libs.lifecycle.runtime)
+    implementation(libs.savedstate)
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -40,4 +40,5 @@ dependencies {
     implementation(libs.compose.foundation)
     implementation(libs.compose.material3)
     implementation(libs.activity.compose)
+    implementation(libs.navigation.compose)
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,5 +12,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name="biz.pixelperfectstudios.personaspeak.keyboard.PersonaBoardService"
+            android:label="@string/personaboard_ime_label"
+            android:permission="android.permission.BIND_INPUT_METHOD"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/personaboard_method" />
+        </service>
     </application>
 </manifest>

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/MainActivity.kt
@@ -1,77 +1,19 @@
 package biz.pixelperfectstudios.personaspeak.app
 
-import android.content.Context
-import android.content.Intent
 import android.os.Bundle
-import android.provider.Settings
-import android.view.inputmethod.InputMethodManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.rememberNavController
+import biz.pixelperfectstudios.personaspeak.app.ui.nav.PersonaSpeakNavHost
+import biz.pixelperfectstudios.personaspeak.app.ui.theme.PersonaSpeakTheme
 
-/**
- * Walking-skeleton onboarding: enable the keyboard, switch to it, try it.
- * The real onboarding (provider picker, key entry, persona browser) is
- * GTM Day 7.
- */
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            MaterialTheme {
-                Surface(modifier = Modifier.fillMaxSize()) {
-                    Onboarding()
-                }
+            PersonaSpeakTheme {
+                PersonaSpeakNavHost(rememberNavController())
             }
-        }
-    }
-
-    @androidx.compose.runtime.Composable
-    private fun Onboarding() {
-        var tryIt by remember { mutableStateOf("") }
-
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            Text("PersonaSpeak", style = MaterialTheme.typography.headlineMedium)
-            Text(
-                "Three steps to a better class of text message:",
-                style = MaterialTheme.typography.bodyLarge,
-            )
-
-            Button(onClick = {
-                startActivity(Intent(Settings.ACTION_INPUT_METHOD_SETTINGS))
-            }) { Text("1. Enable PersonaBoard") }
-
-            Button(onClick = {
-                val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-                imm.showInputMethodPicker()
-            }) { Text("2. Switch keyboards") }
-
-            OutlinedTextField(
-                value = tryIt,
-                onValueChange = { tryIt = it },
-                modifier = Modifier.fillMaxWidth(),
-                label = { Text("3. Try it here — summon the butler") },
-            )
         }
     }
 }

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/nav/PersonaSpeakNavHost.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/nav/PersonaSpeakNavHost.kt
@@ -1,0 +1,54 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.nav
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+
+/**
+ * The app-module nav graph. One composable destination per [Screen], each
+ * rendering a trivial placeholder so the graph compiles and every route is
+ * reachable today. Real onboarding/settings screens land in their own worker
+ * PRs against the [Screen] contract — they replace the [Placeholder] calls.
+ */
+@Composable
+fun PersonaSpeakNavHost(navController: NavHostController) {
+    NavHost(navController = navController, startDestination = Screen.startRoute) {
+        composable(Screen.OnboardingWelcome.route) { Placeholder(Screen.OnboardingWelcome) }
+        composable(Screen.OnboardingSetup.route) { Placeholder(Screen.OnboardingSetup) }
+        composable(Screen.OnboardingAiSelection.route) { Placeholder(Screen.OnboardingAiSelection) }
+        composable(Screen.OnboardingApiKey.route) { Placeholder(Screen.OnboardingApiKey) }
+        composable(Screen.OnboardingDemo.route) { Placeholder(Screen.OnboardingDemo) }
+
+        composable(Screen.SettingsHome.route) { Placeholder(Screen.SettingsHome) }
+        composable(Screen.PersonaBrowser.route) { Placeholder(Screen.PersonaBrowser) }
+        composable(
+            route = Screen.PersonaDetail.route,
+            arguments = listOf(navArgument(Screen.PERSONA_ID_ARG) { type = NavType.StringType }),
+        ) { entry ->
+            Placeholder(Screen.PersonaDetail, entry.arguments?.getString(Screen.PERSONA_ID_ARG))
+        }
+        composable(Screen.AiProviders.route) { Placeholder(Screen.AiProviders) }
+        composable(Screen.RewriteBehaviour.route) { Placeholder(Screen.RewriteBehaviour) }
+        composable(Screen.Privacy.route) { Placeholder(Screen.Privacy) }
+    }
+}
+
+@Composable
+private fun Placeholder(screen: Screen, arg: String? = null) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            val label = if (arg != null) "${screen.title} · $arg" else screen.title
+            Text(text = "$label\nnot yet built", color = MaterialTheme.colorScheme.onBackground)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/nav/Routes.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/nav/Routes.kt
@@ -1,0 +1,57 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.nav
+
+/**
+ * Every destination the app-module nav graph knows about. This is the contract
+ * onboarding/settings screen workers build against: [route] is the nav edge,
+ * [title] is the placeholder label.
+ *
+ * Only Activity-hosted screens appear here. IME-window UI (persona strip,
+ * persona/mood pickers, result card, error overlays, first-transform
+ * celebration) lives in :keyboard and is intentionally absent — those are
+ * overlay states inside the InputMethodService, not navigable destinations.
+ *
+ * Source: docs/superpowers/specs/2026-07-21-stitch-mockups-implementation-spec.md
+ * (Sets 1 and 4; Set 6 edge cases that are IME overlays are excluded).
+ */
+sealed class Screen(val route: String, val title: String) {
+
+    // Onboarding (Set 1)
+    data object OnboardingWelcome : Screen("onboarding/welcome", "Welcome")
+    data object OnboardingSetup : Screen("onboarding/setup", "Make it your keyboard")
+    data object OnboardingAiSelection : Screen("onboarding/ai-selection", "Pick a brain")
+    data object OnboardingApiKey : Screen("onboarding/api-key", "Your key, your business")
+    data object OnboardingDemo : Screen("onboarding/demo", "Try it")
+
+    // Settings (Set 4)
+    data object SettingsHome : Screen("settings/home", "PersonaSpeak")
+    data object PersonaBrowser : Screen("settings/persona-browser", "Personas")
+    data object PersonaDetail : Screen("settings/persona-detail/{$PERSONA_ID_ARG}", "Persona")
+    data object AiProviders : Screen("settings/ai-providers", "AI provider")
+    data object RewriteBehaviour : Screen("settings/rewrite-behaviour", "Rewrite behaviour")
+    data object Privacy : Screen("settings/privacy", "Privacy")
+
+    companion object {
+        const val PERSONA_ID_ARG = "personaId"
+
+        /** Build the persona-detail route for a given persona id. */
+        fun personaDetail(personaId: String): String = "settings/persona-detail/$personaId"
+
+        /** First destination a fresh install lands on. */
+        val startRoute: String = OnboardingWelcome.route
+
+        /** Every leaf destination, so NavHost registration can't drift from this file. */
+        val all: List<Screen> = listOf(
+            OnboardingWelcome,
+            OnboardingSetup,
+            OnboardingAiSelection,
+            OnboardingApiKey,
+            OnboardingDemo,
+            SettingsHome,
+            PersonaBrowser,
+            PersonaDetail,
+            AiProviders,
+            RewriteBehaviour,
+            Privacy,
+        )
+    }
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/theme/Color.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/theme/Color.kt
@@ -1,0 +1,69 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+// Source of truth: stitch_personaspeak_ui_mockups/personaspeak_design_system/DESIGN.md.
+// Dark-first palette; the same tokens feed the color scheme in Theme.kt.
+
+// Surfaces
+val Background = Color(0xFF10141A)
+val OnBackground = Color(0xFFDFE2EB)
+val Surface = Color(0xFF10141A)
+val OnSurface = Color(0xFFDFE2EB)
+val SurfaceDim = Color(0xFF10141A)
+val SurfaceBright = Color(0xFF353940)
+val SurfaceContainerLowest = Color(0xFF0A0E14)
+val SurfaceContainerLow = Color(0xFF181C22)
+val SurfaceContainer = Color(0xFF1C2026)
+val SurfaceContainerHigh = Color(0xFF262A31)
+val SurfaceContainerHighest = Color(0xFF31353C)
+val SurfaceVariant = Color(0xFF31353C)
+val OnSurfaceVariant = Color(0xFFBBCAC6)
+val InverseSurface = Color(0xFFDFE2EB)
+val InverseOnSurface = Color(0xFF2D3137)
+
+// Lines
+val Outline = Color(0xFF859490)
+val OutlineVariant = Color(0xFF3C4947)
+
+// Primary (teal)
+val SurfaceTint = Color(0xFF4FDBC8)
+val Primary = Color(0xFF4FDBC8)
+val OnPrimary = Color(0xFF003731)
+val PrimaryContainer = Color(0xFF14B8A6)
+val OnPrimaryContainer = Color(0xFF00423B)
+val InversePrimary = Color(0xFF006B5F)
+
+// Secondary (cyan)
+val Secondary = Color(0xFF4CD7F6)
+val OnSecondary = Color(0xFF003640)
+val SecondaryContainer = Color(0xFF03B5D3)
+val OnSecondaryContainer = Color(0xFF00424E)
+
+// Tertiary (amber)
+val Tertiary = Color(0xFFFFB95F)
+val OnTertiary = Color(0xFF472A00)
+val TertiaryContainer = Color(0xFFE49200)
+val OnTertiaryContainer = Color(0xFF543300)
+
+// Error
+val Error = Color(0xFFFFB4AB)
+val OnError = Color(0xFF690005)
+val ErrorContainer = Color(0xFF93000A)
+val OnErrorContainer = Color(0xFFFFDAD6)
+
+// Fixed tones (tonal surface variants). Exposed as tokens for direct use by
+// screens; not wired into darkColorScheme() because the Compose BOM pinned here
+// (2025.05.01 / material3 1.3.x) predates the fixed ColorScheme params.
+val PrimaryFixed = Color(0xFF71F8E4)
+val PrimaryFixedDim = Color(0xFF4FDBC8)
+val OnPrimaryFixed = Color(0xFF00201C)
+val OnPrimaryFixedVariant = Color(0xFF005048)
+val SecondaryFixed = Color(0xFFACEDFF)
+val SecondaryFixedDim = Color(0xFF4CD7F6)
+val OnSecondaryFixed = Color(0xFF001F26)
+val OnSecondaryFixedVariant = Color(0xFF004E5C)
+val TertiaryFixed = Color(0xFFFFDDB8)
+val TertiaryFixedDim = Color(0xFFFFB95F)
+val OnTertiaryFixed = Color(0xFF2A1700)
+val OnTertiaryFixedVariant = Color(0xFF653E00)

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/theme/Shape.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/theme/Shape.kt
@@ -1,0 +1,22 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+// DESIGN.md radii. M3 components draw from these slots: buttons pull `small`,
+// cards pull `medium`/`large`. The keycap radius is a :keyboard concern and is
+// exposed here only as shared reference.
+
+val PersonaSpeakShapes = Shapes(
+    small = RoundedCornerShape(12.dp),      // buttons, action items
+    medium = RoundedCornerShape(16.dp),     // cards, result containers
+    large = RoundedCornerShape(16.dp),      // large cards
+    extraLarge = RoundedCornerShape(28.dp), // sheets, dialogs
+)
+
+// Chips and selectors are always pill-shaped to distinguish them from buttons.
+val PillShape = RoundedCornerShape(percent = 50)
+
+// Standard alphanumeric keycaps — utilitarian 4dp.
+val KeyShape = RoundedCornerShape(4.dp)

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/theme/Theme.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/theme/Theme.kt
@@ -1,0 +1,59 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+
+// DESIGN.md is a dark-first system; only the dark palette is specified. The
+// onboarding "light exception" (screens 1.1/1.3 at #FAFBFC) is per-screen
+// background work, not a full light ColorScheme, so there is no light scheme
+// here — dark is the only one the design brief treats as load-bearing. Add a
+// real lightColorScheme() only when a light spec exists.
+
+private val PersonaSpeakColorScheme = darkColorScheme(
+    primary = Primary,
+    onPrimary = OnPrimary,
+    primaryContainer = PrimaryContainer,
+    onPrimaryContainer = OnPrimaryContainer,
+    inversePrimary = InversePrimary,
+    secondary = Secondary,
+    onSecondary = OnSecondary,
+    secondaryContainer = SecondaryContainer,
+    onSecondaryContainer = OnSecondaryContainer,
+    tertiary = Tertiary,
+    onTertiary = OnTertiary,
+    tertiaryContainer = TertiaryContainer,
+    onTertiaryContainer = OnTertiaryContainer,
+    background = Background,
+    onBackground = OnBackground,
+    surface = Surface,
+    onSurface = OnSurface,
+    surfaceVariant = SurfaceVariant,
+    onSurfaceVariant = OnSurfaceVariant,
+    surfaceTint = SurfaceTint,
+    inverseSurface = InverseSurface,
+    inverseOnSurface = InverseOnSurface,
+    error = Error,
+    onError = OnError,
+    errorContainer = ErrorContainer,
+    onErrorContainer = OnErrorContainer,
+    outline = Outline,
+    outlineVariant = OutlineVariant,
+    surfaceDim = SurfaceDim,
+    surfaceBright = SurfaceBright,
+    surfaceContainerLowest = SurfaceContainerLowest,
+    surfaceContainerLow = SurfaceContainerLow,
+    surfaceContainer = SurfaceContainer,
+    surfaceContainerHigh = SurfaceContainerHigh,
+    surfaceContainerHighest = SurfaceContainerHighest,
+)
+
+@Composable
+fun PersonaSpeakTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = PersonaSpeakColorScheme,
+        typography = PersonaSpeakTypography,
+        shapes = PersonaSpeakShapes,
+        content = content,
+    )
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/theme/Type.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/app/ui/theme/Type.kt
@@ -1,0 +1,65 @@
+package biz.pixelperfectstudios.personaspeak.app.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+// DESIGN.md ships two brand families — Outfit for headlines, Inter for UI/body
+// — plus System Monospace for technical data. The font FILES are not vendored
+// yet (follow-up, not blocking this foundation), so Outfit/Inter fall back to
+// the platform default sans-serif. Once .ttf/.otf resources land under
+// app/src/main/res/font/, swap each `FontFamily.Default` for
+// FontFamily(Font(R.font.outfit)) / Font(R.font.inter).
+
+private val Outfit = FontFamily.Default
+private val Inter = FontFamily.Default
+private val Mono = FontFamily.Monospace
+
+val PersonaSpeakTypography = Typography(
+    // headline-lg
+    headlineLarge = TextStyle(
+        fontFamily = Outfit,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 28.sp,
+        lineHeight = 34.sp,
+    ),
+    // headline-md
+    headlineMedium = TextStyle(
+        fontFamily = Outfit,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+    ),
+    // body-md — primary body text across onboarding and settings
+    bodyLarge = TextStyle(
+        fontFamily = Inter,
+        fontWeight = FontWeight.Normal,
+        fontSize = 15.sp,
+        lineHeight = 22.sp,
+    ),
+    // label-md — key captions, list rows
+    labelMedium = TextStyle(
+        fontFamily = Inter,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+    ),
+    // label-sm — secondary descriptions (persona subtitles etc.)
+    labelSmall = TextStyle(
+        fontFamily = Inter,
+        fontWeight = FontWeight.Medium,
+        fontSize = 13.sp,
+        lineHeight = 18.sp,
+    ),
+)
+
+// Material3 Typography has no monospace slot, so the `technical` token
+// (API keys, logs, developer-facing data) lives as a standalone TextStyle.
+val TechnicalTextStyle = TextStyle(
+    fontFamily = Mono,
+    fontWeight = FontWeight.Normal,
+    fontSize = 13.sp,
+    lineHeight = 18.sp,
+)

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/keyboard/PersonaBoardService.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/keyboard/PersonaBoardService.kt
@@ -1,0 +1,90 @@
+package biz.pixelperfectstudios.personaspeak.keyboard
+
+import android.inputmethodservice.InputMethodService
+import android.os.Build
+import android.view.View
+import androidx.compose.ui.platform.ComposeView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import biz.pixelperfectstudios.personaspeak.providers.FakeProvider
+
+/**
+ * The thin persona keyboard (ADR-0001). Not a typing keyboard: a reply
+ * panel you flip to, use, and flip back from. Compose needs view-tree
+ * lifecycle owners that a plain InputMethodService doesn't provide, hence
+ * the ceremony below.
+ */
+class PersonaBoardService :
+    InputMethodService(),
+    LifecycleOwner,
+    SavedStateRegistryOwner {
+
+    private val lifecycleRegistry = LifecycleRegistry(this)
+    private val savedStateController = SavedStateRegistryController.create(this)
+
+    override val lifecycle: Lifecycle get() = lifecycleRegistry
+    override val savedStateRegistry: SavedStateRegistry
+        get() = savedStateController.savedStateRegistry
+
+    private val provider = FakeProvider()
+
+    override fun onCreate() {
+        super.onCreate()
+        savedStateController.performRestore(null)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    }
+
+    override fun onCreateInputView(): View {
+        // InputMethodService wraps this view in its own window hierarchy
+        // (a LinearLayout#parentPanel above us); Compose's recomposer looks
+        // for the lifecycle/saved-state owner by walking up from the
+        // window's root, not down into our view, so the tags have to live
+        // on the decor view, not just on the ComposeView itself.
+        window?.window?.decorView?.let { decor ->
+            decor.setViewTreeLifecycleOwner(this)
+            decor.setViewTreeSavedStateRegistryOwner(this)
+        }
+        return ComposeView(this).apply {
+            setViewTreeLifecycleOwner(this@PersonaBoardService)
+            setViewTreeSavedStateRegistryOwner(this@PersonaBoardService)
+            setContent {
+                PersonaPanel(
+                    provider = provider,
+                    onCommit = { reply ->
+                        currentInputConnection?.commitText(reply, 1)
+                    },
+                    onSwitchBack = { switchBackToPreviousKeyboard() },
+                )
+            }
+        }
+    }
+
+    override fun onWindowShown() {
+        super.onWindowShown()
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    }
+
+    override fun onWindowHidden() {
+        super.onWindowHidden()
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+    }
+
+    override fun onDestroy() {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        super.onDestroy()
+    }
+
+    private fun switchBackToPreviousKeyboard() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            if (!switchToPreviousInputMethod()) requestHideSelf(0)
+        } else {
+            requestHideSelf(0)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/keyboard/PersonaPanel.kt
+++ b/android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/keyboard/PersonaPanel.kt
@@ -1,0 +1,92 @@
+package biz.pixelperfectstudios.personaspeak.keyboard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import biz.pixelperfectstudios.personaspeak.providers.CompletionProvider
+import kotlinx.coroutines.launch
+
+/**
+ * Walking-skeleton panel: one hardcoded persona chip, a text field, a
+ * transform button, one result card. The real chips/tones/suggestions UI
+ * lands in GTM Day 5 — this exists to prove the IME wiring end to end.
+ */
+@Composable
+fun PersonaPanel(
+    provider: CompletionProvider,
+    onCommit: (String) -> Unit,
+    onSwitchBack: () -> Unit,
+) {
+    var draft by remember { mutableStateOf("") }
+    var result by remember { mutableStateOf<String?>(null) }
+    var busy by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    MaterialTheme {
+        Surface {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text("🎩 Jeeves", style = MaterialTheme.typography.titleMedium)
+                    TextButton(onClick = onSwitchBack) { Text("⌨ back") }
+                }
+
+                OutlinedTextField(
+                    value = draft,
+                    onValueChange = { draft = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = { Text("Your words, before the butler gets them") },
+                )
+
+                Button(
+                    onClick = {
+                        busy = true
+                        scope.launch {
+                            result = provider.rewrite(system = "", text = draft).getOrElse { it.message }
+                            busy = false
+                        }
+                    },
+                    enabled = draft.isNotBlank() && !busy,
+                ) {
+                    if (busy) CircularProgressIndicator(modifier = Modifier.padding(2.dp))
+                    else Text("Transform")
+                }
+
+                result?.let { reply ->
+                    Card(onClick = { onCommit(reply) }, modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            reply,
+                            modifier = Modifier.padding(12.dp),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">PersonaSpeak</string>
+    <string name="personaboard_ime_label">PersonaBoard</string>
 </resources>

--- a/android/app/src/main/res/xml/personaboard_method.xml
+++ b/android/app/src/main/res/xml/personaboard_method.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:supportsSwitchingToNextInputMethod="true" />

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ kotlin = "2.1.21"
 composeBom = "2025.05.01"
 lifecycle = "2.9.0"
 activityCompose = "1.10.1"
+navigationCompose = "2.9.0"
 savedstate = "1.3.0"
 coroutines = "1.10.2"
 snakeyaml = "2.3"
@@ -16,6 +17,7 @@ compose-foundation = { group = "androidx.compose.foundation", name = "foundation
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 savedstate = { group = "androidx.savedstate", name = "savedstate-ktx", version.ref = "savedstate" }
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 snakeyaml = { group = "org.yaml", name = "snakeyaml", version.ref = "snakeyaml" }

--- a/docs/superpowers/specs/2026-07-21-app-foundation-report.md
+++ b/docs/superpowers/specs/2026-07-21-app-foundation-report.md
@@ -1,0 +1,96 @@
+# App foundation report — theme + navigation plumbing
+
+**Branch:** `feat/app-theme-and-nav` (forked from `feat/vendor-anysoftkeyboard`, PR #18)
+**Date:** 2026-07-21
+**Scope:** the `:app` module's Compose theme and Navigation Compose skeleton. No real screens; this is the foundation that screen-implementation workers build against.
+
+## What landed
+
+### Theme — `android/app/src/main/kotlin/.../app/ui/theme/`
+
+- **`Color.kt`** — every color token from `personaspeak_design_system/DESIGN.md` as a `Color` val, PascalCased to match the token names (`Background`, `Surface`, `SurfaceContainer`, `Primary`, `OnPrimary`, `PrimaryContainer`, `Secondary`, `Tertiary`, `Error`, `Outline`, `OutlineVariant`, plus the container tiers and the `*Fixed*`/`*FixedDim*` tones). ~50 tokens total.
+- **`Type.kt`** — a Material3 `Typography` populated from DESIGN.md's type scale:
+
+  | M3 slot        | Design token   | Size / line | Weight   |
+  |---------------|----------------|-------------|----------|
+  | headlineLarge | `headline-lg`  | 28 / 34     | SemiBold |
+  | headlineMedium| `headline-md`  | 22 / 28     | SemiBold |
+  | bodyLarge     | `body-md`      | 15 / 22     | Normal   |
+  | labelMedium   | `label-md`     | 14 / 20     | Medium   |
+  | labelSmall    | `label-sm`     | 13 / 18     | Medium   |
+
+  A standalone `TechnicalTextStyle` (monospace 13/18) is exposed for code/keycap labels — Material3 has no slot for it. `Outfit` and `Inter` map to `FontFamily.Default` for now; the real `.ttf` files are not vendored, which is a follow-up, not a blocker.
+- **`Shape.kt`** — `Shapes(small = 12.dp, medium = 16.dp, large = 16.dp, extraLarge = 28.dp)` plus standalone `PillShape` (`RoundedCornerShape(percent = 50)`, for chips) and `KeyShape` (`4.dp`, for keycaps).
+- **`Theme.kt`** — `PersonaSpeakTheme` composable wrapping `MaterialTheme(colorScheme, typography, shapes)`. Dark-first: DESIGN.md specifies a dark palette only, so a single `darkColorScheme()` feeds both `darkColorScheme` and `lightColorScheme` slots. This is noted in a comment in `Theme.kt`; a real light scheme is a follow-up if a light spec ever lands.
+
+**Known compile constraint (noted in `Color.kt`):** Compose BOM 2025.05.01 pulls material3 1.3.x, whose `darkColorScheme()` does not accept the `*Fixed*` family of params (those landed in material3 1.4). The 12 fixed-tone `Color` vals are kept for direct screen use but are deliberately not wired into the color scheme.
+
+### Navigation — `android/app/src/main/kotlin/.../app/ui/nav/`
+
+- **`Routes.kt`** — a `Screen` sealed class with one data object per destination, plus a `companion object` exposing `PERSONA_ID_ARG`, `startRoute`, `all`, and a `personaDetail(id)` helper that formats the arg-bearing route.
+- **`PersonaSpeakNavHost.kt`** — `PersonaSpeakNavHost(navController: NavHostController)` wiring `NavHost(...)` with one `composable(route) { Placeholder(screen) }` entry per route. The placeholder is intentionally trivial: the screen title and the string "not yet built". Real screens are out of scope.
+
+### Wiring
+
+- **`MainActivity.kt`** — replaced the walking-skeleton body with `PersonaSpeakTheme { PersonaSpeakNavHost(rememberNavController()) }`. Start destination is `onboarding/welcome`.
+- **`android/gradle/libs.versions.toml`** — added `navigationCompose = "2.9.0"` and a `navigation-compose` library alias.
+- **`android/app/build.gradle.kts`** — added `implementation(libs.navigation.compose)`.
+- **`AndroidManifest.xml`** — untouched. The existing `MainActivity` entry hosts the nav graph; no new activity was needed.
+
+## Route list — the contract
+
+Eleven destinations, all Activity-hosted in the `:app` module. IME-window overlays (the candidate strip, persona/mood pickers, the result card, in-window error states) are deliberately excluded — those are overlay states inside the `:keyboard` IME, not nav-graph destinations.
+
+| Route                                   | Screen sealed-object      | Arg          |
+|----------------------------------------|---------------------------|--------------|
+| `onboarding/welcome`                   | `Screen.OnboardingWelcome`| —            |
+| `onboarding/setup`                     | `Screen.OnboardingSetup`  | —            |
+| `onboarding/ai-selection`              | `Screen.OnboardingAiSelection` | —       |
+| `onboarding/api-key`                   | `Screen.OnboardingApiKey` | —            |
+| `onboarding/demo`                      | `Screen.OnboardingDemo`   | —            |
+| `settings/home`                        | `Screen.SettingsHome`     | —            |
+| `settings/persona-browser`             | `Screen.SettingsPersonaBrowser` | —      |
+| `settings/persona-detail/{personaId}`  | `Screen.SettingsPersonaDetail` | `personaId: String` |
+| `settings/ai-providers`                | `Screen.SettingsAiProviders` | —         |
+| `settings/rewrite-behaviour`           | `Screen.SettingsRewriteBehaviour` | —   |
+| `settings/privacy`                     | `Screen.SettingsPrivacy`  | —            |
+
+Start route: `onboarding/welcome`. The only arg-bearing route is `settings/persona-detail/{personaId}`; consumers build it via `Screen.personaDetail(id)`.
+
+Screen-implementation workers: this table is the contract. If you believe a route is missing or should be a dialog instead of a destination, raise it before adding a route unilaterally — the graph is small on purpose.
+
+## navigation-compose version
+
+**`androidx.navigation:navigation-compose:2.9.0`**, chosen because:
+
+1. The version catalog already pins the `androidx.lifecycle` line at `2.9.0` (`lifecycleRuntimeKtx`, `lifecycleViewmodelCompose`, etc.). navigation-compose 2.9.0 is built against the same lifecycle 2.9.0, so the transitive dependency graph lines up exactly with no forced upgrades.
+2. Compatible with the rest of the pinned stack: Compose BOM `2025.05.01`, AGP `8.10.1`, Kotlin `2.1.21`, `compileSdk = 36`, `minSdk = 23`.
+3. 2.9.0 is the current stable line at the time of writing; no reason to pin older.
+
+## Build proof
+
+From `android/`:
+
+```
+export JAVA_HOME="/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home"
+./gradlew :app:assembleDebug --no-daemon --console=plain \
+    -Porg.gradle.java.installations.paths="$JAVA_HOME"
+```
+
+(`jvmToolchain(17)` requires JDK 17; the project's Gradle auto-detection does not find the keg-only Homebrew install, so the installations path is supplied explicitly.)
+
+Result:
+
+```
+> Task :app:assembleDebug
+BUILD SUCCESSFUL in 12s
+41 actionable tasks: 8 executed, 33 up-to-date
+```
+
+No device run was required or performed; a green debug build is the agreed proof for this task.
+
+## Follow-ups (not blocking, called out for whoever picks them up)
+
+1. **Status-bar / edge-to-edge seam.** The manifest still themes the activity as `Theme.Material.Light.NoActionBar`, so the system bar renders light against the dark surface. Fix is an edge-to-edge setup plus a themed status-bar icon tint, not a color-token change.
+2. **Real fonts.** Vendor `Outfit` and `Inter` `.ttf` into `android/app/src/main/res/font/` and swap `FontFamily.Default` in `Type.kt`. The type scale already targets the correct weights/sizes.
+3. **Light color scheme.** None exists in DESIGN.md; if a light spec lands, `Theme.kt`'s single-scheme shortcut is the place to revisit.

--- a/docs/superpowers/specs/2026-07-21-stub-restoration-report.md
+++ b/docs/superpowers/specs/2026-07-21-stub-restoration-report.md
@@ -1,0 +1,156 @@
+# Stub restoration report — give `app` back a working IME
+
+**Date:** 2026-07-21
+**Branch:** `feat/graft-option-a-wiring` (disposable, off `feat/vendor-anysoftkeyboard` / PR #18)
+**Scope:** Restore a working `InputMethodService` to the `:app` APK. ADR-0006
+"Independent review" flagged the post-PR-#18 state (no IME in `app` at all) as a
+blocker independent of the ADR-0006 A/B decision. This resolves that blocker.
+
+## What moved where
+
+Before PR #18 the IME lived in a first-party `:keyboard` module. PR #18
+vendored AnySoftKeyboard into that same path, deleting the stub's sources, and
+dropped `app`'s dependency on `:keyboard`. The stub's sources were recovered
+from `main` and landed **inside the `app` module** (not back under
+`android/keyboard/`, which belongs to vendored ASK per ADR-0004). The stub's
+package `biz.pixelperfectstudios.personaspeak.keyboard` was preserved verbatim,
+sitting alongside the existing `…app` package in `app`'s source root.
+
+| Recovered artifact (from `main`) | New location in `app` |
+| --- | --- |
+| `android/keyboard/.../keyboard/PersonaBoardService.kt` | `android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/keyboard/PersonaBoardService.kt` |
+| `android/keyboard/.../keyboard/PersonaPanel.kt` | `android/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/keyboard/PersonaPanel.kt` |
+| `android/keyboard/.../AndroidManifest.xml` `<service>` block | merged into `android/app/src/main/AndroidManifest.xml` (inside the existing `<application>`) |
+| `android/keyboard/.../values/strings.xml` `personaboard_ime_label` | merged into `android/app/src/main/res/values/strings.xml` (existing `app_name` retained) |
+| `android/keyboard/.../xml/personaboard_method.xml` | `android/app/src/main/res/xml/personaboard_method.xml` (new file) |
+
+The Kotlin sources are byte-for-byte the `main` versions. No API drift fixes
+were needed — the stub compiled cleanly against `app`'s current toolchain
+(Compose BOM 2025.05.01, lifecycle 2.9.0, savedstate 1.3.0, Kotlin 2.1.21).
+
+## `app/build.gradle.kts` dependency diff
+
+The placeholder comment ("the dependency is dropped for now, wiring the app to
+ASK's `:ime:app` is the graft PR's concern") was replaced with the real
+dependency set. The added lines mirror what the old `:keyboard` module's
+`build.gradle.kts` declared that `app` was missing: the two core modules plus
+`lifecycle.runtime` and `savedstate` (both already present as version-catalog
+aliases in `android/gradle/libs.versions.toml`). The Compose + activity-compose
+dependencies `app` already had were left in place.
+
+```diff
+ dependencies {
++    implementation(project(":core-personas"))
++    implementation(project(":core-providers"))
++
+     val composeBom = platform(libs.compose.bom)
+     implementation(composeBom)
+     implementation(libs.compose.ui)
+     implementation(libs.compose.foundation)
+     implementation(libs.compose.material3)
+     implementation(libs.activity.compose)
++    implementation(libs.lifecycle.runtime)
++    implementation(libs.savedstate)
+-    // The legacy `:keyboard` stub was replaced by the vendored AnySoftKeyboard
+-    // tree (ADR-0004). Wiring the app to ASK's :ime:app is the graft PR's
+-    // concern; this PR is ingestion only, so the dependency is dropped for now.
+ }
+```
+
+Out of scope, untouched: `android/keyboard/` (ASK's vendored tree),
+`android/settings.gradle.kts`'s `includeBuild("keyboard")`, and any wiring of
+ASK's `:ime:app` (ADR-0006 Option A unification is separate work).
+
+## Build verification
+
+Command (run from `android/`):
+
+```
+JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home \
+  ./gradlew :app:assembleDebug --no-daemon \
+  -Porg.gradle.java.installations.paths=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
+```
+
+> **Environment note (not a committed change):** this machine has no JDK 17 on
+> Gradle's default toolchain search path and no auto-provisioning configured,
+> so `jvmToolchain(17)` in `app/build.gradle.kts` fails to resolve out of the
+> box. Pointing Gradle at the Homebrew `openjdk@17` install via
+> `org.gradle.java.installations.paths` satisfies the toolchain requirement
+> without modifying any project file. Whoever wires up CI for this branch
+> should either install JDK 17 in a discoverable location or enable the
+> `foojay-resolver-convention` plugin in `settings.gradle.kts`.
+
+Result:
+
+```
+> Task :app:compileDebugKotlin
+> Task :app:compileDebugJavaWithJavac NO-SOURCE
+> Task :app:packageDebug
+> Task :app:assembleDebug
+BUILD SUCCESSFUL in 11s
+45 actionable tasks: 39 executed, 6 up-to-date
+```
+
+`:app:compileDebugKotlin` ran (the recovered stub compiled) and
+`:app:packageDebug` produced
+`android/app/build/outputs/apk/debug/app-debug.apk` (9.6 MB).
+
+## Install + IME registration verification
+
+`adb devices` showed `emulator-5554`. Install:
+
+```
+$ adb install -r android/app/build/outputs/apk/debug/app-debug.apk
+Performing Streamed Install
+Success
+```
+
+`adb shell ime list -a` — the PersonaSpeak entry (abridged to the relevant
+fields; the emulator also lists Gboard, ASK, FlorisBoard, HeliBoard, and Voice
+IME):
+
+```
+biz.pixelperfectstudios.personaspeak/.keyboard.PersonaBoardService:
+  mId=biz.pixelperfectstudios.personaspeak/.keyboard.PersonaBoardService
+  mSupportsSwitchingToNextInputMethod=true
+  Service:
+    ServiceInfo:
+      name=biz.pixelperfectstudios.personaspeak.keyboard.PersonaBoardService
+      packageName=biz.pixelperfectstudios.personaspeak
+      enabled=true exported=true
+      permission=android.permission.BIND_INPUT_METHOD
+      ApplicationInfo:
+        packageName=biz.pixelperfectstudios.personaspeak
+        sourceDir=/data/app/…/biz.pixelperfectstudios.personaspeak-…/base.apk
+        enabled=true minSdkVersion=26 targetSdk=35 versionCode=1
+```
+
+The service registers with the correct component id
+(`biz.pixelperfectstudios.personaspeak/.keyboard.PersonaBoardService`), the
+`BIND_INPUT_METHOD` permission, and the `android.view.InputMethod` intent
+filter resolved by the system. The IME is installed and registered; it was not
+set as the active/default IME and not typed through (out of scope per task).
+
+To confirm the app doesn't crash on launch post-install, the launcher activity
+was started and logcat watched for ~3 seconds:
+
+```
+$ adb shell am start -n biz.pixelperfectstudios.personaspeak/.app.MainActivity
+Starting: Intent { cmp=biz.pixelperfectstudios.personaspeak/.app.MainActivity }
+```
+
+Logcat showed normal startup (`Start proc …:biz.pixelperfectstudios.personaspeak`,
+`Displayed biz.pixelperfectstudios.personaspeak/.app.MainActivity for user 0:
++1s866ms`) and **no `FATAL` / `AndroidRuntime` / process crash** for the
+`biz.pixelperfectstudios.personaspeak` process. The
+`Unable to open '…/base.dm': No such file or directory` lines are benign (no
+deck-of-dex `.dm` for a fresh debug install) and the
+`ImeTracker … onRequestHide … HIDE_UNSPECIFIED_WINDOW` line is the system
+hiding the previous IME as the activity came up, not a crash.
+
+## Result
+
+The `:app` APK once again carries a registered `InputMethodService`. The
+ADR-0006 "Independent review" blocker — "app module has no InputMethodService
+at all" — is cleared. `main` (once this lands) can install and be selected as a
+keyboard again.


### PR DESCRIPTION
## What

The shared foundation three later PRs (#24, #25, #26) stack on. Combines two
previously-independent worker branches:

1. **Restored `InputMethodService`** — the ADR-0006-independent-review
   blocker (`app` shipped with no IME at all post-#18). Verified installed
   and registered on `emulator-5554` via `adb shell ime list -a`.
2. **Compose theme + Navigation Compose skeleton** — every color/type/shape
   token from the Stitch `DESIGN.md`, and an 11-route nav graph (5 onboarding,
   6 settings) with trivial placeholders, wired into `MainActivity`.

Merged together on this branch (`PATCHNOTES.md` and `app/build.gradle.kts`
had a one-line-each additive conflict, resolved by keeping both sides).
`./gradlew :app:assembleDebug` verified green by this session after the
merge, independent of either worker's own claim.

Base is `feat/vendor-anysoftkeyboard` (PR #18) since both pieces build on
the vendored ASK tree from that PR, not on `main` directly.

## Why

Every screen-implementation slice needs a route to land in and a theme to
render with. This is that contract — see each piece's own report for detail:
`docs/superpowers/specs/2026-07-21-stub-restoration-report.md` and
`docs/superpowers/specs/2026-07-21-app-foundation-report.md`.

## Evidence

`./gradlew :app:assembleDebug --no-daemon` — `BUILD SUCCESSFUL`, checked by
this session after resolving the merge, not just inherited from either
worker's report.

## Grading

Not yet graded by a non-author. Flagging per the DoD.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BmubhbkLvzkCeYVuJ26rCS