### PR TITLE
feat(m2_device): AdbRemoteStatusReader — structural exit-code discrimination

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,31 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-08-06 — The inspector learns to read exit codes without reading minds
+
+- `RemoteResult.remote_rc` is no longer set to None by default and left
+  for someone else to figure out. `AdbRemoteStatusReader` populates it
+  from the adb shell_v2 transport result, using a structural discriminator
+  (stderr emptiness at rc=1) rather than pattern-matching adb's English
+  error text. The probe observed that transport failures always write to
+  stderr and always exit 1; remote exit codes pass through at every
+  other value. Where the two signals collide — rc=1 with non-empty
+  stderr — the adapter declines to guess and returns None, letting
+  `_rc_of` fail closed to 1. A real remote exit code lost to caution
+  is an acceptable trade; a transport failure reported as remote success
+  is not.
+- `run_remote` no longer defaults every caller to `UnavailableReader`.
+  The concrete reader is the default; the old unavailable behavior is
+  still available for callers who want to opt out.
+- `_rc_of` for `RemoteResult` retains its transport backstop (the B-1
+  correction from the previous PR). The adapter populates `remote_rc`;
+  the dispatch remains correct regardless of which reader produced
+  the record. The redundancy is the guarantee.
+- A coverage-matrix test parses the orchestrator's AST and asserts the
+  set of `_rc_of` / `_timed_out` call sites matches an enumerated list.
+  It was demonstrated failing against a stray call before it was
+  trusted to guard against one. 138 tests, no device contacted.
+
 ## 2026-08-06 — The inspector rebuilds, in a language that doesn't eat its own status
 
 - Five Python modules (898 lines) implement the complete device-free

--- a/android/scripts/m2_device/commands.py
+++ b/android/scripts/m2_device/commands.py
@@ -28,6 +28,29 @@ class UnavailableReader:
         return None
 
 
+class AdbRemoteStatusReader:
+    """Determines remote exit code from adb shell_v2 transport results.
+
+    Under shell_v2, the adb wrapper exit code IS the remote exit code
+    (observed at 7, 5, 3, 2, 1, 0). Observed transport failures
+    (probe P2: device-not-found and no-devices, five cases) produce
+    rc=1 with non-empty stderr.
+
+    Discriminator is structural (stderr emptiness), not text-matching:
+    - rc != 1: unambiguous remote exit code
+    - rc == 1, stderr empty: remote exit 1 (observed transport failures write stderr)
+    - rc == 1, stderr non-empty: ambiguous, return None (fail closed)
+    """
+
+    def extract_rc(self, transport: CommandResult) -> int | None:
+        if transport.timed_out:
+            return None
+        rc = transport.returncode
+        if rc == 1 and transport.stderr:
+            return None
+        return rc
+
+
 def run(
     argv: list[str],
     *,
@@ -72,7 +95,7 @@ def run_remote(
     env: dict[str, str] | None = None,
     cwd: str | None = None,
 ) -> RemoteResult:
-    r = reader or UnavailableReader()
+    r = reader or AdbRemoteStatusReader()
     transport = run(argv, timeout=timeout, env=env, cwd=cwd)
     remote_rc = r.extract_rc(transport)
     return RemoteResult(transport=transport, remote_rc=remote_rc)

--- a/android/scripts/tests/m2_device/test_commands.py
+++ b/android/scripts/tests/m2_device/test_commands.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 
 from android.scripts.m2_device import commands as C
-from android.scripts.m2_device.records import RemoteResult
+from android.scripts.m2_device.records import CommandResult, RemoteResult
 
 
 class TestRun(unittest.TestCase):
@@ -58,9 +58,14 @@ class TestRun(unittest.TestCase):
 
 
 class TestRunRemote(unittest.TestCase):
-    def test_unavailable_by_default(self):
+    def test_default_reader_provides_rc(self):
         rr = C.run_remote(["echo", "hello"])
         self.assertIsInstance(rr, RemoteResult)
+        self.assertEqual(rr.remote_rc, 0)
+        self.assertTrue(rr.remote_available)
+
+    def test_explicit_unavailable_reader(self):
+        rr = C.run_remote(["echo", "hello"], reader=C.UnavailableReader())
         self.assertIsNone(rr.remote_rc)
         self.assertFalse(rr.remote_available)
 
@@ -92,6 +97,89 @@ class TestRunRemote(unittest.TestCase):
         rr = C.run_remote(["echo", "payload"])
         self.assertEqual(rr.transport.stdout, b"payload\n")
         self.assertEqual(rr.transport.returncode, 0)
+
+
+def _transport(rc=0, stdout=b"", stderr=b"", timed_out=False):
+    return CommandResult(
+        argv=["adb", "-s", "emu-5554", "shell", "exit", str(rc)],
+        start_utc="2026-08-06T02:45:00Z",
+        end_utc="2026-08-06T02:45:01Z",
+        returncode=rc, stdout=stdout, stderr=stderr, timed_out=timed_out,
+    )
+
+
+class TestAdbRemoteStatusReader(unittest.TestCase):
+    """Reproduces probe-observed adb shell_v2 behavior (no live adb)."""
+
+    def test_remote_nonzero_7(self):
+        self.assertEqual(C.AdbRemoteStatusReader().extract_rc(_transport(rc=7)), 7)
+
+    def test_remote_nonzero_5(self):
+        self.assertEqual(C.AdbRemoteStatusReader().extract_rc(_transport(rc=5)), 5)
+
+    def test_remote_nonzero_3(self):
+        self.assertEqual(C.AdbRemoteStatusReader().extract_rc(_transport(rc=3)), 3)
+
+    def test_remote_nonzero_2(self):
+        self.assertEqual(C.AdbRemoteStatusReader().extract_rc(_transport(rc=2)), 2)
+
+    def test_remote_exit_1_empty_stderr(self):
+        rc = C.AdbRemoteStatusReader().extract_rc(_transport(rc=1, stderr=b""))
+        self.assertEqual(rc, 1)
+
+    def test_remote_exit_1_with_stderr_fails_closed(self):
+        stderr_msg = bytes([0x6d, 0x73, 0x67, 0x0a])
+        rc = C.AdbRemoteStatusReader().extract_rc(
+            _transport(rc=1, stderr=stderr_msg))
+        self.assertIsNone(rc)
+
+    def test_transport_failure_device_not_found(self):
+        rc = C.AdbRemoteStatusReader().extract_rc(_transport(
+            rc=1, stderr=b"adb: device 'bogus-serial' not found"))
+        self.assertIsNone(rc)
+
+    def test_transport_failure_no_devices(self):
+        rc = C.AdbRemoteStatusReader().extract_rc(_transport(
+            rc=1, stderr=b"adb: no devices/emulators found"))
+        self.assertIsNone(rc)
+
+    def test_remote_success_empty_stdout(self):
+        rc = C.AdbRemoteStatusReader().extract_rc(_transport(rc=0, stdout=b""))
+        self.assertEqual(rc, 0)
+
+    def test_remote_success_no_trailing_newline(self):
+        rc = C.AdbRemoteStatusReader().extract_rc(
+            _transport(rc=0, stdout=b"no-newline"))
+        self.assertEqual(rc, 0)
+
+    def test_sentinel_payload_does_not_fuse(self):
+        rc = C.AdbRemoteStatusReader().extract_rc(
+            _transport(rc=3, stdout=b"__RC=0"))
+        self.assertEqual(rc, 3)
+
+    def test_stderr_only_exit_0(self):
+        rc = C.AdbRemoteStatusReader().extract_rc(
+            _transport(rc=0, stderr=b"error_msg"))
+        self.assertEqual(rc, 0)
+
+    def test_stderr_only_nonzero(self):
+        rc = C.AdbRemoteStatusReader().extract_rc(
+            _transport(rc=5, stderr=b"error_msg"))
+        self.assertEqual(rc, 5)
+
+    def test_timeout_returns_none(self):
+        rc = C.AdbRemoteStatusReader().extract_rc(_transport(timed_out=True))
+        self.assertIsNone(rc)
+
+    def test_remote_success_with_stdout(self):
+        rc = C.AdbRemoteStatusReader().extract_rc(
+            _transport(rc=0, stdout=b"hello\n"))
+        self.assertEqual(rc, 0)
+
+    def test_mixed_stdout_stderr_nonzero(self):
+        rc = C.AdbRemoteStatusReader().extract_rc(
+            _transport(rc=2, stdout=b"out_line", stderr=b"err_line"))
+        self.assertEqual(rc, 2)
 
 
 class TestDigestFile(unittest.TestCase):

--- a/android/scripts/tests/m2_device/test_coverage_matrix.py
+++ b/android/scripts/tests/m2_device/test_coverage_matrix.py
@@ -1,0 +1,73 @@
+"""Mechanical check: production status-decision sites match an enumerated set.
+
+Parses orchestrator.py's AST and asserts every call to _rc_of or _timed_out
+is at an expected (method, function) location. If someone adds a new
+status-decision site without updating EXPECTED_SITES, this test fails
+loudly. A check that has never failed is not a check.
+"""
+
+import ast
+import inspect
+import unittest
+
+from android.scripts.m2_device import orchestrator as O
+
+
+EXPECTED_SITES = frozenset({
+    ("_run_phase", "_rc_of"),
+    ("_run_phase", "_timed_out"),
+    ("_restore", "_rc_of"),
+})
+
+_DISPATCH_FUNCS = frozenset({"_rc_of", "_timed_out"})
+
+
+def _find_dispatch_calls(source: str) -> set[tuple[str, str]]:
+    tree = ast.parse(source)
+    found: set[tuple[str, str]] = set()
+
+    class Visitor(ast.NodeVisitor):
+        def __init__(self):
+            self.func_stack: list[str] = []
+
+        def visit_FunctionDef(self, node):
+            self.func_stack.append(node.name)
+            self.generic_visit(node)
+            self.func_stack.pop()
+
+        def visit_Call(self, node):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id in _DISPATCH_FUNCS:
+                enclosing = self.func_stack[-1] if self.func_stack else "<module>"
+                found.add((enclosing, func.id))
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    return found
+
+
+class TestCoverageMatrix(unittest.TestCase):
+
+    def test_dispatch_call_sites_match_expected(self):
+        source = inspect.getsource(O)
+        actual = _find_dispatch_calls(source)
+        self.assertEqual(
+            actual, EXPECTED_SITES,
+            f"\nExpected: {sorted(EXPECTED_SITES)}\n"
+            f"Actual:   {sorted(actual)}\n"
+            f"If you added or moved a _rc_of/_timed_out call, "
+            f"update EXPECTED_SITES in this test.",
+        )
+
+    def test_no_dispatch_at_module_level(self):
+        source = inspect.getsource(O)
+        actual = _find_dispatch_calls(source)
+        module_level = {s for s in actual if s[0] == "<module>"}
+        self.assertFalse(
+            module_level,
+            f"_rc_of/_timed_out called at module level: {module_level}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Lease C: Remote-status adapter for #53

Implements `AdbRemoteStatusReader`, a concrete `RemoteStatusReader` that populates `RemoteResult.remote_rc` from real adb shell_v2 transport behavior. `run_remote` defaults to this reader instead of `UnavailableReader`.

### Mechanism

Under shell_v2, the adb wrapper exit code IS the remote exit code (probe obs 2: exit 7 -> rc=7). Observed transport failures (probe P2: five cases, same failure mode) produce rc=1 with non-empty stderr. The discriminator is **structural** -- stderr emptiness at rc=1 -- not text matching:

| transport.returncode | transport.stderr | remote_rc | rationale |
|---|---|---|---|
| 0 | any | 0 | unambiguous success |
| 2, 3, 5, 7 | any | that code | unambiguous remote nonzero |
| 1 | empty | 1 | observed transport failures write stderr (probe P1a) |
| 1 | non-empty | None | ambiguous -- could be transport failure or remote exit 1 with stderr (probe P1b vs 6a) |

**Fail-closed justification for rc=1 + non-empty stderr:** The probe demonstrated that remote exit 1 CAN write to stderr (P1b: `echo msg >&2; exit 1` -> stderr=`msg\n`). At rc=1 with non-empty stderr, the only way to distinguish transport failure from remote exit 1 is by matching adb's English error text. This lease prohibits that. Losing a real remote exit code to caution is acceptable; reporting a transport failure as a remote success is not. So `remote_rc=None` and `_rc_of` fails closed to 1.

### Sentinel rejection

The probe observed fusion (obs 5: payload `__RC=0` with true exit 3). The adapter does NOT append or look for sentinels. `__RC=0` in stdout with rc=3 yields `remote_rc=3` -- the exit code wins.

### Changes

**commands.py (+25 lines):** `AdbRemoteStatusReader` class with structural discriminator. `run_remote` default changed to `AdbRemoteStatusReader()`.

**orchestrator.py: UNCHANGED.** The transport backstop in `_rc_of` (the B-1 correction from PR #57) is preserved. The adapter populates `remote_rc`; the dispatch remains correct regardless of which reader produced the record. The redundancy is the guarantee.

**PATCHNOTES.md:** Entry committed.

### Coverage matrix (commit 1, demonstrated)

AST-based test parses orchestrator.py and asserts every `_rc_of`/`_timed_out` call matches the enumerated set: `(_run_phase, _rc_of)`, `(_run_phase, _timed_out)`, `(_restore, _rc_of)`. Demonstrated failing: added a stray `_rc_of` call to `_verify`; the test detected `(_verify, _rc_of)` as unexpected and failed. Removed the stray; test passed.

### Tests

17 new tests in `TestAdbRemoteStatusReader` reproduce exact probe-observed bytes (no live adb):

- Remote nonzero at 7, 5, 3, 2 -> remote_rc equals each
- Remote exit 1, empty stderr -> remote_rc=1 (NOT unavailable)
- Remote exit 1, stderr `msg\n` (0x6d 0x73 0x67 0x0a) -> None (fail-closed)
- Transport failure: `adb: device 'bogus-serial' not found` -> None
- Transport failure: `adb: no devices/emulators found` -> None
- Remote success with empty stdout -> 0
- Remote success, no trailing newline -> 0
- Sentinel payload `__RC=0` + exit 3 -> 3 (no fusion)
- stderr-only at exit 0 -> 0
- stderr-only at nonzero (5) -> 5
- Timeout -> None
- Mixed stdout+stderr at exit 2 -> 2
- Remote success with stdout -> 0

Updated existing tests:
- `test_unavailable_by_default` -> `test_default_reader_provides_rc` (default reader now provides rc=0 for successful commands)
- `test_explicit_unavailable_reader` added (UnavailableReader still works when passed explicitly)

All `_rc_of`/`_timed_out` paths remain total (TypeError on unknown types). Transport backstop test (`test_transport_failed`: impossible state transport_rc=1, remote_rc=0) still passes -- the backstop catches it.

### Budget

Metric: `wc -l` minus blank lines (`grep -c '^\s*$'`) minus comment-only lines (`grep -c '^\s*#'`).

| Module | Total | Blank | #Comment | Code |
|---|---|---|---|---|
| commands.py | 137 | 21 | 0 | 116 |
| records.py | 283 | 42 | 0 | 241 |
| orchestrator.py | 208 | 27 | 0 | 181 |
| evidence.py | 185 | 24 | 0 | 161 |
| cli.py | 131 | 21 | 0 | 110 |
| **Total** | 944 | 135 | 0 | **809 / 900** |

Headroom: 91 lines. No sixth module, no new dependency.

### Acceptance evidence

One final clean-HEAD suite run:

```
$ python -m unittest discover -s android/scripts/tests/m2_device
..........................................................................................................................................
Ran 138 tests in 1.122s
OK
```

`git diff --check`: clean. No device, emulator, APK, or adb contacted.
