### PR TITLE
feat: establish the PersonaSpeak UI boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         run: python desktop/validate_personas.py
       - name: CLI smoke test
         run: python desktop/personaspeak.py --list
+      - name: Persona validation unit tests
+        run: python -m unittest desktop/test_validate_personas.py
 
   patchnote-gate:
     name: PATCHNOTES.md touched
@@ -63,23 +65,53 @@ jobs:
           distribution: temurin
           java-version: "21"
           cache: gradle
+      - name: Install scan tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ripgrep
+          command -v rg
+          rg --version
       - name: Build and test the current Android graph
         working-directory: android
         run: >-
           ./gradlew
           :core-personas:build
           :core-providers:build
+          :personaspeak-ui:testDebugUnitTest
+          :personaspeak-ui:assembleDebug
           :keyboard-stub:assembleDebug
           :app:assembleDebug
           :app:testDebugUnitTest
           --no-daemon
-      - name: Require the temporary app APK and keyboard-stub AAR
+      - name: Require the three current-graph artifacts
         working-directory: android
         shell: bash
         run: |
           set -euo pipefail
           mapfile -t artifacts < <(find . \( -path '*/build/outputs/apk/*/*.apk' -o -path '*/build/outputs/aar/*.aar' \) -type f -print | sort)
           printf '%s\n' "${artifacts[@]}"
-          test "${#artifacts[@]}" -eq 2
+          test "${#artifacts[@]}" -eq 3
           test "${artifacts[0]}" = "./app/build/outputs/apk/debug/app-debug.apk"
           test "${artifacts[1]}" = "./keyboard-stub/build/outputs/aar/keyboard-stub-debug.aar"
+          test "${artifacts[2]}" = "./personaspeak-ui/build/outputs/aar/personaspeak-ui-debug.aar"
+      - name: Forbid Android imports in core modules
+        shell: bash
+        run: |
+          set -euo pipefail
+          ! rg -n '^import android\.' android/core-personas/src android/core-providers/src
+      - name: Forbid AnySoftKeyboard imports in personaspeak-ui
+        shell: bash
+        run: |
+          set -euo pipefail
+          ! rg -n 'com\.anysoftkeyboard|com\.menny' android/personaspeak-ui/src
+      - name: Forbid rejected topology outside the quarantined modules
+        shell: bash
+        run: |
+          set -euo pipefail
+          ! rg -n \
+            'switchBackToPreviousKeyboard|PersonaPanel|fun[[:space:]]+Onboarding[[:space:]]*\(' \
+            android \
+            --glob '!android/app/**' \
+            --glob '!android/keyboard-stub/**' \
+            --glob '!android/keyboard/**' \
+            --glob '*.{kt,java}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ! rg -n '^import android\.' android/core-personas/src android/core-providers/src
+          ! rg -n '^\s*import\s+(android|androidx)\.' android/core-personas/src android/core-providers/src
       - name: Forbid AnySoftKeyboard imports in personaspeak-ui
         shell: bash
         run: |

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -12,6 +12,13 @@ Newest first, like all respectable patch notes.
 
 ## 2026-07-22 — The keyboard and the product become the same application
 
+- The first-party UI boundary is now a contract, not a vibe. CI builds the
+  validated persona catalog/repository, the pure editor contract, and the
+  guarded two-stage rewrite coordinator, then fails if anything first-party
+  reaches for an Android import it shouldn't or an AnySoftKeyboard symbol it
+  hasn't earned. Exactly three artifacts leave the current graph — the
+  temporary app APK and the two first-party AARs — and the vendored ASK
+  snapshot stays inert, outside Gradle, producing nothing.
 - The UI-foundation plan has caught up with `main`: malformed provider
   successes, all six validation fixtures, and the rejected panel now have
   deterministic gates instead of relying on optimism.

--- a/android/core-personas/src/main/kotlin/biz/pixelperfectstudios/personaspeak/personas/Persona.kt
+++ b/android/core-personas/src/main/kotlin/biz/pixelperfectstudios/personaspeak/personas/Persona.kt
@@ -8,6 +8,7 @@ import java.io.InputStream
  * change that document (and every consumer) before changing this class.
  */
 data class Persona(
+    val schemaVersion: Int = 1,
     val name: String,
     val context: String = "",
     val speechPatterns: List<String>,
@@ -21,19 +22,45 @@ data class Persona(
             val data: Map<String, Any?> = Yaml().load(input)
                 ?: throw IllegalArgumentException("empty persona yaml")
             return Persona(
+                schemaVersion = schemaVersion(data["schema_version"]),
                 name = data["name"] as? String
                     ?: throw IllegalArgumentException("persona is missing 'name'"),
-                context = data["context"] as? String ?: "",
-                speechPatterns = stringList(data["speech_patterns"])
+                context = stringField("context", data["context"]),
+                speechPatterns = stringList("speech_patterns", data["speech_patterns"])
                     .ifEmpty { throw IllegalArgumentException("persona is missing 'speech_patterns'") },
-                vocabulary = stringList(data["vocabulary"]),
-                sampleLines = stringList(data["sample_lines"]),
-                notes = data["notes"] as? String ?: "",
-                realPerson = data["real_person"] as? Boolean ?: false,
+                vocabulary = stringList("vocabulary", data["vocabulary"]),
+                sampleLines = stringList("sample_lines", data["sample_lines"]),
+                notes = stringField("notes", data["notes"]),
+                realPerson = booleanField("real_person", data["real_person"]),
             )
         }
 
-        private fun stringList(value: Any?): List<String> =
-            (value as? List<*>)?.map { it.toString() } ?: emptyList()
+        private fun schemaVersion(value: Any?): Int {
+            if (value == null) return 1
+            if (value is Int) return value
+            throw IllegalArgumentException("'schema_version' must be an integer")
+        }
+
+        private fun stringList(field: String, value: Any?): List<String> {
+            if (value == null) return emptyList()
+            val list = value as? List<*>
+                ?: throw IllegalArgumentException("'$field' must be a list of strings")
+            if (list.any { it !is String }) {
+                throw IllegalArgumentException("every '$field' entry must be a string")
+            }
+            return list.filterIsInstance<String>().toList()
+        }
+
+        private fun stringField(field: String, value: Any?): String {
+            if (value == null) return ""
+            if (value !is String) throw IllegalArgumentException("'$field' must be a string")
+            return value
+        }
+
+        private fun booleanField(field: String, value: Any?): Boolean {
+            if (value == null) return false
+            if (value !is Boolean) throw IllegalArgumentException("'$field' must be a boolean")
+            return value
+        }
     }
 }

--- a/android/core-personas/src/main/kotlin/biz/pixelperfectstudios/personaspeak/personas/Persona.kt
+++ b/android/core-personas/src/main/kotlin/biz/pixelperfectstudios/personaspeak/personas/Persona.kt
@@ -8,7 +8,6 @@ import java.io.InputStream
  * change that document (and every consumer) before changing this class.
  */
 data class Persona(
-    val schemaVersion: Int = 1,
     val name: String,
     val context: String = "",
     val speechPatterns: List<String>,
@@ -16,13 +15,13 @@ data class Persona(
     val sampleLines: List<String> = emptyList(),
     val notes: String = "",
     val realPerson: Boolean = false,
+    val schemaVersion: Int = 1,
 ) {
     companion object {
         fun fromYaml(input: InputStream): Persona {
             val data: Map<String, Any?> = Yaml().load(input)
                 ?: throw IllegalArgumentException("empty persona yaml")
             return Persona(
-                schemaVersion = schemaVersion(data["schema_version"]),
                 name = data["name"] as? String
                     ?: throw IllegalArgumentException("persona is missing 'name'"),
                 context = stringField("context", data["context"]),
@@ -32,13 +31,15 @@ data class Persona(
                 sampleLines = stringList("sample_lines", data["sample_lines"]),
                 notes = stringField("notes", data["notes"]),
                 realPerson = booleanField("real_person", data["real_person"]),
+                schemaVersion = schemaVersion(data, "schema_version"),
             )
         }
 
-        private fun schemaVersion(value: Any?): Int {
-            if (value == null) return 1
+        private fun schemaVersion(data: Map<String, Any?>, field: String): Int {
+            if (!data.containsKey(field)) return 1
+            val value = data[field]
             if (value is Int) return value
-            throw IllegalArgumentException("'schema_version' must be an integer")
+            throw IllegalArgumentException("'$field' must be an integer")
         }
 
         private fun stringList(field: String, value: Any?): List<String> {

--- a/android/core-personas/src/main/kotlin/biz/pixelperfectstudios/personaspeak/personas/PersonaIdentity.kt
+++ b/android/core-personas/src/main/kotlin/biz/pixelperfectstudios/personaspeak/personas/PersonaIdentity.kt
@@ -40,4 +40,11 @@ data class ValidatedPersona(
     val id: PersonaId,
     val provenance: PersonaProvenance,
     val content: Persona,
-)
+) {
+    init {
+        val idSource = id.value.substringBefore(':')
+        require(idSource == provenance.source.value) {
+            "persona id source '$idSource' must match provenance source '${provenance.source.value}'"
+        }
+    }
+}

--- a/android/core-personas/src/main/kotlin/biz/pixelperfectstudios/personaspeak/personas/PersonaIdentity.kt
+++ b/android/core-personas/src/main/kotlin/biz/pixelperfectstudios/personaspeak/personas/PersonaIdentity.kt
@@ -1,0 +1,43 @@
+package biz.pixelperfectstudios.personaspeak.personas
+
+@JvmInline
+value class PersonaSourceId(val value: String) {
+    init {
+        require(value.matches(Regex("[a-z0-9][a-z0-9._-]*"))) {
+            "invalid persona source id '$value'"
+        }
+    }
+}
+
+@JvmInline
+value class PersonaId(val value: String) {
+    init {
+        require(value.matches(Regex("[a-z0-9][a-z0-9._-]*:[a-z0-9][a-z0-9._-]*"))) {
+            "persona id must be source-qualified"
+        }
+    }
+
+    companion object {
+        fun bundled(slug: String): PersonaId = PersonaId("bundled:$slug")
+    }
+}
+
+data class PersonaProvenance(
+    val source: PersonaSourceId,
+    val origin: String,
+    val licenseId: String?,
+) {
+    companion object {
+        val bundled = PersonaProvenance(
+            source = PersonaSourceId("bundled"),
+            origin = "PersonaSpeak bundled personas",
+            licenseId = "CC-BY",
+        )
+    }
+}
+
+data class ValidatedPersona(
+    val id: PersonaId,
+    val provenance: PersonaProvenance,
+    val content: Persona,
+)

--- a/android/core-personas/src/main/kotlin/biz/pixelperfectstudios/personaspeak/personas/PersonaValidator.kt
+++ b/android/core-personas/src/main/kotlin/biz/pixelperfectstudios/personaspeak/personas/PersonaValidator.kt
@@ -1,0 +1,29 @@
+package biz.pixelperfectstudios.personaspeak.personas
+
+object PersonaValidator {
+    fun validate(
+        id: PersonaId,
+        provenance: PersonaProvenance,
+        persona: Persona,
+    ): Result<ValidatedPersona> = runCatching {
+        require(persona.schemaVersion == 1) {
+            "unsupported schema_version ${persona.schemaVersion}"
+        }
+        require(persona.name.isNotBlank()) { "name is required" }
+        require(persona.speechPatterns.isNotEmpty()) {
+            "speech_patterns is required and must be non-empty"
+        }
+        require(!persona.realPerson || persona.notes.isNotBlank()) {
+            "real_person is true, so notes must declare a stylistic homage"
+        }
+        ValidatedPersona(
+            id = id,
+            provenance = provenance,
+            content = persona.copy(
+                speechPatterns = persona.speechPatterns.toList(),
+                vocabulary = persona.vocabulary.toList(),
+                sampleLines = persona.sampleLines.toList(),
+            ),
+        )
+    }
+}

--- a/android/core-personas/src/test/kotlin/biz/pixelperfectstudios/personaspeak/personas/PersonaValidatorParityTest.kt
+++ b/android/core-personas/src/test/kotlin/biz/pixelperfectstudios/personaspeak/personas/PersonaValidatorParityTest.kt
@@ -75,6 +75,17 @@ class PersonaValidatorParityTest {
     }
 
     @Test
+    fun `validated persona rejects direct construction when the id source disagrees with provenance source`() {
+        assertFailsWith<IllegalArgumentException> {
+            ValidatedPersona(
+                id = PersonaId("community:drift"),
+                provenance = PersonaProvenance.bundled,
+                content = Persona(name = "Drift", speechPatterns = listOf("drifts apart from its provenance")),
+            )
+        }
+    }
+
+    @Test
     fun `non-integer schema version fails parsing`() {
         val fractional = assertFailsWith<IllegalArgumentException> {
             fixtures.resolve("invalid-fractional-version.yaml")

--- a/android/core-personas/src/test/kotlin/biz/pixelperfectstudios/personaspeak/personas/PersonaValidatorParityTest.kt
+++ b/android/core-personas/src/test/kotlin/biz/pixelperfectstudios/personaspeak/personas/PersonaValidatorParityTest.kt
@@ -1,0 +1,85 @@
+package biz.pixelperfectstudios.personaspeak.personas
+
+import org.junit.Test
+import java.nio.file.Paths
+import kotlin.io.path.inputStream
+import kotlin.test.assertFailsWith
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Parity tests pinning [PersonaValidator] to the same shared fixtures used by
+ * desktop/test_validate_personas.py. The fixtures live at the repo root under
+ * tests/persona-validation/ so both language contracts fail together if they drift.
+ */
+class PersonaValidatorParityTest {
+
+    private val repoRoot = Paths.get("../..").toAbsolutePath().normalize()
+    private val fixtures = repoRoot.resolve("tests/persona-validation")
+
+    @Test
+    fun `valid fixture produces source-qualified identity`() {
+        val persona = fixtures.resolve("valid-minimal.yaml").inputStream().use(Persona::fromYaml)
+        val validated = PersonaValidator.validate(
+            id = PersonaId.bundled("test-butler"),
+            provenance = PersonaProvenance(
+                source = PersonaSourceId("bundled"),
+                origin = "PersonaSpeak bundled personas",
+                licenseId = "CC-BY",
+            ),
+            persona = persona,
+        ).getOrThrow()
+        assertEquals("bundled:test-butler", validated.id.value)
+        assertEquals(1, validated.content.schemaVersion)
+    }
+
+    @Test
+    fun `real person fixture without notes is rejected`() {
+        val persona = fixtures.resolve("invalid-real-person-no-notes.yaml")
+            .inputStream().use(Persona::fromYaml)
+        val result = PersonaValidator.validate(
+            PersonaId.bundled("invalid"),
+            PersonaProvenance.bundled,
+            persona,
+        )
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()!!.message!!.contains("notes"))
+    }
+
+    @Test
+    fun `non-string pattern entry fails parsing`() {
+        assertFailsWith<IllegalArgumentException> {
+            fixtures.resolve("invalid-pattern-entry.yaml").inputStream().use(Persona::fromYaml)
+        }
+    }
+
+    @Test
+    fun `non-boolean real person flag fails parsing`() {
+        assertFailsWith<IllegalArgumentException> {
+            fixtures.resolve("invalid-real-person-type.yaml")
+                .inputStream().use(Persona::fromYaml)
+        }
+    }
+
+    @Test
+    fun `unsupported schema version is rejected`() {
+        val persona = fixtures.resolve("unsupported-version.yaml")
+            .inputStream().use(Persona::fromYaml)
+        val result = PersonaValidator.validate(
+            PersonaId.bundled("future"),
+            PersonaProvenance.bundled,
+            persona,
+        )
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()!!.message!!.contains("schema_version 2"))
+    }
+
+    @Test
+    fun `fractional schema version fails parsing`() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            fixtures.resolve("invalid-fractional-version.yaml")
+                .inputStream().use(Persona::fromYaml)
+        }
+        assertTrue(error.message!!.contains("'schema_version' must be an integer"))
+    }
+}

--- a/android/core-personas/src/test/kotlin/biz/pixelperfectstudios/personaspeak/personas/PersonaValidatorParityTest.kt
+++ b/android/core-personas/src/test/kotlin/biz/pixelperfectstudios/personaspeak/personas/PersonaValidatorParityTest.kt
@@ -75,11 +75,21 @@ class PersonaValidatorParityTest {
     }
 
     @Test
-    fun `fractional schema version fails parsing`() {
-        val error = assertFailsWith<IllegalArgumentException> {
+    fun `non-integer schema version fails parsing`() {
+        val fractional = assertFailsWith<IllegalArgumentException> {
             fixtures.resolve("invalid-fractional-version.yaml")
                 .inputStream().use(Persona::fromYaml)
         }
-        assertTrue(error.message!!.contains("'schema_version' must be an integer"))
+        assertTrue(fractional.message!!.contains("'schema_version' must be an integer"))
+
+        val explicitNull = assertFailsWith<IllegalArgumentException> {
+            Persona.fromYaml(EXPLICIT_NULL_SCHEMA_VERSION.byteInputStream())
+        }
+        assertTrue(explicitNull.message!!.contains("'schema_version' must be an integer"))
+    }
+
+    companion object {
+        private const val EXPLICIT_NULL_SCHEMA_VERSION =
+            "schema_version: null\nname: Test Butler\nspeech_patterns:\n  - Speaks plainly\n"
     }
 }

--- a/android/personaspeak-ui/build.gradle.kts
+++ b/android/personaspeak-ui/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+}
+
+android {
+    namespace = "biz.pixelperfectstudios.personaspeak.ui"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+
+    sourceSets.getByName("main").assets.srcDir("../../personas")
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    implementation(project(":core-personas"))
+    implementation(project(":core-providers"))
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.coroutines.core)
+}

--- a/android/personaspeak-ui/src/main/AndroidManifest.xml
+++ b/android/personaspeak-ui/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/editor/EditorPort.kt
+++ b/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/editor/EditorPort.kt
@@ -1,0 +1,118 @@
+package biz.pixelperfectstudios.personaspeak.ui.editor
+
+/**
+ * Opaque handle for a single editor session.
+ *
+ * The value is opaque to the port's callers; the ASK adapter assigns and
+ * compares it to detect that the user has navigated away from the editor a
+ * snapshot was taken from. It carries no meaning and makes no atomicity
+ * claim across processes.
+ */
+@JvmInline
+value class EditorSessionToken(val value: Long)
+
+/**
+ * Opaque generation counter for a single capture/replace cycle against one
+ * editor session. The adapter bumps it to invalidate earlier snapshots whose
+ * replacement arrived too late.
+ */
+@JvmInline
+value class RequestGeneration(val value: Long)
+
+/**
+ * UTF-16 code-unit selection range, half-open in the same units the platform
+ * editor uses (`InputConnection.getSelectionStart` / `getSelectionEnd`).
+ * UTF-16 — not code points — so a supplementary character occupies two units.
+ */
+data class Utf16Selection(val start: Int, val end: Int) {
+    init {
+        require(start >= 0 && end >= start)
+    }
+}
+
+/**
+ * A complete, bounded draft captured from the editor at one instant.
+ *
+ * - [draft] is capped at 8,000 Unicode code points (counted by code point,
+ *   not UTF-16 unit, so supplementary characters count as one).
+ * - [selection] is in UTF-16 units and must fall within [draft].
+ *
+ * The snapshot is a value: it carries no reference to the live editor and
+ * cannot mutate it. Whether the adapter's read was atomic is the adapter's
+ * concern, not the port's — this type makes no cross-process atomicity claim.
+ */
+data class EditorSnapshot(
+    val session: EditorSessionToken,
+    val generation: RequestGeneration,
+    val draft: String,
+    val selection: Utf16Selection,
+) {
+    init {
+        require(draft.codePointCount(0, draft.length) <= 8_000)
+        require(selection.end <= draft.length)
+    }
+}
+
+/**
+ * Outcome of capturing the editor. Exactly one [Captured] means a snapshot is
+ * available; every other variant is a typed refusal explaining why no
+ * snapshot could be taken.
+ */
+sealed interface CaptureResult {
+    data class Captured(val snapshot: EditorSnapshot) : CaptureResult
+    data object EmptyInput : CaptureResult
+    data object SensitiveEditor : CaptureResult
+    data object UnsupportedEditor : CaptureResult
+    data object IncompleteRead : CaptureResult
+    data object OversizedInput : CaptureResult
+}
+
+/**
+ * Why an attempted replacement was rejected as stale. Returned by the adapter
+ * when the editor moved on between capture and replace.
+ */
+sealed interface StaleReason {
+    data object SessionChanged : StaleReason
+    data object GenerationChanged : StaleReason
+    data object TextChanged : StaleReason
+    data object SelectionChanged : StaleReason
+}
+
+/**
+ * Outcome of attempting to replace the snapshot's selection with [replacement].
+ *
+ * - [AppliedVerified]: the adapter confirms the write landed at the captured
+ *   coordinates.
+ * - [Stale]: the snapshot no longer describes the live editor.
+ * - [WriteRejected]: the editor refused the write outright.
+ * - [WriteUnconfirmed]: the write was issued but the adapter could not verify
+ *   it landed. Honest about uncertainty; no silent success.
+ *
+ * A [Stale] or [WriteUnconfirmed] result is a port-level observation only.
+ * Whether the adapter actually emitted an editor mutation command is proven
+ * by the adapter's own tests, not by this contract.
+ */
+sealed interface ReplaceResult {
+    data object AppliedVerified : ReplaceResult
+    data class Stale(val reason: StaleReason) : ReplaceResult
+    data object WriteRejected : ReplaceResult
+    data object WriteUnconfirmed : ReplaceResult
+}
+
+/**
+ * The accepted editor boundary: a pure Kotlin contract for reading a bounded
+ * draft out of the editor and attempting a replacement.
+ *
+ * No `InputConnection`, `EditorInfo`, ASK, persistence, logging, or
+ * navigation types cross this boundary. The later ASK adapter implements it
+ * against the platform editor; everything upstream (prompt building,
+ * persona selection) depends only on this interface.
+ */
+interface EditorPort {
+    suspend fun captureSnapshot(): CaptureResult
+
+    suspend fun attemptReplace(
+        snapshot: EditorSnapshot,
+        replacement: String,
+    ): ReplaceResult
+}

--- a/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/editor/EditorPort.kt
+++ b/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/editor/EditorPort.kt
@@ -20,9 +20,12 @@ value class EditorSessionToken(val value: Long)
 value class RequestGeneration(val value: Long)
 
 /**
- * UTF-16 code-unit selection range, half-open in the same units the platform
- * editor uses (`InputConnection.getSelectionStart` / `getSelectionEnd`).
- * UTF-16 — not code points — so a supplementary character occupies two units.
+ * Captured UTF-16 code-unit range, half-open. UTF-16 — not code points — so a
+ * supplementary character occupies two units.
+ *
+ * This is a platform-neutral value: it names no Android API. A later adapter
+ * derives these offsets from its complete read of the editor state; how it
+ * obtains them is the adapter's concern, not this type's.
  */
 data class Utf16Selection(val start: Int, val end: Int) {
     init {
@@ -79,18 +82,24 @@ sealed interface StaleReason {
 }
 
 /**
- * Outcome of attempting to replace the snapshot's selection with [replacement].
+ * Outcome of attempting to replace the entire captured bounded draft target
+ * with [replacement].
  *
- * - [AppliedVerified]: the adapter confirms the write landed at the captured
- *   coordinates.
- * - [Stale]: the snapshot no longer describes the live editor.
- * - [WriteRejected]: the editor refused the write outright.
- * - [WriteUnconfirmed]: the write was issued but the adapter could not verify
- *   it landed. Honest about uncertainty; no silent success.
+ * The snapshot's [EditorSnapshot.selection] is not the replacement subrange.
+ * v1 replaces the whole bounded draft; the selection exists to revalidate
+ * drift between capture and replace, and may yield
+ * [StaleReason.SelectionChanged].
  *
- * A [Stale] or [WriteUnconfirmed] result is a port-level observation only.
- * Whether the adapter actually emitted an editor mutation command is proven
- * by the adapter's own tests, not by this contract.
+ * - [AppliedVerified]: a post-write read of the editor observed the expected
+ *   replacement.
+ * - [Stale]: session/generation/text/selection validation failed before any
+ *   text mutation command was sent. No mutation is emitted on a [Stale]
+ *   outcome; that no-mutation guarantee is part of this contract, not merely
+ *   an adapter-test observation.
+ * - [WriteRejected]: a required editor mutation command was rejected.
+ * - [WriteUnconfirmed]: a mutation command was accepted by the editor but the
+ *   post-write verification could not prove the final text. Callers must not
+ *   auto-retry; honest about uncertainty, no silent success.
  */
 sealed interface ReplaceResult {
     data object AppliedVerified : ReplaceResult

--- a/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/AssetPersonaDocumentSource.kt
+++ b/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/AssetPersonaDocumentSource.kt
@@ -1,0 +1,24 @@
+package biz.pixelperfectstudios.personaspeak.ui.personas
+
+import android.content.res.AssetManager
+import java.io.InputStream
+
+class AssetPersonaDocumentSource(private val assets: AssetManager) : PersonaDocumentSource {
+
+    override fun slugs(): Result<List<String>> = runCatching {
+        assets.list("")
+            ?.filter { it.endsWith(YAML_SUFFIX) }
+            ?.map { it.removeSuffix(YAML_SUFFIX) }
+            ?: emptyList()
+    }
+
+    override fun open(slug: String): Result<InputStream> = runCatching {
+        val known = slugs().getOrThrow()
+        require(slug in known) { "unknown persona slug '$slug'" }
+        assets.open("$slug$YAML_SUFFIX")
+    }
+
+    private companion object {
+        const val YAML_SUFFIX = ".yaml"
+    }
+}

--- a/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/BundledPersonaRepository.kt
+++ b/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/BundledPersonaRepository.kt
@@ -10,18 +10,22 @@ class BundledPersonaRepository(private val source: PersonaDocumentSource) : Pers
 
     override fun list(): Result<List<PersonaSummary>> = runCatching {
         source.slugs().getOrThrow()
-            .map { slug -> PersonaSummary(PersonaId.bundled(slug), parse(slug).name) }
+            .map { slug -> validate(slug) }
+            .map { persona -> PersonaSummary(persona.id, persona.content.name) }
             .sortedBy { it.id.value }
     }
 
     override fun load(id: PersonaId): Result<ValidatedPersona> = runCatching {
         require(id.value.startsWith(BUNDLED_PREFIX)) { "unknown persona source '${id.value.substringBefore(':')}'" }
         val slug = id.value.removePrefix(BUNDLED_PREFIX)
-        PersonaValidator.validate(id, PersonaProvenance.bundled, parse(slug)).getOrThrow()
+        validate(slug)
     }
 
-    private fun parse(slug: String): Persona =
-        source.open(slug).map { stream -> stream.use(Persona::fromYaml) }.getOrThrow()
+    private fun validate(slug: String): ValidatedPersona {
+        val id = PersonaId.bundled(slug)
+        val persona = source.open(slug).map { stream -> stream.use(Persona::fromYaml) }.getOrThrow()
+        return PersonaValidator.validate(id, PersonaProvenance.bundled, persona).getOrThrow()
+    }
 
     private companion object {
         const val BUNDLED_PREFIX = "bundled:"

--- a/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/BundledPersonaRepository.kt
+++ b/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/BundledPersonaRepository.kt
@@ -1,0 +1,29 @@
+package biz.pixelperfectstudios.personaspeak.ui.personas
+
+import biz.pixelperfectstudios.personaspeak.personas.Persona
+import biz.pixelperfectstudios.personaspeak.personas.PersonaId
+import biz.pixelperfectstudios.personaspeak.personas.PersonaProvenance
+import biz.pixelperfectstudios.personaspeak.personas.PersonaValidator
+import biz.pixelperfectstudios.personaspeak.personas.ValidatedPersona
+
+class BundledPersonaRepository(private val source: PersonaDocumentSource) : PersonaRepository {
+
+    override fun list(): Result<List<PersonaSummary>> = runCatching {
+        source.slugs().getOrThrow()
+            .map { slug -> PersonaSummary(PersonaId.bundled(slug), parse(slug).name) }
+            .sortedBy { it.id.value }
+    }
+
+    override fun load(id: PersonaId): Result<ValidatedPersona> = runCatching {
+        require(id.value.startsWith(BUNDLED_PREFIX)) { "unknown persona source '${id.value.substringBefore(':')}'" }
+        val slug = id.value.removePrefix(BUNDLED_PREFIX)
+        PersonaValidator.validate(id, PersonaProvenance.bundled, parse(slug)).getOrThrow()
+    }
+
+    private fun parse(slug: String): Persona =
+        source.open(slug).map { stream -> stream.use(Persona::fromYaml) }.getOrThrow()
+
+    private companion object {
+        const val BUNDLED_PREFIX = "bundled:"
+    }
+}

--- a/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/PersonaDocumentSource.kt
+++ b/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/PersonaDocumentSource.kt
@@ -1,0 +1,8 @@
+package biz.pixelperfectstudios.personaspeak.ui.personas
+
+import java.io.InputStream
+
+interface PersonaDocumentSource {
+    fun slugs(): Result<List<String>>
+    fun open(slug: String): Result<InputStream>
+}

--- a/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/PersonaRepository.kt
+++ b/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/PersonaRepository.kt
@@ -1,0 +1,11 @@
+package biz.pixelperfectstudios.personaspeak.ui.personas
+
+import biz.pixelperfectstudios.personaspeak.personas.PersonaId
+import biz.pixelperfectstudios.personaspeak.personas.ValidatedPersona
+
+data class PersonaSummary(val id: PersonaId, val displayName: String)
+
+interface PersonaRepository {
+    fun list(): Result<List<PersonaSummary>>
+    fun load(id: PersonaId): Result<ValidatedPersona>
+}

--- a/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewriteCoordinator.kt
+++ b/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewriteCoordinator.kt
@@ -1,0 +1,110 @@
+package biz.pixelperfectstudios.personaspeak.ui.rewrite
+
+import biz.pixelperfectstudios.personaspeak.personas.PersonaId
+import biz.pixelperfectstudios.personaspeak.personas.PromptBuilder
+import biz.pixelperfectstudios.personaspeak.providers.CompletionProvider
+import biz.pixelperfectstudios.personaspeak.ui.editor.CaptureResult
+import biz.pixelperfectstudios.personaspeak.ui.editor.EditorPort
+import biz.pixelperfectstudios.personaspeak.ui.editor.EditorSnapshot
+import biz.pixelperfectstudios.personaspeak.ui.editor.ReplaceResult
+import biz.pixelperfectstudios.personaspeak.ui.editor.StaleReason
+import biz.pixelperfectstudios.personaspeak.ui.personas.PersonaRepository
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * A captured editor snapshot paired with the provider's replacement text, ready
+ * for the user to approve. The snapshot is the full value captured at request
+ * time; the coordinator does not retain any reference to it between calls.
+ */
+data class RewriteCandidate(
+    val snapshot: EditorSnapshot,
+    val replacement: String,
+)
+
+/**
+ * Outcome of [RewriteCoordinator.request]. Exactly one [Ready] means a candidate
+ * is available for the user to approve; every other variant is a typed refusal
+ * or failure that carries no provider body, exception, or candidate payload.
+ */
+sealed interface RewriteRequestResult {
+    data class Ready(val candidate: RewriteCandidate) : RewriteRequestResult
+    data object NoPersona : RewriteRequestResult
+    data object EmptyInput : RewriteRequestResult
+    data object SensitiveEditor : RewriteRequestResult
+    data object UnsupportedEditor : RewriteRequestResult
+    data object IncompleteRead : RewriteRequestResult
+    data object OversizedInput : RewriteRequestResult
+    data object ProviderFailure : RewriteRequestResult
+    data object MalformedResponse : RewriteRequestResult
+}
+
+/**
+ * Outcome of [RewriteCoordinator.apply]. Mirrors the editor port's
+ * [ReplaceResult] without retry: [AppliedVerified], a typed [Stale] reason,
+ * [WriteRejected], or honest-about-uncertainty [WriteUnconfirmed].
+ */
+sealed interface ApplyResult {
+    data object AppliedVerified : ApplyResult
+    data class Stale(val reason: StaleReason) : ApplyResult
+    data object WriteRejected : ApplyResult
+    data object WriteUnconfirmed : ApplyResult
+}
+
+/**
+ * Coordinates the two-stage persona rewrite: [request] loads the persona,
+ * captures the editor, builds the prompt, and asks the provider — returning a
+ * candidate the user can see before anything is written. [apply] performs a
+ * single replacement attempt from the candidate the user approved.
+ *
+ * Neither method stores candidates, provider bodies, or exception messages
+ * beyond its call. Provider failure (whether returned via `Result.failure` or
+ * thrown) collapses to [RewriteRequestResult.ProviderFailure] with no payload;
+ * [CancellationException] is rethrown before that mapping because cancellation
+ * is control flow, not a provider error.
+ *
+ * No Android, ASK, persistence, logging, analytics, or navigation types cross
+ * this boundary — only the four pure-Kotlin ports it consumes.
+ */
+class RewriteCoordinator(
+    private val personas: PersonaRepository,
+    private val editor: EditorPort,
+    private val provider: CompletionProvider,
+) {
+
+    suspend fun request(personaId: PersonaId): RewriteRequestResult {
+        val persona = personas.load(personaId).getOrNull()
+            ?: return RewriteRequestResult.NoPersona
+
+        val snapshot = when (val capture = editor.captureSnapshot()) {
+            is CaptureResult.Captured -> capture.snapshot
+            CaptureResult.EmptyInput -> return RewriteRequestResult.EmptyInput
+            CaptureResult.SensitiveEditor -> return RewriteRequestResult.SensitiveEditor
+            CaptureResult.UnsupportedEditor -> return RewriteRequestResult.UnsupportedEditor
+            CaptureResult.IncompleteRead -> return RewriteRequestResult.IncompleteRead
+            CaptureResult.OversizedInput -> return RewriteRequestResult.OversizedInput
+        }
+
+        val system = PromptBuilder.build(persona.content)
+
+        val result = try {
+            provider.rewrite(system, snapshot.draft)
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (_: Throwable) {
+            return RewriteRequestResult.ProviderFailure
+        }
+
+        val replacement = result.getOrElse { return RewriteRequestResult.ProviderFailure }
+        if (replacement.isBlank()) return RewriteRequestResult.MalformedResponse
+
+        return RewriteRequestResult.Ready(RewriteCandidate(snapshot, replacement))
+    }
+
+    suspend fun apply(candidate: RewriteCandidate): ApplyResult =
+        when (val outcome = editor.attemptReplace(candidate.snapshot, candidate.replacement)) {
+            is ReplaceResult.AppliedVerified -> ApplyResult.AppliedVerified
+            is ReplaceResult.Stale -> ApplyResult.Stale(outcome.reason)
+            is ReplaceResult.WriteRejected -> ApplyResult.WriteRejected
+            is ReplaceResult.WriteUnconfirmed -> ApplyResult.WriteUnconfirmed
+        }
+}

--- a/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewriteCoordinator.kt
+++ b/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewriteCoordinator.kt
@@ -59,8 +59,9 @@ sealed interface ApplyResult {
  * Neither method stores candidates, provider bodies, or exception messages
  * beyond its call. Provider failure (whether returned via `Result.failure` or
  * thrown) collapses to [RewriteRequestResult.ProviderFailure] with no payload;
- * [CancellationException] is rethrown before that mapping because cancellation
- * is control flow, not a provider error.
+ * [CancellationException] — delivered either by a direct throw or inside a
+ * `Result.failure` — is rethrown before that mapping because cancellation is
+ * control flow, not a provider error.
  *
  * No Android, ASK, persistence, logging, analytics, or navigation types cross
  * this boundary — only the four pure-Kotlin ports it consumes.
@@ -94,7 +95,10 @@ class RewriteCoordinator(
             return RewriteRequestResult.ProviderFailure
         }
 
-        val replacement = result.getOrElse { return RewriteRequestResult.ProviderFailure }
+        val replacement = result.getOrElse { e ->
+            if (e is CancellationException) throw e
+            return RewriteRequestResult.ProviderFailure
+        }
         if (replacement.isBlank()) return RewriteRequestResult.MalformedResponse
 
         return RewriteRequestResult.Ready(RewriteCandidate(snapshot, replacement))

--- a/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/editor/EditorPortContractTest.kt
+++ b/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/editor/EditorPortContractTest.kt
@@ -1,0 +1,287 @@
+package biz.pixelperfectstudios.personaspeak.ui.editor
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Pure-Kotlin contract tests for [EditorPort] driven by a recording fake.
+ *
+ * The later ASK adapter tests prove that a stale result sends no editor
+ * mutation command; these tests only pin the port surface and the snapshot
+ * invariants. No Android, InputConnection, EditorInfo, ASK, persistence,
+ * logging, or navigation types appear here.
+ */
+class EditorPortContractTest {
+
+    // -----------------------------------------------------------------
+    // CaptureResult refusals
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `captureSnapshot surfaces an empty-input refusal`() {
+        val port = FakeEditorPort(capture = CaptureResult.EmptyInput)
+
+        val result = runBlocking { port.captureSnapshot() }
+
+        assertEquals(CaptureResult.EmptyInput, result)
+        assertEquals(1, port.captureCalls)
+    }
+
+    @Test
+    fun `captureSnapshot surfaces a sensitive-editor refusal`() {
+        val port = FakeEditorPort(capture = CaptureResult.SensitiveEditor)
+
+        val result = runBlocking { port.captureSnapshot() }
+
+        assertEquals(CaptureResult.SensitiveEditor, result)
+    }
+
+    @Test
+    fun `captureSnapshot surfaces an unsupported-editor refusal`() {
+        val port = FakeEditorPort(capture = CaptureResult.UnsupportedEditor)
+
+        val result = runBlocking { port.captureSnapshot() }
+
+        assertEquals(CaptureResult.UnsupportedEditor, result)
+    }
+
+    @Test
+    fun `captureSnapshot surfaces an incomplete-read refusal`() {
+        val port = FakeEditorPort(capture = CaptureResult.IncompleteRead)
+
+        val result = runBlocking { port.captureSnapshot() }
+
+        assertEquals(CaptureResult.IncompleteRead, result)
+    }
+
+    @Test
+    fun `captureSnapshot surfaces an oversized-input refusal`() {
+        val port = FakeEditorPort(capture = CaptureResult.OversizedInput)
+
+        val result = runBlocking { port.captureSnapshot() }
+
+        assertEquals(CaptureResult.OversizedInput, result)
+    }
+
+    @Test
+    fun `captureSnapshot returns a captured snapshot`() {
+        val snapshot = aSnapshot(draft = "hello", selection = Utf16Selection(0, 5))
+        val port = FakeEditorPort(capture = CaptureResult.Captured(snapshot))
+
+        val result = runBlocking { port.captureSnapshot() }
+
+        assertEquals(CaptureResult.Captured(snapshot), result)
+    }
+
+    // -----------------------------------------------------------------
+    // ReplaceResult outcomes
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `attemptReplace returns AppliedVerified and records the call`() {
+        val snapshot = aSnapshot()
+        val port = FakeEditorPort(replace = ReplaceResult.AppliedVerified)
+
+        val result = runBlocking { port.attemptReplace(snapshot, "world") }
+
+        assertEquals(ReplaceResult.AppliedVerified, result)
+        assertEquals(listOf(snapshot to "world"), port.replaceCalls)
+    }
+
+    @Test
+    fun `attemptReplace returns a stale SessionChanged reason from exactly one replacement`() {
+        val snapshot = aSnapshot()
+        val port = FakeEditorPort(replace = ReplaceResult.Stale(StaleReason.SessionChanged))
+
+        val result = runBlocking { port.attemptReplace(snapshot, "x") }
+
+        assertEquals(ReplaceResult.Stale(StaleReason.SessionChanged), result)
+        assertEquals(1, port.replaceCalls.size)
+    }
+
+    @Test
+    fun `attemptReplace returns a stale GenerationChanged reason from exactly one replacement`() {
+        val snapshot = aSnapshot()
+        val port = FakeEditorPort(replace = ReplaceResult.Stale(StaleReason.GenerationChanged))
+
+        val result = runBlocking { port.attemptReplace(snapshot, "x") }
+
+        assertEquals(ReplaceResult.Stale(StaleReason.GenerationChanged), result)
+        assertEquals(1, port.replaceCalls.size)
+    }
+
+    @Test
+    fun `attemptReplace returns a stale TextChanged reason from exactly one replacement`() {
+        val snapshot = aSnapshot()
+        val port = FakeEditorPort(replace = ReplaceResult.Stale(StaleReason.TextChanged))
+
+        val result = runBlocking { port.attemptReplace(snapshot, "x") }
+
+        assertEquals(ReplaceResult.Stale(StaleReason.TextChanged), result)
+        assertEquals(1, port.replaceCalls.size)
+    }
+
+    @Test
+    fun `attemptReplace returns a stale SelectionChanged reason from exactly one replacement`() {
+        val snapshot = aSnapshot()
+        val port = FakeEditorPort(replace = ReplaceResult.Stale(StaleReason.SelectionChanged))
+
+        val result = runBlocking { port.attemptReplace(snapshot, "x") }
+
+        assertEquals(ReplaceResult.Stale(StaleReason.SelectionChanged), result)
+        assertEquals(1, port.replaceCalls.size)
+    }
+
+    @Test
+    fun `attemptReplace returns WriteRejected`() {
+        val snapshot = aSnapshot()
+        val port = FakeEditorPort(replace = ReplaceResult.WriteRejected)
+
+        val result = runBlocking { port.attemptReplace(snapshot, "x") }
+
+        assertEquals(ReplaceResult.WriteRejected, result)
+    }
+
+    @Test
+    fun `attemptReplace returns WriteUnconfirmed`() {
+        val snapshot = aSnapshot()
+        val port = FakeEditorPort(replace = ReplaceResult.WriteUnconfirmed)
+
+        val result = runBlocking { port.attemptReplace(snapshot, "x") }
+
+        assertEquals(ReplaceResult.WriteUnconfirmed, result)
+    }
+
+    // -----------------------------------------------------------------
+    // EditorSnapshot: 8,000 Unicode code-point boundary
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `EditorSnapshot accepts a draft of exactly 8000 code points`() {
+        val draft = "a".repeat(8_000)
+
+        val snapshot = aSnapshot(draft = draft, selection = Utf16Selection(0, 8_000))
+
+        assertEquals(8_000, draft.codePointCount(0, draft.length))
+        assertEquals(draft, snapshot.draft)
+    }
+
+    @Test
+    fun `EditorSnapshot rejects a draft exceeding 8000 code points`() {
+        val draft = "a".repeat(8_001)
+
+        assertFailsWith<IllegalArgumentException> {
+            aSnapshot(draft = draft, selection = Utf16Selection(0, 0))
+        }
+    }
+
+    @Test
+    fun `EditorSnapshot counts a supplementary character as one code point`() {
+        // U+1F600 GRINNING FACE: two UTF-16 surrogate units, one code point.
+        val supplementary = "\uD83D\uDE00"
+        assertEquals(2, supplementary.length)
+        assertEquals(1, supplementary.codePointCount(0, supplementary.length))
+
+        // 7,999 ASCII + 1 supplementary = 8,000 code points, 8,001 UTF-16 units.
+        val draft = "a".repeat(7_999) + supplementary
+
+        val snapshot = aSnapshot(draft = draft, selection = Utf16Selection(0, draft.length))
+
+        assertEquals(8_001, draft.length)
+        assertEquals(8_000, draft.codePointCount(0, draft.length))
+        assertEquals(draft, snapshot.draft)
+    }
+
+    @Test
+    fun `EditorSnapshot rejects a draft whose supplementary character tips past 8000 code points`() {
+        val supplementary = "\uD83D\uDE00"
+        // 8,000 ASCII + 1 supplementary = 8,001 code points.
+        val draft = "a".repeat(8_000) + supplementary
+
+        assertFailsWith<IllegalArgumentException> {
+            aSnapshot(draft = draft, selection = Utf16Selection(0, 0))
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Invalid UTF-16 selections
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `Utf16Selection rejects a negative start`() {
+        assertFailsWith<IllegalArgumentException> {
+            Utf16Selection(start = -1, end = 0)
+        }
+    }
+
+    @Test
+    fun `Utf16Selection rejects an end before the start`() {
+        assertFailsWith<IllegalArgumentException> {
+            Utf16Selection(start = 2, end = 1)
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Selection bounds
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `EditorSnapshot rejects a selection ending past the draft length`() {
+        assertFailsWith<IllegalArgumentException> {
+            aSnapshot(draft = "abc", selection = Utf16Selection(0, 4))
+        }
+    }
+
+    @Test
+    fun `EditorSnapshot accepts a selection ending exactly at the draft length`() {
+        val snapshot = aSnapshot(draft = "abc", selection = Utf16Selection(1, 3))
+
+        assertEquals(3, snapshot.selection.end)
+    }
+
+    @Test
+    fun `EditorSnapshot accepts a collapsed caret selection inside the draft`() {
+        val snapshot = aSnapshot(draft = "abc", selection = Utf16Selection(2, 2))
+
+        assertEquals(2, snapshot.selection.start)
+        assertEquals(2, snapshot.selection.end)
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private fun aSnapshot(
+        draft: String = "draft",
+        selection: Utf16Selection = Utf16Selection(0, draft.length),
+    ): EditorSnapshot = EditorSnapshot(
+        session = EditorSessionToken(1L),
+        generation = RequestGeneration(1L),
+        draft = draft,
+        selection = selection,
+    )
+
+    private class FakeEditorPort(
+        private val capture: CaptureResult = CaptureResult.EmptyInput,
+        private val replace: ReplaceResult = ReplaceResult.AppliedVerified,
+    ) : EditorPort {
+        var captureCalls: Int = 0
+            private set
+        val replaceCalls: MutableList<Pair<EditorSnapshot, String>> = mutableListOf()
+
+        override suspend fun captureSnapshot(): CaptureResult {
+            captureCalls += 1
+            return capture
+        }
+
+        override suspend fun attemptReplace(
+            snapshot: EditorSnapshot,
+            replacement: String,
+        ): ReplaceResult {
+            replaceCalls += snapshot to replacement
+            return replace
+        }
+    }
+}

--- a/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/BundledPersonaRepositoryTest.kt
+++ b/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/BundledPersonaRepositoryTest.kt
@@ -54,6 +54,21 @@ class BundledPersonaRepositoryTest {
     }
 
     @Test
+    fun `list fails for a parseable but semantically invalid bundled document`() {
+        val source = InMemoryPersonaDocumentSource(
+            "invalid" to """
+                name: "   "
+                schema_version: 1
+                speech_patterns:
+                  - "speaks in riddles"
+            """.trimIndent(),
+        )
+        val repository = BundledPersonaRepository(source)
+
+        assertTrue(repository.list().isFailure)
+    }
+
+    @Test
     fun `load rejects a non-bundled id without opening the document`() {
         val source = TrackingPersonaDocumentSource(FakePersonaDocumentSource(bundledPersonasDir))
         val repository = BundledPersonaRepository(source)
@@ -83,6 +98,19 @@ class BundledPersonaRepositoryTest {
         override fun open(slug: String): Result<InputStream> {
             openCalls += 1
             return delegate.open(slug)
+        }
+    }
+
+    private class InMemoryPersonaDocumentSource(
+        private val documents: Map<String, String>,
+    ) : PersonaDocumentSource {
+        constructor(vararg entries: Pair<String, String>) : this(entries.toMap())
+
+        override fun slugs(): Result<List<String>> = runCatching { documents.keys.toList() }
+
+        override fun open(slug: String): Result<InputStream> = runCatching {
+            documents[slug]?.byteInputStream()
+                ?: error("unknown persona slug '$slug'")
         }
     }
 }

--- a/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/BundledPersonaRepositoryTest.kt
+++ b/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/personas/BundledPersonaRepositoryTest.kt
@@ -1,0 +1,88 @@
+package biz.pixelperfectstudios.personaspeak.ui.personas
+
+import biz.pixelperfectstudios.personaspeak.personas.PersonaId
+import biz.pixelperfectstudios.personaspeak.personas.PersonaProvenance
+import biz.pixelperfectstudios.personaspeak.personas.ValidatedPersona
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+import java.nio.file.Paths
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BundledPersonaRepositoryTest {
+
+    private val bundledPersonasDir: File =
+        Paths.get("../..").toAbsolutePath().normalize().resolve("personas").toFile()
+
+    @Test
+    fun `lists every bundled persona sorted by source-qualified id`() {
+        val repository = BundledPersonaRepository(FakePersonaDocumentSource(bundledPersonasDir))
+
+        assertEquals(
+            listOf("bundled:amitabh-bachchan", "bundled:dr-schultz", "bundled:jeeves", "bundled:sir-humphrey"),
+            repository.list().getOrThrow().map { it.id.value },
+        )
+    }
+
+    @Test
+    fun `summary display name mirrors the yaml name field`() {
+        val repository = BundledPersonaRepository(FakePersonaDocumentSource(bundledPersonasDir))
+
+        val names = repository.list().getOrThrow().associate { it.id.value to it.displayName }
+
+        assertEquals("Jeeves", names["bundled:jeeves"])
+        assertEquals("Amitabh Bachchan", names["bundled:amitabh-bachchan"])
+    }
+
+    @Test
+    fun `load returns a validated bundled persona`() {
+        val repository = BundledPersonaRepository(FakePersonaDocumentSource(bundledPersonasDir))
+
+        val persona: ValidatedPersona = repository.load(PersonaId.bundled("jeeves")).getOrThrow()
+
+        assertEquals(PersonaId.bundled("jeeves"), persona.id)
+        assertEquals(PersonaProvenance.bundled, persona.provenance)
+        assertEquals("Jeeves", persona.content.name)
+    }
+
+    @Test
+    fun `load fails for a bundled id that is not packaged`() {
+        val repository = BundledPersonaRepository(FakePersonaDocumentSource(bundledPersonasDir))
+
+        assertTrue(repository.load(PersonaId("bundled:missing")).isFailure)
+    }
+
+    @Test
+    fun `load rejects a non-bundled id without opening the document`() {
+        val source = TrackingPersonaDocumentSource(FakePersonaDocumentSource(bundledPersonasDir))
+        val repository = BundledPersonaRepository(source)
+
+        assertTrue(repository.load(PersonaId("other:jeeves")).isFailure)
+        assertEquals(0, source.openCalls)
+    }
+
+    private class FakePersonaDocumentSource(private val dir: File) : PersonaDocumentSource {
+        override fun slugs(): Result<List<String>> = runCatching {
+            dir.listFiles { file -> file.isFile && file.extension == "yaml" }
+                ?.map { it.nameWithoutExtension }
+                ?: emptyList()
+        }
+
+        override fun open(slug: String): Result<InputStream> = runCatching {
+            File(dir, "$slug.yaml").inputStream()
+        }
+    }
+
+    private class TrackingPersonaDocumentSource(private val delegate: PersonaDocumentSource) : PersonaDocumentSource {
+        var openCalls: Int = 0
+            private set
+
+        override fun slugs(): Result<List<String>> = delegate.slugs()
+
+        override fun open(slug: String): Result<InputStream> {
+            openCalls += 1
+            return delegate.open(slug)
+        }
+    }
+}

--- a/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewriteCoordinatorTest.kt
+++ b/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewriteCoordinatorTest.kt
@@ -17,6 +17,7 @@ import biz.pixelperfectstudios.personaspeak.ui.editor.Utf16Selection
 import biz.pixelperfectstudios.personaspeak.ui.personas.PersonaRepository
 import biz.pixelperfectstudios.personaspeak.ui.personas.PersonaSummary
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -215,6 +216,23 @@ class RewriteCoordinatorTest {
     // -----------------------------------------------------------------
     // Cancellation propagation
     // -----------------------------------------------------------------
+
+    @Test
+    fun `request rethrows a CancellationException delivered via Result failure rather than collapsing it to ProviderFailure`() = runBlocking {
+        val editor = FakeEditorPort(capture = CaptureResult.Captured(aSnapshot()))
+        val provider = FakeCompletionProvider(
+            result = Result.failure(CancellationException("delivered as a failure result")),
+        )
+        val coordinator = coordinator(editor, provider)
+
+        val job = launch { coordinator.request(PERSONA_ID) }
+        job.join()
+
+        assertTrue(job.isCancelled, "CancellationException in Result.failure must propagate, not become ProviderFailure")
+        assertEquals(1, provider.calls.size)
+        assertTrue(editor.replaceCalls.isEmpty(), "cancellation-as-failure must not reach attemptReplace")
+        Unit
+    }
 
     @Test
     fun `cancellation during the provider rewrite propagates without ProviderFailure or attemptReplace`() = runBlocking {

--- a/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewriteCoordinatorTest.kt
+++ b/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewriteCoordinatorTest.kt
@@ -1,0 +1,432 @@
+package biz.pixelperfectstudios.personaspeak.ui.rewrite
+
+import biz.pixelperfectstudios.personaspeak.personas.Persona
+import biz.pixelperfectstudios.personaspeak.personas.PersonaId
+import biz.pixelperfectstudios.personaspeak.personas.PersonaProvenance
+import biz.pixelperfectstudios.personaspeak.personas.PromptBuilder
+import biz.pixelperfectstudios.personaspeak.personas.ValidatedPersona
+import biz.pixelperfectstudios.personaspeak.providers.CompletionProvider
+import biz.pixelperfectstudios.personaspeak.ui.editor.CaptureResult
+import biz.pixelperfectstudios.personaspeak.ui.editor.EditorPort
+import biz.pixelperfectstudios.personaspeak.ui.editor.EditorSessionToken
+import biz.pixelperfectstudios.personaspeak.ui.editor.EditorSnapshot
+import biz.pixelperfectstudios.personaspeak.ui.editor.ReplaceResult
+import biz.pixelperfectstudios.personaspeak.ui.editor.RequestGeneration
+import biz.pixelperfectstudios.personaspeak.ui.editor.StaleReason
+import biz.pixelperfectstudios.personaspeak.ui.editor.Utf16Selection
+import biz.pixelperfectstudios.personaspeak.ui.personas.PersonaRepository
+import biz.pixelperfectstudios.personaspeak.ui.personas.PersonaSummary
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pure-Kotlin contract tests for [RewriteCoordinator] driven by recording fakes.
+ *
+ * Pins the two-stage request/apply split: a provider result appears before any
+ * editor mutation is attempted, every typed capture refusal short-circuits
+ * before the provider is invoked, provider failure never leaks the raw body or
+ * exception, blank responses collapse to MalformedResponse, cancellation
+ * propagates as control flow rather than a ProviderFailure, and apply never
+ * retries. No Android, ASK, persistence, logging, analytics, or navigation
+ * types appear here.
+ */
+class RewriteCoordinatorTest {
+
+    // -----------------------------------------------------------------
+    // Capture refusals: provider never invoked
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `request surfaces an empty-input refusal and never calls the provider`() {
+        val editor = FakeEditorPort(capture = CaptureResult.EmptyInput)
+        val provider = FakeCompletionProvider()
+
+        val result = runBlocking { coordinator(editor, provider).request(PERSONA_ID) }
+
+        assertEquals(RewriteRequestResult.EmptyInput, result)
+        assertEquals(1, editor.captureCalls)
+        assertTrue(provider.calls.isEmpty())
+        assertTrue(editor.replaceCalls.isEmpty())
+    }
+
+    @Test
+    fun `request surfaces a sensitive-editor refusal and never calls the provider`() {
+        val editor = FakeEditorPort(capture = CaptureResult.SensitiveEditor)
+        val provider = FakeCompletionProvider()
+
+        val result = runBlocking { coordinator(editor, provider).request(PERSONA_ID) }
+
+        assertEquals(RewriteRequestResult.SensitiveEditor, result)
+        assertTrue(provider.calls.isEmpty())
+    }
+
+    @Test
+    fun `request surfaces an unsupported-editor refusal and never calls the provider`() {
+        val editor = FakeEditorPort(capture = CaptureResult.UnsupportedEditor)
+        val provider = FakeCompletionProvider()
+
+        val result = runBlocking { coordinator(editor, provider).request(PERSONA_ID) }
+
+        assertEquals(RewriteRequestResult.UnsupportedEditor, result)
+        assertTrue(provider.calls.isEmpty())
+    }
+
+    @Test
+    fun `request surfaces an incomplete-read refusal and never calls the provider`() {
+        val editor = FakeEditorPort(capture = CaptureResult.IncompleteRead)
+        val provider = FakeCompletionProvider()
+
+        val result = runBlocking { coordinator(editor, provider).request(PERSONA_ID) }
+
+        assertEquals(RewriteRequestResult.IncompleteRead, result)
+        assertTrue(provider.calls.isEmpty())
+    }
+
+    @Test
+    fun `request surfaces an oversized-input refusal and never calls the provider`() {
+        val editor = FakeEditorPort(capture = CaptureResult.OversizedInput)
+        val provider = FakeCompletionProvider()
+
+        val result = runBlocking { coordinator(editor, provider).request(PERSONA_ID) }
+
+        assertEquals(RewriteRequestResult.OversizedInput, result)
+        assertTrue(provider.calls.isEmpty())
+    }
+
+    // -----------------------------------------------------------------
+    // Persona resolution
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `request returns NoPersona when the persona is unknown and never touches the editor or provider`() {
+        val editor = FakeEditorPort(capture = CaptureResult.Captured(aSnapshot()))
+        val provider = FakeCompletionProvider()
+        val personas = FakePersonaRepository(persona = null)
+
+        val result = runBlocking { coordinator(personas, editor, provider).request(PERSONA_ID) }
+
+        assertEquals(RewriteRequestResult.NoPersona, result)
+        assertEquals(1, personas.loadCalls)
+        assertEquals(0, editor.captureCalls)
+        assertTrue(provider.calls.isEmpty())
+    }
+
+    // -----------------------------------------------------------------
+    // Successful request
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `request builds the prompt, calls the provider once, and returns a candidate with the snapshot and replacement`() {
+        val snapshot = aSnapshot(draft = "the original draft")
+        val editor = FakeEditorPort(capture = CaptureResult.Captured(snapshot))
+        val provider = FakeCompletionProvider(result = Result.success("the polished rewrite"))
+
+        val result = runBlocking { coordinator(editor, provider).request(PERSONA_ID) }
+
+        val candidate = (result as RewriteRequestResult.Ready).candidate
+        assertEquals(snapshot, candidate.snapshot)
+        assertEquals("the polished rewrite", candidate.replacement)
+        assertEquals(1, provider.calls.size)
+        assertEquals(PromptBuilder.build(TEST_PERSONA.content), provider.calls.single().first)
+        assertEquals("the original draft", provider.calls.single().second)
+    }
+
+    // -----------------------------------------------------------------
+    // Malformed responses
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `request returns MalformedResponse for a blank provider response and never produces a candidate`() {
+        val editor = FakeEditorPort(capture = CaptureResult.Captured(aSnapshot()))
+        val provider = FakeCompletionProvider(result = Result.success(""))
+
+        val result = runBlocking { coordinator(editor, provider).request(PERSONA_ID) }
+
+        assertEquals(RewriteRequestResult.MalformedResponse, result)
+        assertEquals(1, provider.calls.size)
+        assertFalse(result is RewriteRequestResult.Ready)
+    }
+
+    @Test
+    fun `request returns MalformedResponse for a whitespace-only provider response and never produces a candidate`() {
+        val editor = FakeEditorPort(capture = CaptureResult.Captured(aSnapshot()))
+        val provider = FakeCompletionProvider(result = Result.success("   \n\t "))
+
+        val result = runBlocking { coordinator(editor, provider).request(PERSONA_ID) }
+
+        assertEquals(RewriteRequestResult.MalformedResponse, result)
+        assertFalse(result is RewriteRequestResult.Ready)
+    }
+
+    // -----------------------------------------------------------------
+    // Provider failure: no raw leakage
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `request returns ProviderFailure when the provider returns a failure result without leaking the raw message`() {
+        val editor = FakeEditorPort(capture = CaptureResult.Captured(aSnapshot()))
+        val provider = FakeCompletionProvider(
+            result = Result.failure(RuntimeException("a secret api key that must not leak")),
+        )
+
+        val result = runBlocking { coordinator(editor, provider).request(PERSONA_ID) }
+
+        assertEquals(RewriteRequestResult.ProviderFailure, result)
+        assertEquals(1, provider.calls.size)
+        assertFalse(result.toString().contains("secret"), "raw exception message must not leak into the result")
+    }
+
+    @Test
+    fun `request returns ProviderFailure when the provider throws without leaking the raw message`() {
+        val editor = FakeEditorPort(capture = CaptureResult.Captured(aSnapshot()))
+        val provider = FakeCompletionProvider(
+            throwOnCall = RuntimeException("a secret stack trace that must not leak"),
+        )
+
+        val result = runBlocking { coordinator(editor, provider).request(PERSONA_ID) }
+
+        assertEquals(RewriteRequestResult.ProviderFailure, result)
+        assertEquals(1, provider.calls.size)
+        assertFalse(result.toString().contains("secret"), "raw exception message must not leak into the result")
+    }
+
+    // -----------------------------------------------------------------
+    // Request never applies
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `request never calls attemptReplace even on a successful candidate`() {
+        val editor = FakeEditorPort(capture = CaptureResult.Captured(aSnapshot()))
+        val provider = FakeCompletionProvider(result = Result.success("rewritten"))
+
+        val result = runBlocking { coordinator(editor, provider).request(PERSONA_ID) }
+
+        assertTrue(result is RewriteRequestResult.Ready)
+        assertTrue(editor.replaceCalls.isEmpty(), "request must not touch attemptReplace")
+    }
+
+    // -----------------------------------------------------------------
+    // Cancellation propagation
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `cancellation during the provider rewrite propagates without ProviderFailure or attemptReplace`() = runBlocking {
+        val entered = CompletableDeferred<Unit>()
+        val exited = CompletableDeferred<Unit>()
+        val editor = FakeEditorPort(capture = CaptureResult.Captured(aSnapshot()))
+        val provider = CancellingCompletionProvider(entered, exited)
+        val coordinator = coordinator(editor, provider)
+
+        val job = launch { coordinator.request(PERSONA_ID) }
+
+        entered.await()
+        job.cancelAndJoin()
+
+        assertTrue(job.isCancelled, "cancellation must propagate as CancellationException, not ProviderFailure")
+        assertTrue(exited.isCompleted, "provider finally must run on cancellation")
+        assertEquals(1, provider.calls.size)
+        assertTrue(editor.replaceCalls.isEmpty(), "cancellation must not reach attemptReplace")
+        Unit
+    }
+
+    // -----------------------------------------------------------------
+    // Apply: all four ReplaceResult variants, exactly one attempt each
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `apply maps AppliedVerified from exactly one replacement attempt`() {
+        val editor = FakeEditorPort(replace = ReplaceResult.AppliedVerified)
+        val candidate = RewriteCandidate(aSnapshot(), "rewritten")
+
+        val result = runBlocking { coordinator(editor = editor).apply(candidate) }
+
+        assertEquals(ApplyResult.AppliedVerified, result)
+        assertEquals(1, editor.replaceCalls.size)
+        assertEquals(candidate.snapshot to candidate.replacement, editor.replaceCalls.single())
+    }
+
+    @Test
+    fun `apply maps a stale SessionChanged reason from exactly one replacement attempt`() =
+        assertStaleMapping(StaleReason.SessionChanged)
+
+    @Test
+    fun `apply maps a stale GenerationChanged reason from exactly one replacement attempt`() =
+        assertStaleMapping(StaleReason.GenerationChanged)
+
+    @Test
+    fun `apply maps a stale TextChanged reason from exactly one replacement attempt`() =
+        assertStaleMapping(StaleReason.TextChanged)
+
+    @Test
+    fun `apply maps a stale SelectionChanged reason from exactly one replacement attempt`() =
+        assertStaleMapping(StaleReason.SelectionChanged)
+
+    @Test
+    fun `apply maps WriteRejected from exactly one replacement attempt`() {
+        val editor = FakeEditorPort(replace = ReplaceResult.WriteRejected)
+        val candidate = RewriteCandidate(aSnapshot(), "rewritten")
+
+        val result = runBlocking { coordinator(editor = editor).apply(candidate) }
+
+        assertEquals(ApplyResult.WriteRejected, result)
+        assertEquals(1, editor.replaceCalls.size)
+    }
+
+    @Test
+    fun `apply maps WriteUnconfirmed from exactly one replacement attempt`() {
+        val editor = FakeEditorPort(replace = ReplaceResult.WriteUnconfirmed)
+        val candidate = RewriteCandidate(aSnapshot(), "rewritten")
+
+        val result = runBlocking { coordinator(editor = editor).apply(candidate) }
+
+        assertEquals(ApplyResult.WriteUnconfirmed, result)
+        assertEquals(1, editor.replaceCalls.size)
+    }
+
+    @Test
+    fun `apply does not retain candidate state between calls`() {
+        val editor = FakeEditorPort(replace = ReplaceResult.AppliedVerified)
+        val coordinator = coordinator(editor = editor)
+        val first = RewriteCandidate(aSnapshot(draft = "first"), "first-out")
+        val second = RewriteCandidate(aSnapshot(draft = "second"), "second-out")
+
+        runBlocking { coordinator.apply(first) }
+        runBlocking { coordinator.apply(second) }
+
+        assertEquals(2, editor.replaceCalls.size)
+        assertEquals(first.snapshot to first.replacement, editor.replaceCalls[0])
+        assertEquals(second.snapshot to second.replacement, editor.replaceCalls[1])
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private fun assertStaleMapping(reason: StaleReason) {
+        val editor = FakeEditorPort(replace = ReplaceResult.Stale(reason))
+        val candidate = RewriteCandidate(aSnapshot(), "rewritten")
+
+        val result = runBlocking { coordinator(editor = editor).apply(candidate) }
+
+        assertEquals(ApplyResult.Stale(reason), result)
+        assertEquals(1, editor.replaceCalls.size, "apply must attempt replacement exactly once — no retry")
+    }
+
+    private fun coordinator(
+        editor: FakeEditorPort = FakeEditorPort(),
+        provider: FakeCompletionProvider = FakeCompletionProvider(),
+    ): RewriteCoordinator = RewriteCoordinator(FakePersonaRepository(), editor, provider)
+
+    private fun coordinator(
+        personas: PersonaRepository,
+        editor: FakeEditorPort,
+        provider: FakeCompletionProvider,
+    ): RewriteCoordinator = RewriteCoordinator(personas, editor, provider)
+}
+
+// -----------------------------------------------------------------
+// File-private fixtures
+// -----------------------------------------------------------------
+
+private val PERSONA_ID: PersonaId = PersonaId.bundled("jeeves")
+
+private val TEST_PERSONA: ValidatedPersona = ValidatedPersona(
+    id = PERSONA_ID,
+    provenance = PersonaProvenance.bundled,
+    content = Persona(
+        name = "Jeeves",
+        speechPatterns = listOf("speaks with precise, deferential economy"),
+    ),
+)
+
+private fun aSnapshot(
+    draft: String = "draft text",
+    selection: Utf16Selection = Utf16Selection(0, draft.length),
+): EditorSnapshot = EditorSnapshot(
+    session = EditorSessionToken(7L),
+    generation = RequestGeneration(1L),
+    draft = draft,
+    selection = selection,
+)
+
+private class FakePersonaRepository(
+    private val persona: ValidatedPersona? = TEST_PERSONA,
+) : PersonaRepository {
+    var loadCalls: Int = 0
+        private set
+
+    override fun list(): Result<List<PersonaSummary>> =
+        Result.success(listOfNotNull(persona?.let { PersonaSummary(it.id, it.content.name) }))
+
+    override fun load(id: PersonaId): Result<ValidatedPersona> {
+        loadCalls += 1
+        return if (persona != null && id == persona.id) Result.success(persona)
+        else Result.failure(NoSuchElementException("unknown persona ${id.value}"))
+    }
+}
+
+private class FakeEditorPort(
+    private val capture: CaptureResult = CaptureResult.Captured(aSnapshot()),
+    private val replace: ReplaceResult = ReplaceResult.AppliedVerified,
+) : EditorPort {
+    var captureCalls: Int = 0
+        private set
+    val replaceCalls: MutableList<Pair<EditorSnapshot, String>> = mutableListOf()
+
+    override suspend fun captureSnapshot(): CaptureResult {
+        captureCalls += 1
+        return capture
+    }
+
+    override suspend fun attemptReplace(snapshot: EditorSnapshot, replacement: String): ReplaceResult {
+        replaceCalls += snapshot to replacement
+        return replace
+    }
+}
+
+private open class FakeCompletionProvider(
+    private val result: Result<String> = Result.success("rewritten"),
+    private val throwOnCall: Throwable? = null,
+) : CompletionProvider {
+    val calls: MutableList<Pair<String, String>> = mutableListOf()
+
+    override val id: String = "fake"
+    override val displayName: String = "Fake"
+
+    override suspend fun rewrite(system: String, text: String): Result<String> {
+        recordCall(system, text)
+        throwOnCall?.let { throw it }
+        return result
+    }
+
+    protected fun recordCall(system: String, text: String) {
+        calls += system to text
+    }
+}
+
+private class CancellingCompletionProvider(
+    val entered: CompletableDeferred<Unit>,
+    val exited: CompletableDeferred<Unit>,
+) : FakeCompletionProvider() {
+    override val id: String = "cancelling"
+    override val displayName: String = "Cancelling"
+
+    override suspend fun rewrite(system: String, text: String): Result<String> {
+        recordCall(system, text)
+        entered.complete(Unit)
+        try {
+            suspendCancellableCoroutine<Unit> { /* suspends until cancelled */ }
+        } finally {
+            exited.complete(Unit)
+        }
+        @Suppress("UNREACHABLE_CODE")
+        error("suspendCancellableCoroutine never returns normally")
+    }
+}

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -19,4 +19,5 @@ rootProject.name = "personaboard"
 include(":core-personas")
 include(":core-providers")
 include(":keyboard-stub")
+include(":personaspeak-ui")
 include(":app")

--- a/desktop/test_validate_personas.py
+++ b/desktop/test_validate_personas.py
@@ -1,0 +1,36 @@
+import unittest
+from pathlib import Path
+
+from desktop.validate_personas import validate
+
+
+FIXTURES = Path(__file__).parent.parent / "tests" / "persona-validation"
+
+
+class PersonaValidationTest(unittest.TestCase):
+    def test_valid_minimal(self) -> None:
+        self.assertEqual([], validate(FIXTURES / "valid-minimal.yaml"))
+
+    def test_real_person_requires_notes(self) -> None:
+        errors = validate(FIXTURES / "invalid-real-person-no-notes.yaml")
+        self.assertTrue(any("notes" in error for error in errors), errors)
+
+    def test_pattern_entries_are_strings(self) -> None:
+        errors = validate(FIXTURES / "invalid-pattern-entry.yaml")
+        self.assertTrue(any("entry must be a string" in error for error in errors), errors)
+
+    def test_real_person_is_boolean(self) -> None:
+        errors = validate(FIXTURES / "invalid-real-person-type.yaml")
+        self.assertTrue(any("real_person" in error for error in errors), errors)
+
+    def test_schema_version_is_rejected(self) -> None:
+        errors = validate(FIXTURES / "unsupported-version.yaml")
+        self.assertTrue(any("unsupported schema_version 2" in error for error in errors), errors)
+
+    def test_schema_version_must_be_an_integer(self) -> None:
+        errors = validate(FIXTURES / "invalid-fractional-version.yaml")
+        self.assertTrue(any("schema_version' must be an integer" in error for error in errors), errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/desktop/test_validate_personas.py
+++ b/desktop/test_validate_personas.py
@@ -1,3 +1,4 @@
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -30,6 +31,19 @@ class PersonaValidationTest(unittest.TestCase):
     def test_schema_version_must_be_an_integer(self) -> None:
         errors = validate(FIXTURES / "invalid-fractional-version.yaml")
         self.assertTrue(any("schema_version' must be an integer" in error for error in errors), errors)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            explicit_null = Path(tmp) / "explicit-null-version.yaml"
+            explicit_null.write_text(
+                "schema_version: null\n"
+                "name: Test Butler\n"
+                "speech_patterns:\n"
+                "  - Speaks plainly\n"
+            )
+            errors = validate(explicit_null)
+            self.assertTrue(
+                any("schema_version' must be an integer" in error for error in errors), errors
+            )
 
 
 if __name__ == "__main__":

--- a/desktop/validate_personas.py
+++ b/desktop/validate_personas.py
@@ -37,14 +37,19 @@ def validate(path: Path) -> list[str]:
         if value is not None and not isinstance(value, str):
             errors.append(f"{path.name}: '{optional_str}' must be a string")
 
-    if data.get("real_person") is True and not data.get("notes"):
+    real_person = data.get("real_person")
+    if real_person is not None and not isinstance(real_person, bool):
+        errors.append(f"{path.name}: 'real_person' must be a boolean")
+    elif real_person is True and not data.get("notes"):
         errors.append(
             f"{path.name}: real_person is true, so 'notes' must declare this a "
             "stylistic homage (see docs/persona-schema.md)"
         )
 
     version = data.get("schema_version", 1)
-    if version != 1:
+    if "schema_version" in data and type(version) is not int:
+        errors.append(f"{path.name}: 'schema_version' must be an integer")
+    elif version != 1:
         errors.append(f"{path.name}: unsupported schema_version {version}")
 
     return errors

--- a/tests/persona-validation/invalid-fractional-version.yaml
+++ b/tests/persona-validation/invalid-fractional-version.yaml
@@ -1,0 +1,4 @@
+schema_version: 1.5
+name: Fractional Butler
+speech_patterns:
+  - Arrived between parsers

--- a/tests/persona-validation/invalid-pattern-entry.yaml
+++ b/tests/persona-validation/invalid-pattern-entry.yaml
@@ -1,0 +1,5 @@
+schema_version: 1
+name: Broken List
+speech_patterns:
+  - Valid entry
+  - 42

--- a/tests/persona-validation/invalid-real-person-no-notes.yaml
+++ b/tests/persona-validation/invalid-real-person-no-notes.yaml
@@ -1,0 +1,5 @@
+schema_version: 1
+name: Unqualified Homage
+speech_patterns:
+  - Sounds authoritative
+real_person: true

--- a/tests/persona-validation/invalid-real-person-type.yaml
+++ b/tests/persona-validation/invalid-real-person-type.yaml
@@ -1,0 +1,5 @@
+schema_version: 1
+name: Ambiguous Biography
+speech_patterns:
+  - Speaks ambiguously
+real_person: "sometimes"

--- a/tests/persona-validation/unsupported-version.yaml
+++ b/tests/persona-validation/unsupported-version.yaml
@@ -1,0 +1,4 @@
+schema_version: 2
+name: Future Persona
+speech_patterns:
+  - Arrived before its parser

--- a/tests/persona-validation/valid-minimal.yaml
+++ b/tests/persona-validation/valid-minimal.yaml
@@ -1,0 +1,4 @@
+schema_version: 1
+name: Test Butler
+speech_patterns:
+  - Speaks plainly


### PR DESCRIPTION
## Summary

- add source-qualified persona identities, provenance, and shared Python/Kotlin validation fixtures
- add the `:personaspeak-ui` boundary with a validated bundled catalog, pure editor contract, and guarded two-stage rewrite coordinator
- enforce the temporary pre-cutover topology in CI with exact artifacts and ASK remaining inert

Closes #41. Advances #38.

## Scope

This is milestone 1 of the accepted UI-foundation plan. It establishes first-party boundaries and tests; it does not graft them into AnySoftKeyboard yet. The vendored ASK tree is byte-identical to `main`, remains outside `settings.gradle.kts`, and produces no build output. The later atomic cutover will replace the temporary `:app`/`:keyboard-stub` topology and add the real ASK adapter in one slice.

## Verification

Fresh after `git fetch origin main` at immutable range `a4b88a4c3185b631c1cdbd64b1ff067eea8297e6..5c7b52e819008c39c72e8f9966228fb17fc6a1e3`:

```text
python3 desktop/validate_personas.py
4 personas validated. Impeccable, sir.

python3 desktop/personaspeak.py --list
amitabh-bachchan     Amitabh Bachchan
dr-schultz           Dr. King Schultz
jeeves               Jeeves
sir-humphrey         Sir Humphrey Appleby

python3 -m unittest desktop/test_validate_personas.py
Ran 6 tests in 0.002s
OK

./gradlew clean :core-personas:build :core-providers:build \
  :personaspeak-ui:testDebugUnitTest :personaspeak-ui:assembleDebug \
  :keyboard-stub:assembleDebug :app:assembleDebug :app:testDebugUnitTest --no-daemon
BUILD SUCCESSFUL in 9s
114 actionable tasks: 104 executed, 10 up-to-date
```

Fresh JUnit results:

- `PersonaValidatorParityTest`: 6 passing
- `PromptBuilderGoldenTest`: 1 passing
- `EditorPortContractTest`: 22 passing
- `BundledPersonaRepositoryTest`: 6 passing
- `RewriteCoordinatorTest`: 21 passing
- total Kotlin tests: 56, zero failures

Boundary scans found no placeholders, Android imports in `core-*`, ASK imports in `personaspeak-ui`, reverse core→UI edges, or rejected topology outside the three quarantined directories.

Exact clean-build artifacts:

```text
./app/build/outputs/apk/debug/app-debug.apk
./keyboard-stub/build/outputs/aar/keyboard-stub-debug.aar
./personaspeak-ui/build/outputs/aar/personaspeak-ui-debug.aar
```

ASK evidence:

- base/head `android/keyboard` tree: `c64fa785863f83e82995c5f93424dbc57b70b080`
- base/head `UPSTREAM-MODIFIED.md` blob: `940ff076ab181a0bdc545dadb16d7d0574067b83`
- `android/keyboard/build`: absent

## Independent review

- Claude Alt (different model family, non-author): Approved — 0 Critical, 0 Important, 5 non-blocking Minor findings
- Opencode cumulative audit: Approved — 0 Critical, 0 Important, 5 non-blocking Minor findings

Both reviewers independently re-ran tests, scans, artifact enumeration, ASK tree checks, and contract audits. Their detailed verdicts will be posted as a PR comment.

## Visual/device evidence

Screenshots and emulator evidence are not applicable to this slice: it adds no shipping UI and deliberately leaves ASK inert. Visual and device journeys belong to the later ASK adapter/cutover milestone, where there will be an actual keyboard surface to inspect instead of a library boundary wearing a convincing hat.

## Checklist

- [x] Accepted plan implemented through Task 5
- [x] Patch note added
- [x] Fresh deterministic gate green locally
- [x] Different-family non-author review has no Critical or Important findings
- [x] ASK snapshot unchanged and inert
- [x] GitHub CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a validated persona catalog with schema versioning, provenance, and bundled persona discovery/loading.
  * Introduced personas UI editor and rewrite coordinator contracts with safe capture/replace and typed outcomes, including an asset-backed bundled repository.
* **Bug Fixes**
  * Hardened persona YAML parsing/validation with strict typing, required notes for real-person entries, and stricter schema-version handling.
* **Tests**
  * Expanded persona, repository, editor-port, and rewrite-flow contract tests; CI now runs persona validation unit tests.
* **Chores**
  * Strengthened CI checks to enforce the first-party UI boundary and restrict build graph outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->