### PR TITLE
fix(issue-65): reap the exited emulator, observed identity, private atomic ledger

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -35,6 +35,39 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-08-16 (later that day) — The corpse is identified, reaped, and given a clean receipt
+
+- Post-merge review round (two independent findings sets, same P1): a
+  crashed or failed-boot emulator — the most common non-nominal path —
+  was refused by cleanup instead of reaped. `ps` reports an unreaped
+  leader as `<defunct>`, which failed the argv match, stamped the run
+  `CLEANUP_PARTIAL`, and dropped the only handle. `release_emulator` now
+  polls and reaps an already-exited leader first and returns a clean
+  release, never group-terminating after the reap (a freed pid's group
+  could belong to someone else by then).
+- Live-process validation now compares start-time continuity against an
+  identity *observed from the process* and retained at launch/ownership —
+  launch argv is not a stable runtime identity, because the SDK emulator
+  launcher execs its engine and engines rewrite their titles.
+  `establish_ownership` rejects unrecognizable commands (a bare
+  `<defunct>` among them) via start-continuity plus executable-or-AVD
+  tokens, space-tolerant for SDK paths.
+- The command ledger gains the one entry it was missing — the emulator
+  launch itself (`kind="launch"`). `dump_ledger` now writes privately
+  (0600) and atomically (same-dir temp file, fsync, `os.replace`), so an
+  interrupted write can no longer report `COMPLETED` over a truncated
+  file. A signal arriving during cleanup always leaves a recorded step,
+  even when a primary cause already holds the terminal. The fallback PID
+  lifecycle validates identity before its *first* signal, group-liveness
+  checks no longer count unreaped zombies as survivors (macOS `killpg(0)`
+  EPERM quirk included), the launch phase moved inside the cleanup guard
+  so a signal in the launch window converges to release, and
+  screenrecord is now stopped explicitly (SIGTERM accepted as a normal
+  stop, closing the 30-second-limit vs 15-second-finish disagreement).
+  Ten new regressions, including a real exec-transformed process and a
+  real zombie-held group.
+
+---
 
 ## 2026-08-13 — The test suite learns to mind its own environment
 

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 import socket
+import tempfile
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from typing import Any
@@ -120,6 +121,7 @@ class AdbHarness:
         self.screenrecord_process: commands.ManagedProcess | None = None
         self._owned_pid: int | None = None
         self._owned_identity: commands.ProcessIdentity | None = None
+        self._launch_identity: commands.ProcessIdentity | None = None
         self._session_launched = False
         self.ledger = commands.CommandLedger()
 
@@ -213,6 +215,14 @@ class AdbHarness:
         self.emulator_process = self.starter(argv, new_session=True)
         self._session_launched = True
         pid = self.emulator_process.proc.pid
+        # Observed from the process itself immediately after launch —
+        # never copied from expectations. The start time survives a
+        # launcher exec/title rewrite; the command line may not.
+        self._launch_identity = commands.pid_identity(pid)
+        self.ledger.record(
+            argv, self.emulator_process.start_utc, _UTC(),
+            0, None, False, "launch",
+        )
         msg = (
             f"launched pid={pid} start={self.emulator_process.start_utc}"
             f" exe={self.emulator_tool.path} avd={AVD_NAME}"
@@ -227,6 +237,20 @@ class AdbHarness:
         identity = commands.pid_identity(pid)
         if identity is None:
             return self._fail("ownership", f"pid {pid} not running".encode())
+        if (self._launch_identity is not None
+                and identity.start != self._launch_identity.start):
+            return self._fail(
+                "ownership",
+                b"start-time discontinuity - pid reuse suspected")
+        exe = self.emulator_process.argv[0]
+        if not (self._token_in(exe, identity.command)
+                or AVD_NAME in identity.command):
+            # Neither the launched executable nor the pinned AVD appears
+            # in the observed command (a zombie reports "<defunct>"):
+            # refuse to own what we cannot recognize.
+            return self._fail(
+                "ownership",
+                b"observed command matches neither executable nor AVD")
         self._owned_pid = pid
         self._owned_identity = identity
         return self._ok(
@@ -696,10 +720,17 @@ class AdbHarness:
         local_vid = os.path.join(evidence_dir, "journey.mp4")
         if self.screenrecord_process is not None:
             try:
+                # We stop the recorder ourselves: a journey shorter than
+                # --time-limit would otherwise outlive the finish window
+                # and be classified as a timeout. A wrapper rc of -15/143
+                # is our SIGTERM, not a failure — the file finalizes on
+                # the device when the shell connection drops.
                 rec = self._shell_finish(
-                    self.screenrecord_process, timeout=15.0)
+                    self.screenrecord_process, timeout=15.0, terminate=True)
                 if rec.transport.timed_out:
                     errors.append("screenrecord timed out")
+                elif rec.transport.returncode in (-15, 143):
+                    pass
                 elif rec.remote_rc is None:
                     errors.append("screenrecord status ambiguous")
                 elif rec.transport.returncode != 0 or rec.remote_rc != 0:
@@ -765,24 +796,27 @@ class AdbHarness:
             return False
         return current == self._owned_identity
 
+    @staticmethod
+    def _token_in(token: str, command: str) -> bool:
+        """Whitespace-token containment that tolerates spaces inside
+        *token* (SDK paths often contain them)."""
+        return f" {token} " in f" {command} "
+
     def _identity_matches_launch(
         self, identity: commands.ProcessIdentity,
     ) -> bool:
-        """Provisional ownership: the observed command must be the
-        process we launched — same executable, same AVD token — read
-        from the live process, never from our expectations.
-
-        The executable is matched as a whitespace token, not a prefix:
-        shebang-launched scripts appear in ``ps`` behind their
-        interpreter (``python3 /path/to/emulator -avd ...``)."""
+        """Fallback provisional-ownership check for the case where no
+        identity was observed at launch: the observed command must carry
+        the launched executable and AVD tokens — read from the live
+        process. Shebang-launched scripts appear in ``ps`` behind their
+        interpreter, hence token matching rather than a prefix."""
         launched = (
             self.emulator_process.argv if self.emulator_process is not None
             else None
         )
         if not launched:
             return False
-        exe = launched[0]
-        if exe not in identity.command.split():
+        if not self._token_in(launched[0], identity.command):
             return False
         if AVD_NAME in launched and AVD_NAME not in identity.command:
             return False
@@ -792,33 +826,70 @@ class AdbHarness:
         evidence_dir = os.path.join(self.run_dir, "artifacts")
         os.makedirs(evidence_dir, exist_ok=True)
         path = os.path.join(evidence_dir, "command_ledger.json")
+        tmp_path = None
         try:
-            with open(path, "w") as fh:
+            # Private (0600) and atomic: an interrupted write can never
+            # leave a truncated artifact behind the 0-return-code path.
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=".command_ledger.", dir=evidence_dir)
+            with os.fdopen(fd, "w") as fh:
                 fh.write(self.ledger.serialize())
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_path, path)
+            tmp_path = None
             return self._ok("ledger", f"{len(self.ledger)} entries -> {path}".encode())
         except OSError as e:
             return self._fail("ledger", str(e).encode())
+        finally:
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
 
     def release_emulator(self) -> CommandResult:
         if self.emulator_process is not None:
             proc = self.emulator_process.proc
+            if proc.poll() is not None:
+                # The leader already exited — crashed emulator, failed
+                # boot, the most common non-nominal path. Reap it and
+                # report a clean release. Never group-terminate after
+                # the reap: the pid is free and a pgid fallback could
+                # target an unrelated recycled group.
+                try:
+                    proc.communicate(timeout=5.0)
+                except Exception:
+                    pass
+                self.emulator_process = None
+                return self._ok(
+                    "release", b"released (process already exited)")
             identity = commands.pid_identity(proc.pid)
-            if identity is None and proc.poll() is None:
+            if identity is None:
                 # Running but unobservable: we cannot prove ownership,
                 # so we refuse to signal it.
                 self.emulator_process = None
                 return self._fail(
                     "release", b"identity unobservable - refuse kill")
-            if identity is not None and not self._identity_matches_launch(identity):
+            retained = self._owned_identity or self._launch_identity
+            if retained is not None:
+                # Start-time continuity against an identity observed
+                # from the process itself. The command line may change
+                # legitimately (launcher exec of the engine, process
+                # title rewrites); a different start time means the
+                # original is gone and this pid may be reused — refuse.
+                if identity.start != retained.start:
+                    self.emulator_process = None
+                    return self._fail(
+                        "release",
+                        b"identity changed (pid reuse) - refuse kill")
+            elif not self._identity_matches_launch(identity):
+                # No launch observation was retained: fall back to
+                # launch-argv tokens as the only available evidence.
                 self.emulator_process = None
                 return self._fail(
-                    "release", b"identity does not match launch - refuse kill")
-            if (identity is not None and self._owned_pid == proc.pid
-                    and self._owned_identity is not None
-                    and identity != self._owned_identity):
-                self.emulator_process = None
-                return self._fail(
-                    "release", b"PID reuse detected - refuse kill")
+                    "release",
+                    b"identity does not match launch - refuse kill")
             try:
                 outcome = commands.bounded_terminate(
                     proc, group=self._session_launched)

--- a/android/scripts/m2_device/commands.py
+++ b/android/scripts/m2_device/commands.py
@@ -247,10 +247,36 @@ def _group_alive(pgid: int) -> bool:
         os.killpg(pgid, 0)
     except ProcessLookupError:
         return False
-    except PermissionError:
-        return True
     except OSError:
-        return False
+        # EPERM on a zombie-held group (macOS) — fall through.
+        pass
+    # killpg(0) succeeds for unreaped zombies (Linux) and is
+    # inconclusive on macOS zombie groups; only a live member keeps
+    # the group meaningfully alive. ps decides; on ps failure fail
+    # conservative (alive).
+    return _group_has_live_member(pgid)
+
+
+def _group_has_live_member(pgid: int) -> bool:
+    for ps_path in ("/bin/ps", "/usr/bin/ps"):
+        if not (os.path.isfile(ps_path) and os.access(ps_path, os.X_OK)):
+            continue
+        try:
+            listing = subprocess.run(
+                [ps_path, "-eo", "pgid=,stat="],
+                capture_output=True, timeout=5,
+            )
+            if listing.returncode != 0:
+                return True
+            for line in listing.stdout.decode(
+                    "utf-8", errors="replace").splitlines():
+                fields = line.split(None, 1)
+                if len(fields) == 2 and int(fields[0]) == pgid:
+                    if not fields[1].strip().startswith("Z"):
+                        return True
+            return False
+        except (OSError, ValueError, subprocess.TimeoutExpired):
+            return True
     return True
 
 
@@ -372,10 +398,13 @@ def bounded_terminate_pid(
 ) -> bool:
     """Bounded validated lifecycle for a process whose handle was dropped.
 
-    SIGTERM → bounded identity wait → SIGKILL → bounded wait. Signals
-    only while *pid* still carries *identity*; pid reuse is never
-    signaled. Returns True when SIGKILL was required.
+    SIGTERM → bounded identity wait → SIGKILL → bounded wait. The
+    identity is validated before every signal, including the first; a
+    pid reuse is never signaled. Returns True when SIGKILL was required.
     """
+    current = pid_identity(pid)
+    if current is None or current != identity:
+        return False
     try:
         os.kill(pid, signal.SIGTERM)
     except (OSError, ProcessLookupError):

--- a/android/scripts/m2_device/orchestrator.py
+++ b/android/scripts/m2_device/orchestrator.py
@@ -114,14 +114,25 @@ class Orchestrator:
         self.fixture_receipt_digest = ""
 
     def _on_signal(self, signum, frame):
+        if self._in_cleanup:
+            # Recorded, never raised: cleanup must complete. The step
+            # guarantees the interruption stays visible even when a
+            # primary cause already holds the terminal slot.
+            if self.terminal is None:
+                self.terminal = TerminalCause.SIGNAL_INTERRUPT
+            self.steps.append(_make_step(
+                "signal", f"signal {signum} during cleanup",
+                CommandResult(
+                    argv=[], start_utc="", end_utc="", returncode=0,
+                    stdout=f"signum={signum}".encode(), stderr=b""),
+                TerminalCause.SIGNAL_INTERRUPT))
+            return
         if self.terminal is None:
             self.terminal = TerminalCause.SIGNAL_INTERRUPT
-        if not self._in_cleanup:
-            # Interrupt the active phase (blocked subprocesses included)
-            # so the run converges into bounded cleanup instead of
-            # sleeping out its command timeout. During cleanup the
-            # signal is only recorded — cleanup must complete.
-            raise commands.SignalInterrupt(signum)
+        # Interrupt the active phase (blocked subprocesses included)
+        # so the run converges into bounded cleanup instead of
+        # sleeping out its command timeout.
+        raise commands.SignalInterrupt(signum)
 
     def execute(self) -> CaptureRecord:
         prev_int = signal.signal(signal.SIGINT, self._on_signal)
@@ -163,12 +174,14 @@ class Orchestrator:
             self.terminal = TerminalCause.FIXTURE_MISMATCH
             return self._record()
 
-        self._emulator_launched = True
-        self._run_phase("emulator_launch", "boot pinned snapshot",
-                        lambda: self.harness.launch_emulator())
-
         try:
             try:
+                # Launched inside the try: a signal arriving during the
+                # launch window must converge into release, not escape
+                # past the cleanup guard.
+                self._emulator_launched = True
+                self._run_phase("emulator_launch", "boot pinned snapshot",
+                                lambda: self.harness.launch_emulator())
                 if not self.terminal:
                     self._run_phase("attach", "adb attach serial",
                                     lambda: self.harness.attach())

--- a/android/scripts/tests/m2_device/test_adb_harness.py
+++ b/android/scripts/tests/m2_device/test_adb_harness.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import os
+import stat
+import subprocess
+import sys
 import tempfile
+import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -473,7 +478,8 @@ class TestAdbHarness(unittest.TestCase):
 
         res = self.harness.release_emulator()
         self.assertEqual(res.returncode, 0)
-        mock_process.proc.send_signal.assert_called_once()
+        self.assertIn(b"already exited", res.stdout)
+        mock_process.proc.communicate.assert_called_once()
         self.assertIsNone(self.harness.emulator_process)
 
     def test_release_emulator_fallback(self):
@@ -608,7 +614,7 @@ class TestScreenrecordBoundary(unittest.TestCase):
         self.assertEqual(res.returncode, 1)
         self.assertIn(b"screenrecord rc=3", res.stderr)
 
-    def test_restore_finishes_and_ledgers_recording(self):
+    def test_release_finishes_and_ledgers_recording(self):
         mp = self._recording()
         self.harness.screenrecord_process = mp
         self.mock_runner.return_value = _cr(rc=0)
@@ -619,6 +625,125 @@ class TestScreenrecordBoundary(unittest.TestCase):
             mp, timeout=5.0, terminate=True)
         self.assertIsNone(self.harness.screenrecord_process)
         self.assertEqual(len(self.harness.ledger.entries()), 2)
+
+    def test_capture_evidence_accepts_sigterm_stopped_recording(self):
+        self._stage_valid_media()
+        self.mock_finisher.return_value = _cr(rc=-15)
+        self.harness.screenrecord_process = self._recording()
+        res = self.harness.capture_evidence()
+        self.assertEqual(res.returncode, 0)
+        self.assertNotIn(b"screenrecord", res.stderr)
+
+    def test_launch_emulator_records_launch_ledger_entry(self):
+        self.harness.emulator_tool = ToolIdentity(
+            name="emulator", path="/usr/bin/emulator", version="1.0")
+        real_proc = subprocess.Popen(["sleep", "30"])
+        self.mock_starter.return_value = commands.ManagedProcess(
+            proc=real_proc,
+            argv=["/usr/bin/emulator", "-avd", "M2_Qual_Fixture",
+                  "-snapshot", "m2_pristine", "-no-snapshot-save",
+                  "-port", "5554"],
+            start_utc="2026-08-16T12:00:00Z", new_session=True)
+        try:
+            res = self.harness.launch_emulator()
+            self.assertEqual(res.returncode, 0)
+            entries = self.harness.ledger.entries()
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0].kind, "launch")
+            self.assertIn("M2_Qual_Fixture", " ".join(entries[0].argv))
+            self.assertIsNotNone(self.harness._launch_identity)
+        finally:
+            real_proc.terminate()
+            real_proc.wait()
+
+    def test_establish_ownership_rejects_defunct_identity(self):
+        self.harness.emulator_process = commands.ManagedProcess(
+            proc=MagicMock(),
+            argv=["/usr/bin/emulator", "-avd", "M2_Qual_Fixture"],
+            start_utc="2026-08-16T12:00:00Z")
+        with patch(
+            "android.scripts.m2_device.commands.pid_identity",
+            return_value=commands.ProcessIdentity(
+                start="Sun Aug 16 12:00:00 2026", command="<defunct>"),
+        ):
+            res = self.harness.establish_ownership()
+        self.assertEqual(res.returncode, 1)
+        self.assertIn(b"neither executable nor AVD", res.stderr)
+
+    def test_establish_ownership_accepts_exec_engine_command(self):
+        # The SDK launcher execs its engine: the command line changes
+        # but keeps the pinned AVD; start time is continuous.
+        self.harness.emulator_process = commands.ManagedProcess(
+            proc=MagicMock(),
+            argv=["/usr/bin/emulator", "-avd", "M2_Qual_Fixture"],
+            start_utc="2026-08-16T12:00:00Z")
+        observed = commands.ProcessIdentity(
+            start="Sun Aug 16 12:00:00 2026",
+            command="/sdk/qemu-system-arm64-headless -avd M2_Qual_Fixture -port 5554")
+        with patch(
+            "android.scripts.m2_device.commands.pid_identity",
+            return_value=observed,
+        ):
+            res = self.harness.establish_ownership()
+        self.assertEqual(res.returncode, 0)
+        self.assertEqual(self.harness._owned_identity, observed)
+
+    def test_release_reaps_already_exited_process(self):
+        # The P1: a crashed emulator must be reaped and reported clean,
+        # not refused as an identity mismatch (<defunct>).
+        proc = subprocess.Popen(
+            ["sleep", "0.3"], start_new_session=True)
+        time.sleep(0.8)  # exited, deliberately not reaped yet
+        self.harness.emulator_process = commands.ManagedProcess(
+            proc=proc, argv=["/usr/bin/emulator", "-avd", "M2_Qual_Fixture"],
+            start_utc="2026-08-16T12:00:00Z", new_session=True)
+        self.harness._session_launched = True
+        res = self.harness.release_emulator()
+        self.assertEqual(res.returncode, 0)
+        self.assertIn(b"already exited", res.stdout)
+        self.assertIsNotNone(proc.returncode)  # reaped
+
+    def test_release_uses_start_continuity_not_argv(self):
+        # Launcher exec'd its engine: command differs from launch argv,
+        # start time matches the retained observation → release proceeds.
+        proc = subprocess.Popen(
+            [sys.executable, "-c",
+             "import os; os.execvp('sleep', ['sleep', '30'])"],
+            start_new_session=True)
+        time.sleep(0.5)
+        try:
+            self.harness._launch_identity = commands.pid_identity(proc.pid)
+            self.assertNotIn(
+                "/usr/bin/emulator", self.harness._launch_identity.command)
+            self.harness.emulator_process = commands.ManagedProcess(
+                proc=proc,
+                argv=["/usr/bin/emulator", "-avd", "M2_Qual_Fixture",
+                      "-port", "5554"],
+                start_utc="2026-08-16T12:00:00Z", new_session=True)
+            self.harness._session_launched = True
+            res = self.harness.release_emulator()
+            self.assertEqual(res.returncode, 0)
+            self.assertIsNotNone(proc.returncode)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+            proc.wait()
+
+    def test_dump_ledger_is_private_and_atomic(self):
+        self.harness.ledger.record(
+            ["adb", "-s", "emulator-5554", "shell", "getprop"],
+            "2026-08-16T12:00:00Z", "2026-08-16T12:00:01Z", 0, 0, False,
+            "shell")
+        res = self.harness.dump_ledger()
+        self.assertEqual(res.returncode, 0)
+        path = os.path.join(self.run_dir, "artifacts", "command_ledger.json")
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        self.assertEqual(mode, 0o600)
+        leftovers = [f for f in os.listdir(os.path.dirname(path))
+                     if f.startswith(".command_ledger.")]
+        self.assertEqual(leftovers, [])
+        with open(path) as fh:
+            self.assertEqual(json.load(fh)[0]["kind"], "shell")
 
 
 if __name__ == "__main__":

--- a/android/scripts/tests/m2_device/test_execution_boundary.py
+++ b/android/scripts/tests/m2_device/test_execution_boundary.py
@@ -594,7 +594,7 @@ class TestBoundedTerminate(unittest.TestCase):
 
     def test_release_fails_when_group_survives_escalation(self):
         # Simulated survivor: real signals are delivered (the leader
-        # dies), but the liveness probe keeps reporting the group
+        # dies), but both liveness probes keep reporting the group
         # alive → release must fail closed instead of reporting success.
         proc = subprocess.Popen(
             ["sleep", "30"], start_new_session=True)
@@ -613,7 +613,9 @@ class TestBoundedTerminate(unittest.TestCase):
                 return None  # probe: group still "alive"
             real_killpg(target, sig)
 
-        with patch("os.killpg", side_effect=fake_killpg):
+        with patch("os.killpg", side_effect=fake_killpg), \
+                patch("android.scripts.m2_device.commands._group_has_live_member",
+                      return_value=True):
             res = h.release_emulator()
         self.assertEqual(res.returncode, 1)
         self.assertIn(b"still alive", res.stderr)
@@ -956,6 +958,24 @@ class TestSignalBlockedChild(unittest.TestCase):
         restore_steps = [s for s in rec.steps if s.phase == "restore"]
         self.assertEqual(restore_steps[0].cause, TerminalCause.COMPLETED)
 
+    def test_cleanup_signal_visible_when_primary_cause_exists(self):
+        # PATCHNOTES claims signals during cleanup are recorded; that
+        # must hold when the terminal slot is already taken.
+        class H(FakeHarness):
+            def restore(self):
+                os.kill(os.getpid(), signal.SIGTERM)
+                return _cr(rc=0)
+
+        h = H(fail_at="install")
+        orch = Orchestrator(h, repo_head="a", apk_sha256="", tools=_tools())
+        rec = orch.execute()
+        self.assertEqual(orch.terminal, TerminalCause.INSTALL_FAILED)
+        signal_steps = [s for s in rec.steps if s.phase == "signal"]
+        self.assertEqual(len(signal_steps), 1)
+        self.assertEqual(signal_steps[0].cause, TerminalCause.SIGNAL_INTERRUPT)
+        self.assertIn(b"signum=15", signal_steps[0].result.stdout)
+        self.assertEqual(h.release_count, 1)
+
 
 # --- Ledger persistence as a recorded step (P1) ---
 
@@ -1021,6 +1041,33 @@ class TestFallbackPidRelease(unittest.TestCase):
         self.assertIn(b"SIGKILL", res.stdout)
         self.assertIsNotNone(proc.poll())
         self.assertNotEqual(C.pid_identity(proc.pid), h._owned_identity)
+
+    def test_fallback_validates_identity_before_first_signal(self):
+        # P3: the pre-SIGTERM identity check is inside the lifecycle,
+        # not only at escalation — a mismatched pid is never signaled.
+        proc = subprocess.Popen(["sleep", "30"])
+        time.sleep(0.2)
+        try:
+            wrong = C.ProcessIdentity(
+                start="Mon Jan  1 00:00:00 2001", command="/some/other/proc")
+            killed = C.bounded_terminate_pid(proc.pid, wrong)
+            self.assertFalse(killed)
+            self.assertIsNone(proc.poll(),
+                              "mismatched identity must not be signaled")
+        finally:
+            proc.terminate()
+            proc.wait()
+
+    def test_group_alive_ignores_zombie_members(self):
+        # killpg(0) counts unreaped zombies; a group holding only
+        # zombies is extinct for release purposes.
+        proc = subprocess.Popen(
+            ["sleep", "0.3"], start_new_session=True)
+        time.sleep(0.8)  # exited, unreaped: zombie holds the group open
+        try:
+            self.assertFalse(C._group_alive(proc.pid))  # leader pid == pgid
+        finally:
+            proc.poll()  # reap
 
 
 if __name__ == "__main__":

--- a/docs/adr/0008-production-m2-journey-harness.md
+++ b/docs/adr/0008-production-m2-journey-harness.md
@@ -38,6 +38,7 @@ No new runtime or external testing dependencies are permitted. We use only insta
 ### 4. Tool and Status Separation
 We execute all commands via subprocess argv lists. Argv, stdout, stderr, timeout, local status, and remote status are treated as separate structured facts.
 We do not text-match localized adb errors or append a status sentinel to stdout. Redacted or sensitive command outputs are stored in private digests/run-bound artifacts, keeping only synthetic content and metadata in the ledger.
+The ledger artifact (`artifacts/command_ledger.json`) is persisted at the end of cleanup as a private (0600), atomically replaced file. Runs that fail before the emulator launches (preflight, capture-context) produce no ledger artifact by design — nothing device-facing has run yet; the absence is expected, not a lost file.
 
 ### 5. Pinned Fixture Invariants
 We pin the accepted #56 pristine fixture receipt `dad6f7ac3b3c10ac7b88dfe2397746acb11ee6a42957cf2d1fee7afe1325bdb0`:


### PR DESCRIPTION
## What

Correction round for the two post-merge reviews of #67 (Cassie's detailed review and ghostinprod-pixelperfect's exact-head review — both "changes required" on the same P1). Targeting the integration branch per the #59 partition; no scope beyond #65.

## P1 — already-exited emulator refused and left unreaped (both reviews; fixed first)

`release_emulator` read `ps` identity before `poll()`. An unreaped crashed/failed-boot leader reports `<defunct>`, which failed the argv match → false `CLEANUP_PARTIAL`, handle dropped, child never reaped. Now:

- **Exited leader:** poll → reap → clean release (`released (process already exited)`). Never group-terminates after the reap — a freed pid's group could be recycled (exactly the hole the review warned about).
- **Live leader:** start-time continuity against an identity **observed from the process and retained at launch/ownership** (`_launch_identity` captured in `launch_emulator`, `_owned_identity` at `establish_ownership`). Launch argv is not a stable runtime identity — the SDK launcher execs its engine and engines rewrite titles; exec keeps the start time, reuse changes it. The argv-token check survives only as the fallback when no observation was retained.
- **`establish_ownership`** now rejects what it cannot recognize: start-time discontinuity (reuse) or a command carrying neither the launched executable token nor the pinned AVD (space-tolerant token matching — SDK paths contain spaces). A bare `<defunct>` is refused, closing the "owned a dead emulator" trace.

Regressions: real exited-unreaped process → reaped + rc 0; real exec-transformed process (`os.execvp`) → released despite argv mismatch; defunct refused at ownership; engine-style command accepted at ownership.

## P2s

- **Ledger launch entry** — `launch_emulator` records `kind="launch"`; the "no production command bypasses the ledger" claim now holds.
- **Private, atomic ledger** — `dump_ledger`: 0600 same-dir tempfile, flush + fsync, `os.replace`; interrupted writes can no longer report `COMPLETED` over a truncated file (mode asserted in tests, no temp leftovers).
- **Cleanup signals stay visible** — a signal during cleanup appends a `signal` step unconditionally, even when a primary cause holds the terminal (regression: `install_failed` + SIGTERM during restore → step present, terminal preserved).

## P3s (all taken)

- `bounded_terminate_pid` validates identity before its **first** signal, not only at escalation.
- Group liveness ignores zombie members: `killpg(0)` succeeds for unreaped zombies (Linux) and EPERMs on zombie-held groups (macOS — verified empirically); `ps -eo pgid=,stat=` makes the live-member call, conservative on ps failure. Regression with a real zombie-held group.
- The launch phase moved inside the cleanup guard — a signal in the launch window now converges to release instead of escaping past it.
- `screenrecord` is stopped explicitly (`terminate=True`); wrapper rc −15/143 is our SIGTERM and a normal stop — closing the `--time-limit 30` vs 15-second-finish disagreement that the new status classification would have turned into a hard `CAPTURE_FAILED` on a fast journey.

Also: PATCHNOTES doubled-blank-line nit fixed; ADR-0008 documents that pre-launch failures produce no ledger artifact by design.

## Evidence

- Local: `python -m unittest discover -s android/scripts/tests/m2_device` — **274/274, run twice** (10 new regressions).
- Budgets hold without amendment: adb_harness 834/850, total 2283/2300.
- Hosted: results appended at this head when the run completes.

Closes the P1 from both reviews; #63/#64/#62 remain queued; `records.py`, evidence finalization, product code, and dependencies untouched.