### PR TITLE
docs: fix the IME registration gate

### DIFF
--- a/docs/superpowers/plans/2026-07-22-ask-snapshot-ingestion.md
+++ b/docs/superpowers/plans/2026-07-22-ask-snapshot-ingestion.md
@@ -501,7 +501,7 @@ With the repository's emulator running:
 ```bash
 set -euo pipefail
 APP_ID='biz.pixelperfectstudios.personaspeak'
-LEGACY_IME='biz.pixelperfectstudios.personaspeak/biz.pixelperfectstudios.personaspeak.keyboard.PersonaBoardService'
+LEGACY_IME='biz.pixelperfectstudios.personaspeak/.keyboard.PersonaBoardService'
 PREVIOUS_IME="$(adb shell settings get secure default_input_method | tr -d '\r')"
 if adb shell ime list -s | tr -d '\r' | rg -Fx "$LEGACY_IME" >/dev/null; then
   LEGACY_WAS_ENABLED=1
@@ -538,7 +538,9 @@ fi
 
 Expected: install succeeds, the service component is registered, switching it
 on for startup does not crash, the temporary activity launches, and the trap
-restores the previous IME. Do not tap the panel, type into its local field,
+restores the previous IME. The flattened component spelling above deliberately
+matches Android's `ime list` output while naming the same service as the fully
+qualified manifest class. Do not tap the panel, type into its local field,
 invoke Transform, use its back button, record it as a journey, or take product
 screenshots. This is a retirement-baseline smoke check, nothing more.
 


### PR DESCRIPTION
## Summary

- use Android's canonical flattened `ComponentName` spelling in the Task 3 IME registration check
- document why it names the same fully qualified manifest service
- keep the rejected panel interaction prohibitions and IME restoration trap unchanged

## Evidence

The prior exact match was a false negative: the installed emulator reports:

```text
biz.pixelperfectstudios.personaspeak/.keyboard.PersonaBoardService
```

The old fully qualified spelling does not appear in `adb shell ime list -a -s`.
With the corrected spelling, `ime enable`, `ime set`, and `ime disable` all exit
successfully. The probe restored the prior default IME and left PersonaSpeak
disabled, matching its pre-test state.

## Independent review

OpenCode `zai-coding-plan/glm-5.2` reviewed exact commit `96230f3` against
parent `cfc053a` and returned **APPROVED**.

- Critical: none
- Important: none
- Minor: noted the consciously omitted patch note; immediate plan-correction
  precedent #34 also used the docs-only/no-patchnote route.

The reviewer independently verified the device spelling, command acceptance,
manifest equivalence, restoration behavior, and unchanged rejected-UX guardrails.

## Checks

- `git diff --check`
- placeholder scan for `TBD` / `TODO` / `FIXME`
- device exact-match registration probe
- independent GLM exact-commit review

No product behavior or accepted UI changes; no screenshots apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated on-device verification instructions for IME registration and service startup.
  * Clarified the expected Android component format and its relationship to the manifest service.
  * Reiterated that the rejected panel is not intended for tapping, typing, or product experience checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->