### PR TITLE
docs: reconcile the UI foundation plan

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -12,6 +12,9 @@ Newest first, like all respectable patch notes.
 
 ## 2026-07-22 — The keyboard and the product become the same application
 
+- The UI-foundation plan has caught up with `main`: malformed provider
+  successes, all six validation fixtures, and the rejected panel now have
+  deterministic gates instead of relying on optimism.
 - The Stitch exports have acquired adult supervision: every requested screen
   now has an explicit disposition, with truthful privacy copy and your words
   still requiring one deliberate `Use this` before they move.

--- a/docs/superpowers/plans/2026-07-22-personaspeak-ui-foundation.md
+++ b/docs/superpowers/plans/2026-07-22-personaspeak-ui-foundation.md
@@ -762,10 +762,24 @@ Require exactly these three artifacts, sorted:
 ./personaspeak-ui/build/outputs/aar/personaspeak-ui-debug.aar
 ```
 
+Install `ripgrep` in the `android-build` job before running the first-party
+scans, and prove the binary exists before using shell negation:
+
+```yaml
+- name: Install scan tools
+  run: |
+    sudo apt-get update
+    sudo apt-get install --yes ripgrep
+    command -v rg
+    rg --version
+```
+
 Add first-party scans that fail on Android imports in `core-*`, ASK imports in
 `:personaspeak-ui`, and new occurrences of the rejected calls/phrases outside
 the quarantined `keyboard-stub`, temporary `app`, and inert ASK snapshot. Use
-this exact rejected-topology gate:
+this exact rejected-topology gate only after the availability check above.
+Without that prerequisite, `! rg ...` would turn a missing command into a
+passing gate:
 
 ```bash
 ! rg -n \
@@ -802,6 +816,7 @@ env JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home \
     --no-daemon
 cd ..
 git diff --check
+command -v rg
 ! rg -n '\b(TB''D|TO''DO|FIX''ME)\b' \
   android/core-personas android/personaspeak-ui .github/workflows/ci.yml PATCHNOTES.md
 ! rg -n '^import android\.' android/core-personas/src android/core-providers/src

--- a/docs/superpowers/plans/2026-07-22-personaspeak-ui-foundation.md
+++ b/docs/superpowers/plans/2026-07-22-personaspeak-ui-foundation.md
@@ -21,8 +21,10 @@ JDK 21, Android SDK 35, JUnit 4, SnakeYAML 2.3.
 
 ## Global Constraints
 
-- Start from current `origin/main` after PR #37, currently
-  `81835ebd22dad97dd19e4fbef31a240341ba545b`.
+- Start from a fresh `origin/main` after this plan correction lands. The
+  reviewed baseline before the correction is
+  `476667afc24484e9bc5a7cea65e1ecdc132badbc`; record the actual starting SHA
+  for the implementation PR's immutable receipts.
 - Read `/Users/devkiran/AGENTS.md` and repository `AGENTS.md` before acting.
 - Keep `android/` as the only Gradle root.
 - ASK stays excluded from `android/settings.gradle.kts`; no ASK task or APK runs
@@ -88,6 +90,7 @@ JDK 21, Android SDK 35, JUnit 4, SnakeYAML 2.3.
 - Create: `tests/persona-validation/invalid-pattern-entry.yaml`
 - Create: `tests/persona-validation/invalid-real-person-type.yaml`
 - Create: `tests/persona-validation/unsupported-version.yaml`
+- Create: `tests/persona-validation/invalid-fractional-version.yaml`
 - Modify: `desktop/validate_personas.py`
 
 **Interfaces:**
@@ -421,7 +424,7 @@ env JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home \
   ./gradlew :core-personas:test --no-daemon
 ```
 
-Expected: four repository personas validate, five Python tests pass, Kotlin
+Expected: four repository personas validate, six Python tests pass, Kotlin
 validator tests pass, and existing prompt goldens remain unchanged.
 
 - [ ] **Step 8: Commit the pure persona boundary**
@@ -666,6 +669,8 @@ Tests must prove:
 - unknown or invalid persona does not call the editor or provider;
 - a successful request builds the prompt, calls the provider once, and returns
   a candidate containing the original snapshot and replacement;
+- a successful blank or whitespace-only provider response returns
+  `MalformedResponse`, never a candidate;
 - provider failure returns a generic `ProviderFailure` without exposing the raw
   exception message;
 - requesting a candidate never calls `attemptReplace`;
@@ -692,6 +697,7 @@ sealed interface RewriteRequestResult {
     data object IncompleteRead : RewriteRequestResult
     data object OversizedInput : RewriteRequestResult
     data object ProviderFailure : RewriteRequestResult
+    data object MalformedResponse : RewriteRequestResult
 }
 
 sealed interface ApplyResult {
@@ -708,6 +714,9 @@ successful capture. It never catches an exception into user-visible raw text.
 If provider invocation is guarded by a broad exception handler, catch and
 rethrow `CancellationException` before mapping other failures to
 `ProviderFailure`; cancellation is control flow, not a provider error.
+After unwrapping a successful provider result, reject `replacement.isBlank()`
+as `MalformedResponse` before constructing `RewriteCandidate`. Do not expose or
+log the raw response.
 `RewriteCoordinator.apply(candidate)` calls `attemptReplace` exactly once and
 maps the returned type. Neither method stores candidates beyond its call.
 
@@ -755,7 +764,18 @@ Require exactly these three artifacts, sorted:
 
 Add first-party scans that fail on Android imports in `core-*`, ASK imports in
 `:personaspeak-ui`, and new occurrences of the rejected calls/phrases outside
-the quarantined `keyboard-stub` and temporary `app`.
+the quarantined `keyboard-stub`, temporary `app`, and inert ASK snapshot. Use
+this exact rejected-topology gate:
+
+```bash
+! rg -n \
+  'switchBackToPreviousKeyboard|PersonaPanel|fun[[:space:]]+Onboarding[[:space:]]*\(' \
+  android \
+  --glob '!android/app/**' \
+  --glob '!android/keyboard-stub/**' \
+  --glob '!android/keyboard/**' \
+  --glob '*.{kt,java}'
+```
 
 - [ ] **Step 2: Add the patch note**
 
@@ -786,6 +806,13 @@ git diff --check
   android/core-personas android/personaspeak-ui .github/workflows/ci.yml PATCHNOTES.md
 ! rg -n '^import android\.' android/core-personas/src android/core-providers/src
 ! rg -n 'com\.anysoftkeyboard|com\.menny' android/personaspeak-ui/src
+! rg -n \
+  'switchBackToPreviousKeyboard|PersonaPanel|fun[[:space:]]+Onboarding[[:space:]]*\(' \
+  android \
+  --glob '!android/app/**' \
+  --glob '!android/keyboard-stub/**' \
+  --glob '!android/keyboard/**' \
+  --glob '*.{kt,java}'
 ```
 
 Expected: all commands pass; exactly one current APK and two AARs exist; ASK


### PR DESCRIPTION
## What

Corrects the milestone 1 implementation plan before issue #41 begins:

- starts implementation from fresh main and records the reviewed pre-correction baseline;
- adds the missing fractional-version fixture to the six-fixture manifest and reconciles test receipts;
- adds the typed MalformedResponse outcome for blank provider successes;
- makes the rejected switcher/keyless-panel exclusion an executable, fail-closed rg gate.

## Why

Independent preflight review found drift between the written plan, accepted single-APK design, and current repository state. This PR fixes only that plan and its required patch note. It does not implement issue #41.

Part of #38. Prepares #41.

## Evidence

- **Commands run + output:** git diff --check passed; exact changed-file scope is two files; placeholder and VOICE banned-term scans returned no matches; all six validation fixtures and both six-test receipts are present; all Modify paths exist; the topology gate is silent outside quarantine and catches the known rejected demo symbols inside it; restricted-PATH execution fails at command -v rg before any negated scan; python3 desktop/validate_personas.py reported 4 personas validated; python3 desktop/personaspeak.py --list listed all four personas.
- **Screenshots / goldens:** Not applicable; documentation-only plan correction.
- **Journey recording:** Not applicable; no runtime behavior changed.
- **Graded by:** Claude-alt READY and OpenCode GLM READY on cumulative range 476667afc24484e9bc5a7cea65e1ecdc132badbc..57820f6d8b8ff185722e9fd85e3ce1e7c57f82c1. Both reproduced the fail-closed scanner evidence. Full attributed findings are recorded in the PR review-evidence comment.
- **CodeRabbit:** Substantive ready-for-review run completed on the exact two-file range with no actionable comments.

## Patch note

- The UI-foundation plan has caught up with `main`: malformed provider successes, all six validation fixtures, and the rejected panel now have deterministic gates instead of relying on optimism.

## Checklist

- [x] Tests ride with the code: not applicable; no behavior changed
- [x] Goldens updated and explained: not applicable; no goldens changed
- [x] Docs in this PR
- [x] Desktop validator and persona listing pass
- [x] Patch-note entry committed to PATCHNOTES.md
- [x] Graded by non-author reviewers
- [x] CI is green
- [x] Nothing here stores what a user typed
