### PR TITLE
fix(ui): expose Loading cancellation

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,18 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-08-10 — The Loading row learns the word "Cancel"
+
+- While PersonaSpeak is thinking, the row now shows a Cancel button next
+  to the spinner. This is not a second cancellation path; it is the
+  existing one (`onDismiss` → `RewritePanelViewModel.dismiss()`, which
+  drops the in-flight request) finally given somewhere to be tapped.
+  Idle, Message, and Review are unchanged — Review keeps its own
+  Dismiss. The control clears the 48dp touch minimum, carries the
+  `personaspeak_cancel` test tag, and exists only in Loading. Closes
+  the M2 contradiction where the qualification journey required a
+  Loading/cancel control the row did not render (#60).
+
 ## 2026-08-06 — The inspector learns to read exit codes without reading minds
 
 - `RemoteResult.remote_rc` is no longer set to None by default and left

--- a/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewritePanel.kt
+++ b/android/personaspeak-ui/src/main/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewritePanel.kt
@@ -84,6 +84,7 @@ fun RewritePanel(
             CompactLayout(
                 state = state,
                 onRewrite = onRewrite,
+                onDismiss = onDismiss,
                 onSettings = onSettings,
             )
         }
@@ -95,6 +96,7 @@ fun RewritePanel(
 private fun CompactLayout(
     state: RewritePanelState,
     onRewrite: () -> Unit,
+    onDismiss: () -> Unit,
     onSettings: () -> Unit,
 ) {
     Row(
@@ -124,6 +126,14 @@ private fun CompactLayout(
                         .testTag("personaspeak_loading"),
                     strokeWidth = 2.dp,
                 )
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier
+                        .heightIn(min = MinInteractiveHeight)
+                        .testTag("personaspeak_cancel"),
+                ) {
+                    Text("Cancel")
+                }
             }
 
             is RewritePanelState.Message -> {

--- a/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewritePanelTest.kt
+++ b/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewritePanelTest.kt
@@ -1,12 +1,15 @@
 package biz.pixelperfectstudios.personaspeak.ui.rewrite
 
+import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import biz.pixelperfectstudios.personaspeak.ui.editor.EditorSessionToken
 import biz.pixelperfectstudios.personaspeak.ui.editor.EditorSnapshot
@@ -58,13 +61,14 @@ class RewritePanelTest {
     private fun setPanel(
         state: RewritePanelState,
         preExpansionImeHeightPx: Int = 1000,
+        onDismiss: () -> Unit = {},
     ) {
         composeRule.setContent {
             RewritePanel(
                 state = state,
                 onRewrite = {},
                 onApply = {},
-                onDismiss = {},
+                onDismiss = onDismiss,
                 onSettings = {},
                 preExpansionImeHeightPx = { preExpansionImeHeightPx },
             )
@@ -84,13 +88,52 @@ class RewritePanelTest {
     }
 
     @Test
-    fun `loading exposes a loading indicator and keeps settings reachable`() {
+    fun `loading exposes a loading indicator, a 48dp cancel control, and settings`() {
         setPanel(RewritePanelState.Loading)
 
         composeRule.onNodeWithTag("personaspeak_loading").assertIsDisplayed()
+        composeRule.onNodeWithTag("personaspeak_cancel")
+            .assertIsDisplayed()
+            .assertHeightIsAtLeast(48.dp)
         composeRule.onNodeWithTag("personaspeak_settings")
             .assertIsDisplayed()
             .assertHeightIsAtLeast(48.dp)
+    }
+
+    @Test
+    fun `loading cancel invokes the dismiss callback`() {
+        var dismissCount = 0
+        setPanel(RewritePanelState.Loading, onDismiss = { dismissCount++ })
+
+        composeRule.onNodeWithTag("personaspeak_cancel").performClick()
+
+        assertEquals(
+            "Loading Cancel must route through the existing onDismiss path",
+            1,
+            dismissCount,
+        )
+    }
+
+    @Test
+    fun `idle has no cancel control`() {
+        setPanel(RewritePanelState.Idle)
+
+        composeRule.onNodeWithTag("personaspeak_cancel").assertDoesNotExist()
+    }
+
+    @Test
+    fun `message has no cancel control`() {
+        setPanel(RewritePanelState.Message(RewriteMessage.ProviderFailure))
+
+        composeRule.onNodeWithTag("personaspeak_cancel").assertDoesNotExist()
+    }
+
+    @Test
+    fun `review uses its own dismiss control, not the loading cancel`() {
+        setPanel(RewritePanelState.Review(candidate))
+
+        composeRule.onNodeWithTag("personaspeak_cancel").assertDoesNotExist()
+        composeRule.onNodeWithTag("personaspeak_dismiss").assertIsDisplayed()
     }
 
     @Test

--- a/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewritePanelTest.kt
+++ b/android/personaspeak-ui/src/test/kotlin/biz/pixelperfectstudios/personaspeak/ui/rewrite/RewritePanelTest.kt
@@ -1,10 +1,10 @@
 package biz.pixelperfectstudios.personaspeak.ui.rewrite
 
-import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
@@ -118,21 +118,21 @@ class RewritePanelTest {
     fun `idle has no cancel control`() {
         setPanel(RewritePanelState.Idle)
 
-        composeRule.onNodeWithTag("personaspeak_cancel").assertDoesNotExist()
+        assertCancelNodeCount(0)
     }
 
     @Test
     fun `message has no cancel control`() {
         setPanel(RewritePanelState.Message(RewriteMessage.ProviderFailure))
 
-        composeRule.onNodeWithTag("personaspeak_cancel").assertDoesNotExist()
+        assertCancelNodeCount(0)
     }
 
     @Test
     fun `review uses its own dismiss control, not the loading cancel`() {
         setPanel(RewritePanelState.Review(candidate))
 
-        composeRule.onNodeWithTag("personaspeak_cancel").assertDoesNotExist()
+        assertCancelNodeCount(0)
         composeRule.onNodeWithTag("personaspeak_dismiss").assertIsDisplayed()
     }
 
@@ -179,6 +179,22 @@ class RewritePanelTest {
         assertTrue(
             "review body $height exceeds the 120dp cap",
             height <= 120.dp,
+        )
+    }
+
+    /**
+     * Absence/presence of `personaspeak_cancel` as a direct node count. The
+     * pinned Compose BOM (2025.05.01 / ui-test 1.8.2) does not resolve
+     * `assertDoesNotExist`, so the count is measured directly — the same
+     * fallback the cap test above uses for an unavailable convenience
+     * assertion.
+     */
+    private fun assertCancelNodeCount(expected: Int) {
+        assertEquals(
+            "personaspeak_cancel node count",
+            expected,
+            composeRule.onAllNodesWithTag("personaspeak_cancel")
+                .fetchSemanticsNodes().size,
         )
     }
 }


### PR DESCRIPTION
## What

PersonaSpeak's Loading row now exposes the existing cancellation path as a
48dp `Cancel` control. The change remains Loading-only; Idle and Message stay
compact, while Review keeps its separate Dismiss action.

## Why

The M2 qualification contract requires a visible Loading/cancel journey, but
the shipped Loading state rendered only a spinner and Settings. This small
correction makes the required behavior operable before the production harness
and final device qualification proceed.

Fixes #60.

## Evidence

- **Commands run + output:** `git diff --check origin/main...dcdc71257228b0939981c39dbbcabe27599b78e9` passed with exit 0 and no output. All four GitHub CI jobs succeeded at that exact head, including the Milestone 2 gate.
- **Screenshots / goldens:** Not captured. Lease 60-A is device-free and grants no AVD authority.
- **Journey recording:** Not captured for the same device-free boundary. Final runtime proof remains in #55.
- **Graded by:** Sigrid Nyström, non-author, OpenAI model family. Exact-head verdict: https://github.com/apexcloudwise/personaspeak/pull/61#issuecomment-5236467477

## Patch note

While PersonaSpeak is thinking, the row now shows a Cancel button next to the
spinner. It uses the existing cancellation path; the button has merely acquired
somewhere to exist, which is usually considered helpful for buttons.

## Checklist

- [x] Tests ride with the code (regression test, if this fixes a bug)
- [x] Goldens updated and explained (none changed)
- [x] Docs in this PR (no ADR or schema change required)
- [x] `desktop/personaspeak.py --list` + golden tests pass, if `personas/` or prompt code was touched (not applicable)
- [x] Patch-note entry committed to `PATCHNOTES.md` (not just pasted above)
- [x] Graded by a non-author (or "review skipped: <reason>" stated above)
- [x] CI is green
- [x] Nothing here stores what a user typed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Cancel** button to PersonaSpeak’s loading state.
  * Cancel is available only while content is loading and meets accessibility touch-target requirements.
  * Existing idle, message, and review states remain unchanged.

* **Documentation**
  * Added patch notes for the new loading-state cancellation control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->