### PR TITLE
ci: defer Android gate for draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   personas-and-cli:
@@ -72,6 +73,9 @@ jobs:
 
   android-build:
     name: Milestone 2 gate
+    # Draft integration PRs receive the cheap checks above; run the costly
+    # Android qualification when the PR is ready, and always on main pushes.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Parent: #59.

Draft integration PRs continue to run the cheap persona/CLI, patch-note, and device-free M2 Python checks, but skip the costly Android qualification job. Ready child PRs and pushes to `main` retain the full gate.

Adding `ready_for_review` to the pull-request activity types ensures converting a draft to ready immediately runs the expensive gate.

Evidence:
- workflow YAML parses successfully;
- `git diff --check` passes;
- the only changed path is `.github/workflows/ci.yml`;
- no product, fixture, evidence, schema, or device behavior changes.

This CI-only PR intentionally carries the loud `no-patchnote` escape hatch.