### PR TITLE
feat(issue-63): pinned fixture transaction and exact ASK journey

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -47,7 +47,11 @@ Newest first, like all respectable patch notes.
   the observed facts become the runtime-private restoration baseline,
   which `verify_restore` re-checks after the snapshot reload. Private
   facts never enter the public record; only the comparison verdict
-  does.
+  does. Review round: an unparsable or undumpable keyboard hierarchy
+  now fails closed before the first tap (absent facts never authorize
+  one), and injected fake-only digests mechanically blank the recorded
+  fixture receipt — a run over arbitrary snapshot bytes can no longer
+  present itself as an accepted-fixture qualification.
 - Every ASK tap coordinate is now validated against uniquely observed
   key geometry: missing, duplicated, malformed, or non-containing key
   facts fail closed before the first tap. The stale path became

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -51,7 +51,13 @@ Newest first, like all respectable patch notes.
   now fails closed before the first tap (absent facts never authorize
   one), and injected fake-only digests mechanically blank the recorded
   fixture receipt — a run over arbitrary snapshot bytes can no longer
-  present itself as an accepted-fixture qualification.
+  present itself as an accepted-fixture qualification. Re-review round:
+  the pinned-versus-injected verdict now rides in the validate_fixture
+  step's own serialized stdout ("fake-only … not an accepted-fixture
+  qualification" vs the pinned receipt prefix), so the boundary
+  survives into the persisted CaptureRecord instead of an attribute
+  the receipt politely forgot; asserted end-to-end against the decoded
+  capture record.
 - Every ASK tap coordinate is now validated against uniquely observed
   key geometry: missing, duplicated, malformed, or non-containing key
   facts fail closed before the first tap. The stale path became

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -35,6 +35,32 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-08-16, evening — The harness stops taking the fixture's word for it
+
+- The qualification journey now proves its preconditions instead of
+  assuming them. Before any mutation: the pinned snapshot bytes are
+  verified against the accepted fixture digests (missing or drifted
+  files fail closed — the CLI grows `--fixture-root` and
+  `--fixture-digests` for honest fake-only runs), the animator scale
+  joins window/transition as a pinned "unset", and the editor must be
+  observed empty and unfocused before the journey touches anything —
+  the observed facts become the runtime-private restoration baseline,
+  which `verify_restore` re-checks after the snapshot reload. Private
+  facts never enter the public record; only the comparison verdict
+  does.
+- Every ASK tap coordinate is now validated against uniquely observed
+  key geometry: missing, duplicated, malformed, or non-containing key
+  facts fail closed before the first tap. The stale path became
+  explicit — applying a stale candidate must retain it in REVIEW for an
+  explicit dismiss, never silently drop it — and the fake toolchain
+  learned to model focus, per-key bounds, animator state, snapshot-load
+  reversion, and stale retention, so it matches the product state
+  machine rather than a polite fiction. Twelve adversarial regressions
+  ride along, including a real CLI fixture-drift run. Budgets amended
+  to 1,000/2,500 (actual 979/2,439) in ADR-0008.
+
+---
+
 ## 2026-08-16 (later that day) — The corpse is identified, reaped, and given a clean receipt
 
 - Post-merge review round (two independent findings sets, same P1): a

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -132,6 +132,9 @@ class AdbHarness:
         self.fixture_digests = dict(FIXTURE_FILES)
         self._injected_fixture_digests = bool(fixture_digests)
         if fixture_digests:
+            # Deliberately merges rather than replaces: a typo'd key in
+            # override JSON adds an entry while the pinned one stays in
+            # force, so a mistyped override fails closed on drift.
             self.fixture_digests.update(fixture_digests)
         self.adb_tool: ToolIdentity | None = None
         self.emulator_tool: ToolIdentity | None = None
@@ -604,8 +607,13 @@ class AdbHarness:
         if self._pristine_private != {
                 "editor_text": "", "editor_focused": False,
                 "panel_present": False}:
+            detail = self._pristine_private
+            # A rejected observation must not survive as the restoration
+            # baseline — otherwise the receipt blames a correct restore
+            # for what was a precondition failure.
+            self._pristine_private = None
             self._step(steps, "pin_pristine_state",
-                       self._fail("pristine", f"not pristine: {self._pristine_private}".encode()))
+                       self._fail("pristine", f"not pristine: {detail}".encode()))
             return False
         self._step(steps, "pin_pristine_state", self._ok("pristine"))
         return True
@@ -636,11 +644,11 @@ class AdbHarness:
         uniquely identified observed key. Missing, duplicate, or
         malformed key facts fail closed."""
         errors = []
-        used = sorted({ch for ch in (SOURCE_TEXT + STALE_TEXT)})
+        used = sorted({ch.upper() if ch.isalpha() else ch
+                       for ch in (SOURCE_TEXT + STALE_TEXT)})
         for ch in used:
-            label = KEY_LABELS.get(ch, ch.upper())
-            lookup = ch.upper() if ch.isalpha() else ch
-            coord = ASK_KEY_COORDS.get(lookup)
+            label = KEY_LABELS.get(ch, ch)
+            coord = ASK_KEY_COORDS.get(ch)
             if coord is None:
                 errors.append(f"no pinned coordinate for {ch!r}")
                 continue

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -451,7 +451,19 @@ class AdbHarness:
 
         if errors:
             return self._fail("validate_fixture", "\n".join(errors).encode())
-        return self._ok("validate_fixture", b"Fixture identity validated.")
+        # The pinned-versus-injected verdict is carried in the step's own
+        # serialized stdout, so the persisted CaptureRecord mechanically
+        # distinguishes an accepted-fixture qualification from a fake-only
+        # run over injected digests — the boundary survives serialization.
+        if self._injected_fixture_digests:
+            return self._ok(
+                "validate_fixture",
+                b"fake-only fixture transaction: injected digests verified"
+                b" - not an accepted-fixture qualification")
+        return self._ok(
+            "validate_fixture",
+            f"Fixture identity validated against pinned receipt"
+            f" {FIXTURE_RECEIPT_DIGEST[:12]}.".encode())
 
     def install_apk(self) -> CommandResult:
         res = self._host("install", "-r", self.apk_path, timeout=120.0)

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -130,6 +130,7 @@ class AdbHarness:
         self.fixture_root = fixture_root or os.path.join(
             os.path.expanduser("~"), ".android", "avd")
         self.fixture_digests = dict(FIXTURE_FILES)
+        self._injected_fixture_digests = bool(fixture_digests)
         if fixture_digests:
             self.fixture_digests.update(fixture_digests)
         self.adb_tool: ToolIdentity | None = None
@@ -228,9 +229,14 @@ class AdbHarness:
         tools = [self.adb_tool, self.emulator_tool]
         if self.build_tools_tool is not None:
             tools.append(self.build_tools_tool)
+        # A run over injected (fake-only) digests is mechanically barred
+        # from claiming the accepted fixture receipt: the recorded
+        # digest is blanked, so no capture over arbitrary snapshot bytes
+        # can present itself as an accepted-fixture qualification.
+        receipt = "" if self._injected_fixture_digests else FIXTURE_RECEIPT_DIGEST
         return CaptureContext(
             repo_head=repo_head, apk_sha256=apk_sha,
-            tools=tools, fixture_receipt_digest=FIXTURE_RECEIPT_DIGEST,
+            tools=tools, fixture_receipt_digest=receipt,
         )
 
     def launch_emulator(self) -> CommandResult:
@@ -733,12 +739,21 @@ class AdbHarness:
         if not self._step(steps, "focus_editor", res):
             return steps
 
-        _, kb_root = self._dump_hierarchy("keyboard_check")
-        if kb_root is not None and not self._validate_keyboard(steps, kb_root):
+        # The keyboard hierarchy carries the pre-tap pins; if it cannot
+        # be dumped, pulled, or parsed, fail closed — never tap on the
+        # strength of absent facts.
+        kb_res, kb_root = self._dump_hierarchy("keyboard_check")
+        if kb_root is None:
+            if self._rc_of(kb_res) == 0 and not self._timed_out(kb_res):
+                kb_res = self._fail(
+                    "keyboard_check", b"hierarchy missing or unparsable")
+            self._step(steps, "keyboard_hierarchy", kb_res)
             return steps
-        if kb_root is not None and not self._pin_editor_focused_empty(steps, kb_root):
+        if not self._validate_keyboard(steps, kb_root):
             return steps
-        if kb_root is not None and not self._validate_key_geometry(steps, kb_root):
+        if not self._pin_editor_focused_empty(steps, kb_root):
+            return steps
+        if not self._validate_key_geometry(steps, kb_root):
             return steps
 
         if not self._type_text(steps, SOURCE_TEXT, "type_source_1"):

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -93,6 +93,17 @@ EXPECTED_ENABLED_IMES = [
     "com.google.android.inputmethod.latin/com.google.android.apps.inputmethod.latin.MockVoiceIME",
 ]
 EXPECTED_EDITOR_CLASS = "android.widget.EditText"
+ANIMATOR_SCALE = "null"  # fixture pins animator unset
+
+# Fixture transaction: the snapshot files whose exact bytes the
+# accepted #56 receipt pins. Defaults are the pinned digests; fake-only
+# runs inject digests computed from their own fixture files.
+FIXTURE_FILES = {
+    "M2_Qual_Fixture.avd/hardware.ini": HARDWARE_INI_HASH,
+    "M2_Qual_Fixture.avd/snapshots/m2_pristine/ram.bin": RAM_BIN_HASH,
+    "M2_Qual_Fixture.avd/snapshots/m2_pristine/textures.bin": TEXTURES_BIN_HASH,
+}
+KEY_LABELS = {" ": "Space", ".": "Period"}
 
 
 class AdbHarness:
@@ -106,6 +117,8 @@ class AdbHarness:
         starter: Any = None,
         finisher: Any = None,
         repo_root: str = "",
+        fixture_root: str = "",
+        fixture_digests: dict[str, str] | None = None,
     ):
         self.run_dir = run_dir
         self.apk_path = apk_path
@@ -114,6 +127,11 @@ class AdbHarness:
         self.starter = starter or commands.start
         self.finisher = finisher or commands.finish
         self.repo_root = repo_root or os.getcwd()
+        self.fixture_root = fixture_root or os.path.join(
+            os.path.expanduser("~"), ".android", "avd")
+        self.fixture_digests = dict(FIXTURE_FILES)
+        if fixture_digests:
+            self.fixture_digests.update(fixture_digests)
         self.adb_tool: ToolIdentity | None = None
         self.emulator_tool: ToolIdentity | None = None
         self.build_tools_tool: ToolIdentity | None = None
@@ -124,6 +142,11 @@ class AdbHarness:
         self._launch_identity: commands.ProcessIdentity | None = None
         self._session_launched = False
         self.ledger = commands.CommandLedger()
+        # Runtime-only private restoration facts (editor text/focus/panel).
+        # Deliberately never serialized into records: private facts stay
+        # harness-local; the public record carries only the comparison
+        # verdict.
+        self._pristine_private: dict | None = None
 
     @property
     def _adb(self) -> str:
@@ -389,6 +412,7 @@ class AdbHarness:
             (("getprop", "ro.sf.lcd_density"), str(SCREEN_DPI)),
             (("settings", "get", "global", "window_animation_scale"), ANIMATION_SCALE),
             (("settings", "get", "global", "transition_animation_scale"), ANIMATION_SCALE),
+            (("settings", "get", "global", "animator_duration_scale"), ANIMATOR_SCALE),
             (("settings", "get", "secure", "default_input_method"), EXPECTED_ENABLED_IMES[0]),
         ]
         for args, expected in fixture_props:
@@ -401,6 +425,23 @@ class AdbHarness:
                 actual = res.transport.stdout.decode("utf-8", errors="replace").strip()
                 if actual != expected:
                     errors.append(f"{' '.join(args)} mismatch: got {actual}")
+
+        # Fixture transaction: the pinned snapshot bytes are verified
+        # before any mutation. Missing or drifted files fail closed.
+        for rel, expected_digest in sorted(self.fixture_digests.items()):
+            path = os.path.join(self.fixture_root, *rel.split("/"))
+            if not os.path.isfile(path):
+                errors.append(f"fixture file missing: {rel}")
+                continue
+            try:
+                actual_digest = commands.digest_file(path)
+            except OSError as e:
+                errors.append(f"fixture file unreadable: {rel}: {e}")
+                continue
+            if actual_digest != expected_digest:
+                errors.append(
+                    f"fixture digest drift: {rel}: "
+                    f"expected {expected_digest[:12]} got {actual_digest[:12]}")
 
         if errors:
             return self._fail("validate_fixture", "\n".join(errors).encode())
@@ -526,6 +567,88 @@ class AdbHarness:
                    self._ok("kb") if ok else self._fail("kb", f"bounds: {actual}".encode()))
         return ok
 
+    def _pin_pristine(self, steps, root) -> bool:
+        """Pre-mutation pristine pins, observed before anything is
+        typed: editor empty and unfocused, no panel. The observed facts
+        become the runtime-private restoration baseline."""
+        field = self._find(root, SEARCH_RES_ID)
+        if field is None:
+            self._step(steps, "pin_pristine_state",
+                       self._fail("pristine", b"editor not found"))
+            return False
+        self._pristine_private = {
+            "editor_text": field.attrib.get("text", ""),
+            "editor_focused": field.attrib.get("focused", "") == "true",
+            "panel_present": self._find(root, PANEL_STATE_RES_ID) is not None,
+        }
+        # Selection is cursor-at-end (uiautomator exposes no selection);
+        # pristine selection 0 is implied by empty text.
+        if self._pristine_private != {
+                "editor_text": "", "editor_focused": False,
+                "panel_present": False}:
+            self._step(steps, "pin_pristine_state",
+                       self._fail("pristine", f"not pristine: {self._pristine_private}".encode()))
+            return False
+        self._step(steps, "pin_pristine_state", self._ok("pristine"))
+        return True
+
+    def _pin_editor_focused_empty(self, steps, root) -> bool:
+        """After the focus tap: the editor must already be empty (the
+        fixture guarantees it; we clear nothing on faith) and focused."""
+        field = self._find(root, SEARCH_RES_ID)
+        errors = []
+        if field is None:
+            errors.append("editor not found")
+        else:
+            if field.attrib.get("text", "") != "":
+                errors.append(
+                    f"editor not empty: {field.attrib.get('text', '')[:40]!r}")
+            if field.attrib.get("focused", "") != "true":
+                errors.append(
+                    f"editor not focused: {field.attrib.get('focused', '')!r}")
+        if errors:
+            self._step(steps, "pin_editor_focused_empty",
+                       self._fail("pin", "\n".join(errors).encode()))
+            return False
+        self._step(steps, "pin_editor_focused_empty", self._ok("pin"))
+        return True
+
+    def _validate_key_geometry(self, steps, root) -> bool:
+        """Every pinned ASK coordinate must land inside exactly one
+        uniquely identified observed key. Missing, duplicate, or
+        malformed key facts fail closed."""
+        errors = []
+        used = sorted({ch for ch in (SOURCE_TEXT + STALE_TEXT)})
+        for ch in used:
+            label = KEY_LABELS.get(ch, ch.upper())
+            lookup = ch.upper() if ch.isalpha() else ch
+            coord = ASK_KEY_COORDS.get(lookup)
+            if coord is None:
+                errors.append(f"no pinned coordinate for {ch!r}")
+                continue
+            matches = [e for e in root.iter()
+                       if e.attrib.get("content-desc", "") == label]
+            if len(matches) != 1:
+                errors.append(
+                    f"key {label}: {len(matches)} matching nodes, need exactly 1")
+                continue
+            m = re.match(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]",
+                         matches[0].attrib.get("bounds", ""))
+            if not m:
+                errors.append(f"key {label}: malformed bounds")
+                continue
+            x1, y1, x2, y2 = (int(g) for g in m.groups())
+            if not (x1 <= coord[0] <= x2 and y1 <= coord[1] <= y2):
+                errors.append(
+                    f"key {label}: pinned ({coord[0]},{coord[1]})"
+                    f" outside [{x1},{y1}][{x2},{y2}]")
+        if errors:
+            self._step(steps, "validate_key_geometry",
+                       self._fail("keys", "\n".join(errors).encode()))
+            return False
+        self._step(steps, "validate_key_geometry", self._ok("keys"))
+        return True
+
     def _tap_ask_key(self, steps, ch):
         key = ch.upper() if ch.isalpha() else ch
         coord = ASK_KEY_COORDS.get(key)
@@ -595,6 +718,9 @@ class AdbHarness:
             return steps
         self._step(steps, "dump_hierarchy", d_res)
 
+        if not self._pin_pristine(steps, root):
+            return steps
+
         field = self._find(root, SEARCH_RES_ID)
         if field is None:
             self._step(steps, "locate_editor", self._fail("locate", b"not found"))
@@ -609,6 +735,10 @@ class AdbHarness:
 
         _, kb_root = self._dump_hierarchy("keyboard_check")
         if kb_root is not None and not self._validate_keyboard(steps, kb_root):
+            return steps
+        if kb_root is not None and not self._pin_editor_focused_empty(steps, kb_root):
+            return steps
+        if kb_root is not None and not self._validate_key_geometry(steps, kb_root):
             return steps
 
         if not self._type_text(steps, SOURCE_TEXT, "type_source_1"):
@@ -685,23 +815,41 @@ class AdbHarness:
         if review_root is None:
             return steps
 
+        # Explicit stale: applying a candidate whose source changed
+        # must make zero mutations and RETAIN the candidate in REVIEW
+        # for an explicit dismiss — it is never silently dropped.
         if not self._clear_field(steps) or not self._type_text(steps, STALE_TEXT, "type_stale"):
             return steps
         if not self._tap_btn(steps, review_root, "apply_stale", APPLY_RES_ID):
             return steps
         v_res, v_root = self._dump_hierarchy("after_stale")
         if v_root is None:
-            self._step(steps, "verify_stale", v_res)
+            self._step(steps, "verify_stale_retained", v_res)
             return steps
-        if not self._verify_text(steps, v_root, STALE_TEXT, "verify_stale"):
+        if not self._verify_text(steps, v_root, STALE_TEXT, "verify_stale_retained"):
             return steps
-        candidate = self._find(v_root, CANDIDATE_RES_ID)
-        if candidate is not None:
-            self._step(steps, "verify_stale_outcome",
-                       self._fail("stale_outcome", b"candidate present after stale apply"))
+        panel = self._find(v_root, PANEL_STATE_RES_ID)
+        retained = (
+            panel is not None
+            and panel.attrib.get("text", "") == STATE_REVIEW
+            and self._find(v_root, CANDIDATE_RES_ID) is not None)
+        self._step(steps, "verify_stale_candidate_retained",
+                   self._ok("stale") if retained
+                   else self._fail("stale", b"stale candidate not retained in REVIEW"))
+        if not retained:
             return steps
-        self._step(steps, "verify_stale_outcome", self._ok("stale_outcome"))
         if not self._take_screenshot(steps, "06-stale"):
+            return steps
+
+        if not self._tap_btn(steps, v_root, "dismiss_stale_candidate", DISMISS_RES_ID):
+            return steps
+        d_res, d_root = self._dump_hierarchy("after_stale_dismiss")
+        if d_root is None:
+            self._step(steps, "verify_stale_dismissed", d_res)
+            return steps
+        if not self._verify_idle(steps, d_root, "after_stale_dismiss"):
+            return steps
+        if not self._verify_text(steps, d_root, STALE_TEXT, "verify_stale_dismissed"):
             return steps
 
         res = self._shell("am", "start", "-a", SETTINGS_ACTION)
@@ -786,6 +934,26 @@ class AdbHarness:
         state = self.capture_prior_state()
         if state is None:
             raise RuntimeError("verification prior state unavailable")
+        # Private restoration facts: editor text/focus and panel presence
+        # must equal the runtime-only baseline observed before mutation.
+        if self._pristine_private is not None:
+            _, root = self._dump_hierarchy("verify_restore")
+            if root is None:
+                raise RuntimeError(
+                    "restoration mismatch: hierarchy unavailable for private facts")
+            field = self._find(root, SEARCH_RES_ID)
+            if field is None:
+                raise RuntimeError(
+                    "restoration mismatch: editor node absent after restore")
+            observed = {
+                "editor_text": field.attrib.get("text", ""),
+                "editor_focused": field.attrib.get("focused", "") == "true",
+                "panel_present": self._find(root, PANEL_STATE_RES_ID) is not None,
+            }
+            if observed != self._pristine_private:
+                raise RuntimeError(
+                    f"restoration mismatch: private facts {observed}"
+                    f" != pristine {self._pristine_private}")
         return state
 
     def _revalidate_ownership(self) -> bool:

--- a/android/scripts/m2_device/cli.py
+++ b/android/scripts/m2_device/cli.py
@@ -33,8 +33,13 @@ def cmd_capture(args: argparse.Namespace) -> int:
     run_dir = os.path.join(args.evidence_root, run_id)
     os.makedirs(run_dir, exist_ok=False)
 
+    fixture_digests = None
+    if args.fixture_digests:
+        with open(args.fixture_digests) as f:
+            fixture_digests = json.load(f)
     harness = AdbHarness(
         run_dir=run_dir, apk_path=args.apk_path, repo_root=args.repo_root,
+        fixture_root=args.fixture_root, fixture_digests=fixture_digests,
     )
     orchestrator = Orchestrator(
         harness=harness, apk_sha256=args.apk_sha256,
@@ -148,6 +153,12 @@ def build_parser() -> argparse.ArgumentParser:
     cap.add_argument("--apk-path", required=True)
     cap.add_argument("--apk-sha256", required=True)
     cap.add_argument("--expected-head", default="")
+    cap.add_argument("--fixture-root", default="",
+                     help="AVD root holding M2_Qual_Fixture.avd "
+                          "(default: ~/.android/avd)")
+    cap.add_argument("--fixture-digests", default="",
+                     help="JSON file of fixture-relative-path → sha256; "
+                          "overrides the pinned digests (fake-only runs)")
     cap.set_defaults(func=cmd_capture)
 
     fin = sub.add_parser("finalize", help="produce final receipt")

--- a/android/scripts/m2_device/cli.py
+++ b/android/scripts/m2_device/cli.py
@@ -157,8 +157,10 @@ def build_parser() -> argparse.ArgumentParser:
                      help="AVD root holding M2_Qual_Fixture.avd "
                           "(default: ~/.android/avd)")
     cap.add_argument("--fixture-digests", default="",
-                     help="JSON file of fixture-relative-path → sha256; "
-                          "overrides the pinned digests (fake-only runs)")
+                     help="JSON file of fixture-relative-path → sha256 for "
+                          "fake-only runs. Mechanical boundary: providing "
+                          "it blanks the recorded fixture receipt digest, "
+                          "so the run cannot claim the accepted fixture")
     cap.set_defaults(func=cmd_capture)
 
     fin = sub.add_parser("finalize", help="produce final receipt")

--- a/android/scripts/tests/m2_device/fixtures/bin/adb
+++ b/android/scripts/tests/m2_device/fixtures/bin/adb
@@ -12,6 +12,7 @@ if log_path:
 
 STATE_FILE = os.environ.get("FAKE_ADB_STATE", "/tmp/fake_adb_edittext.state")
 KB_FILE = os.environ.get("FAKE_ADB_KEYBOARD", "/tmp/fake_adb_keyboard.state")
+FOCUS_FILE = os.environ.get("FAKE_ADB_FOCUS", "/tmp/fake_adb_focus.state")
 CANDIDATE = os.environ.get("FAKE_ADB_REPHRASING", "")
 SOURCE = "Tea at six."
 STALE = "Tea at seven."
@@ -19,6 +20,7 @@ STALE = "Tea at seven."
 APPLY_BOUNDS = (100, 2300, 500, 2380)
 CANCEL_BOUNDS = (580, 2300, 980, 2380)
 CLEAR_BOUNDS = (950, 200, 1020, 270)
+EDITOR_BOUNDS = (100, 200, 900, 300)
 KEY_TAP_BOUNDS = [
     ("t", 430, 1330, 520, 1420), ("e", 240, 1330, 330, 1420),
     ("a", 55, 1430, 145, 1520), ("s", 150, 1430, 240, 1520),
@@ -26,6 +28,10 @@ KEY_TAP_BOUNDS = [
     ("v", 390, 1530, 480, 1620), ("n", 580, 1530, 670, 1620),
     (" ", 345, 1630, 675, 1720), (".", 685, 1630, 775, 1720),
 ]
+KEY_LABELS = {
+    "t": "T", "e": "E", "a": "A", "s": "S", "i": "I", "x": "X",
+    "v": "V", "n": "N", " ": "Space", ".": "Period",
+}
 KB_VIEW = (
     '<node resource-id="biz.pixelperfectstudios.personaspeak:id/keyboard_view" '
     'class="android.widget.FrameLayout" bounds="[0,1300][1080,2400]"/>'
@@ -43,6 +49,23 @@ def _read(path):
 def _write(path, s):
     with open(path, "w") as f:
         f.write(s)
+
+
+def _reset_to_pristine():
+    """`emu snapshot load` reverts the whole device: editor contents,
+    keyboard panel, and focus return to the pristine fixture state."""
+    _write(STATE_FILE, "")
+    _write(KB_FILE, "")
+    _write(FOCUS_FILE, "")
+
+
+def _key_nodes():
+    return "".join(
+        f'<node resource-id="biz.pixelperfectstudios.personaspeak:id/key"'
+        f' content-desc="{KEY_LABELS[ch]}" class="android.widget.Key"'
+        f' bounds="[{x1},{y1}][{x2},{y2}]"/>'
+        for ch, x1, y1, x2, y2 in KEY_TAP_BOUNDS
+    )
 
 
 def _write_png(path):
@@ -76,7 +99,8 @@ def _write_mp4(path):
 def _write_hierarchy(path):
     text = _read(STATE_FILE)
     kb = _read(KB_FILE)
-    nodes = KB_VIEW
+    focused = "true" if _read(FOCUS_FILE) == "1" else "false"
+    nodes = KB_VIEW + _key_nodes()
     if text:
         nodes += (
             '<node resource-id="com.android.settings:id/search_close_btn" '
@@ -93,18 +117,18 @@ def _write_hierarchy(path):
     elif kb == "REVIEW":
         nodes += (
             f'<node text="REVIEW" resource-id="biz.pixelperfectstudios.personaspeak:id/panel_state" '
-            'class="android.widget.TextView" bounds="[10,1810][1070,1850]"/>'
+            f'class="android.widget.TextView" bounds="[10,1810][1070,1850]"/>'
             f'<node text="{CANDIDATE}" resource-id="biz.pixelperfectstudios.personaspeak:id/candidate_text" '
-            'class="android.widget.TextView" bounds="[10,1850][1070,1900]"/>'
-            '<node resource-id="biz.pixelperfectstudios.personaspeak:id/apply_button" '
-            'content-desc="Apply" class="android.widget.Button" bounds="[100,2300][500,2380]"/>'
-            '<node resource-id="biz.pixelperfectstudios.personaspeak:id/cancel_button" '
-            'content-desc="Cancel" class="android.widget.Button" bounds="[580,2300][980,2380]"/>'
+            f'class="android.widget.TextView" bounds="[10,1850][1070,1900]"/>'
+            f'<node resource-id="biz.pixelperfectstudios.personaspeak:id/apply_button" '
+            f'content-desc="Apply" class="android.widget.Button" bounds="[100,2300][500,2380]"/>'
+            f'<node resource-id="biz.pixelperfectstudios.personaspeak:id/cancel_button" '
+            f'content-desc="Cancel" class="android.widget.Button" bounds="[580,2300][980,2380]"/>'
         )
     with open(path, "w") as f:
         f.write(
             '<hierarchy rotation="0">'
-            f'<node index="0" text="{text}" '
+            f'<node index="0" text="{text}" focused="{focused}" '
             'resource-id="com.android.settings:id/search_action_bar" '
             'class="android.widget.EditText" bounds="[100,200][900,300]"/>'
             f'{nodes}'
@@ -128,6 +152,8 @@ elif "settings get global window_animation_scale" in cmd:
     print("1.0")
 elif "settings get global transition_animation_scale" in cmd:
     print("1.0")
+elif "settings get global animator_duration_scale" in cmd:
+    print("null")
 elif "settings get secure default_input_method" in cmd:
     print("com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME")
 elif "wm size" in cmd:
@@ -163,6 +189,9 @@ elif "input tap" in cmd:
     parts = sys.argv
     x_idx = parts.index("tap") + 1
     x, y = int(parts[x_idx]), int(parts[x_idx + 1])
+    ex1, ey1, ex2, ey2 = EDITOR_BOUNDS
+    if ex1 <= x <= ex2 and ey1 <= y <= ey2:
+        _write(FOCUS_FILE, "1")
     for char, bx1, by1, bx2, by2 in KEY_TAP_BOUNDS:
         if bx1 <= x <= bx2 and by1 <= y <= by2:
             cur = _read(STATE_FILE)
@@ -186,15 +215,18 @@ elif "input tap" in cmd:
                 if ax1 <= x <= ax2 and ay1 <= y <= ay2:
                     cur = _read(STATE_FILE)
                     if cur == SOURCE:
+                        # Fresh candidate: exactly one mutation, panel idle.
                         _write(STATE_FILE, CANDIDATE)
-                    _write(KB_FILE, "")
+                        _write(KB_FILE, "")
+                    # else: stale candidate RETAINED — panel stays REVIEW,
+                    # editor unchanged, zero mutations.
                 elif cx1b <= x <= cx2b and cy1b <= y <= cy2b:
                     _write(KB_FILE, "")
 elif "input keyevent" in cmd:
     cur = _read(STATE_FILE)
     _write(STATE_FILE, cur[:-1])
 elif "emu snapshot load" in cmd:
-    pass
+    _reset_to_pristine()
 elif "emu kill" in cmd:
     pass
 elif "pull" in sys.argv:

--- a/android/scripts/tests/m2_device/test_adb_harness.py
+++ b/android/scripts/tests/m2_device/test_adb_harness.py
@@ -262,6 +262,70 @@ class TestAdbHarness(unittest.TestCase):
         self.assertEqual(ctx.repo_head, "abc123git")
         self.assertTrue(ctx.apk_sha256)
         self.assertEqual(len(ctx.tools), 2)
+        # setUp injects fake-only digests → the run must be mechanically
+        # barred from claiming the accepted fixture receipt.
+        self.assertEqual(ctx.fixture_receipt_digest, "")
+
+    def test_capture_context_records_accepted_receipt_when_pinned(self):
+        h = AdbHarness(
+            run_dir=self.run_dir, apk_path=self.apk_path,
+            runner=self.mock_runner,
+            fixture_root=self.fixture_root,
+        )
+
+        def side_effect(argv, **kwargs):
+            if "status" in argv:
+                return _cr(stdout=b"")
+            return _cr(stdout=b"abc123git\n")
+
+        self.mock_runner.side_effect = side_effect
+        from android.scripts.m2_device.adb_harness import FIXTURE_RECEIPT_DIGEST
+        ctx = h.capture_context()
+        self.assertEqual(ctx.fixture_receipt_digest, FIXTURE_RECEIPT_DIGEST)
+
+    def test_run_journey_fails_closed_on_unparsable_keyboard_hierarchy(self):
+        # Reviewer reproduction: malformed keyboard_check XML must stop
+        # the journey before any tap — absent facts never authorize one.
+        writer = _journey_pull_writer()
+
+        def side_effect(argv, **kwargs):
+            if "pull" in argv and "keyboard_check" in argv[-1]:
+                with open(argv[-1], "w") as f:
+                    f.write("<not-xml")
+                return _cr(rc=0, argv=argv)
+            return writer(argv, **kwargs)
+
+        self.mock_runner.side_effect = side_effect
+        self.mock_starter.return_value = MagicMock()
+        steps = self.harness.run_journey()
+        failed = [s for s in steps if s.operation == "keyboard_hierarchy"]
+        self.assertTrue(failed)
+        self.assertNotEqual(failed[0].cause, TerminalCause.COMPLETED)
+        self.assertIn(b"unparsable", failed[0].result.stderr)
+        self.assertFalse(
+            [s for s in steps if s.operation.startswith("tap_key")],
+            "taps must not run on the strength of absent hierarchy facts")
+
+    def test_run_journey_fails_closed_on_failed_keyboard_dump(self):
+        writer = _journey_pull_writer()
+        dump_calls = {"n": 0}
+
+        def side_effect(argv, **kwargs):
+            cmd = " ".join(argv)
+            if "uiautomator" in cmd:
+                dump_calls["n"] += 1
+                if dump_calls["n"] == 2:  # keyboard_check is the 2nd dump
+                    return _cr(rc=1, stderr=b"dump failed")
+            return writer(argv, **kwargs)
+
+        self.mock_runner.side_effect = side_effect
+        self.mock_starter.return_value = MagicMock()
+        steps = self.harness.run_journey()
+        failed = [s for s in steps if s.operation == "keyboard_hierarchy"]
+        self.assertTrue(failed)
+        self.assertNotEqual(failed[0].cause, TerminalCause.COMPLETED)
+        self.assertFalse(
+            [s for s in steps if s.operation.startswith("tap_key")])
 
     def test_launch_emulator(self):
         self.mock_starter.return_value = MagicMock()

--- a/android/scripts/tests/m2_device/test_adb_harness.py
+++ b/android/scripts/tests/m2_device/test_adb_harness.py
@@ -620,6 +620,17 @@ class TestAdbHarness(unittest.TestCase):
         self.assertTrue(pin)
         self.assertEqual(pin[0].cause, TerminalCause.JOURNEY_FAILED)
 
+    def test_rejected_pristine_observation_not_retained_as_baseline(self):
+        # Review finding: a rejected observation must not survive as the
+        # restoration baseline, or the receipt blames a correct restore
+        # for what was a precondition failure.
+        self._run_journey_with_override(
+            "journey.xml", _journey_xml("leftover text"))
+        self.assertIsNone(self.harness._pristine_private)
+        with patch.object(self.harness, "capture_prior_state",
+                          return_value=object()):
+            self.harness.verify_restore()  # must not raise
+
     def test_run_journey_rejects_unfocused_editor(self):
         steps = self._run_journey_with_override(
             "keyboard_check", _journey_xml("", focused=False))

--- a/android/scripts/tests/m2_device/test_adb_harness.py
+++ b/android/scripts/tests/m2_device/test_adb_harness.py
@@ -76,6 +76,104 @@ def _write_valid_mp4(path):
         f.write(ftyp + mdat)
 
 
+_KEY_GEOMETRY = [
+    ("T", 430, 1330, 520, 1420), ("E", 240, 1330, 330, 1420),
+    ("A", 55, 1430, 145, 1520), ("S", 150, 1430, 240, 1520),
+    ("I", 715, 1330, 805, 1420), ("X", 200, 1530, 290, 1620),
+    ("V", 390, 1530, 480, 1620), ("N", 580, 1530, 670, 1620),
+    ("Space", 345, 1630, 675, 1720), ("Period", 685, 1630, 775, 1720),
+]
+KEY_NODES_XML = "".join(
+    f'<node resource-id="biz.pixelperfectstudios.personaspeak:id/key"'
+    f' content-desc="{lbl}" class="android.widget.Key"'
+    f' bounds="[{x1},{y1}][{x2},{y2}]"/>'
+    for lbl, x1, y1, x2, y2 in _KEY_GEOMETRY)
+
+
+def _journey_xml(text="", kb="", focused=False, keys=True,
+                 editor_class="android.widget.EditText"):
+    """Hierarchy XML matching the fake-toolchain contract: editor with
+    focus attribute, keyboard view, per-key geometry nodes, and the
+    panel/candidate/button set implied by *kb*."""
+    ps = "biz.pixelperfectstudios.personaspeak:id"
+    ss = "com.android.settings:id"
+    nodes = (
+        f'<node resource-id="{ps}/keyboard_view" '
+        f'class="android.widget.FrameLayout" bounds="[0,1300][1080,2400]"/>'
+    )
+    if keys:
+        nodes += KEY_NODES_XML
+    if text:
+        nodes += (
+            f'<node resource-id="{ss}/search_close_btn" '
+            f'content-desc="Clear" class="android.widget.ImageView" '
+            f'bounds="[950,200][1020,270]"/>'
+        )
+    if kb == "LOADING":
+        nodes += (
+            f'<node text="LOADING" resource-id="{ps}/panel_state" '
+            f'class="android.widget.TextView" bounds="[10,1810][1070,1850]"/>'
+            f'<node resource-id="{ps}/cancel_button" content-desc="Cancel" '
+            f'class="android.widget.Button" bounds="[580,2300][980,2380]"/>'
+        )
+    elif kb == "REVIEW":
+        nodes += (
+            f'<node text="REVIEW" resource-id="{ps}/panel_state" '
+            f'class="android.widget.TextView" bounds="[10,1810][1070,1850]"/>'
+            f'<node text="{CANDIDATE_REPHRASING}" resource-id="{ps}/candidate_text" '
+            f'class="android.widget.TextView" bounds="[10,1850][1070,1900]"/>'
+            f'<node resource-id="{ps}/apply_button" content-desc="Apply" '
+            f'class="android.widget.Button" bounds="[100,2300][500,2380]"/>'
+            f'<node resource-id="{ps}/cancel_button" content-desc="Cancel" '
+            f'class="android.widget.Button" bounds="[580,2300][980,2380]"/>'
+        )
+    return (
+        '<hierarchy rotation="0">'
+        f'<node index="0" text="{text}" '
+        f'focused="{"true" if focused else "false"}" '
+        f'resource-id="{ss}/search_action_bar" class="{editor_class}" '
+        f'bounds="[100,200][900,300]"/>{nodes}</hierarchy>'
+    )
+
+
+def _journey_pull_writer():
+    """Returns a side_effect(argv, **kwargs) that answers every pull the
+    journey makes, mirroring the fake adb's state machine."""
+    def side_effect(argv, **kwargs):
+        if "pull" not in argv:
+            return _cr(rc=0, argv=argv)
+        dest = argv[-1]
+        label = os.path.basename(dest)
+        if dest.endswith(".png"):
+            _write_valid_png(dest)
+            return _cr(rc=0, argv=argv)
+        if dest.endswith(".mp4"):
+            _write_valid_mp4(dest)
+            return _cr(rc=0, argv=argv)
+        if label.startswith("loading"):
+            xml = _journey_xml("Tea at six.", "LOADING")
+        elif "after_stale_dismiss" in label:
+            xml = _journey_xml(STALE_TEXT)
+        elif "after_stale" in label:
+            xml = _journey_xml(STALE_TEXT, "REVIEW")
+        elif label.startswith("review"):
+            xml = _journey_xml("Tea at six.", "REVIEW")
+        elif "after_cancel" in label or "after_dismiss" in label:
+            xml = _journey_xml("Tea at six.")
+        elif "after_apply" in label:
+            xml = _journey_xml(CANDIDATE_REPHRASING)
+        elif "keyboard_check" in label:
+            xml = _journey_xml("", focused=True)
+        elif "verify_restore" in label:
+            xml = _journey_xml("")
+        else:
+            xml = _journey_xml("")
+        with open(dest, "w") as f:
+            f.write(xml)
+        return _cr(rc=0, argv=argv)
+    return side_effect
+
+
 class TestAdbHarness(unittest.TestCase):
 
     def setUp(self):
@@ -84,6 +182,21 @@ class TestAdbHarness(unittest.TestCase):
         self.apk_path = os.path.join(self.run_dir, "test.apk")
         with open(self.apk_path, "wb") as f:
             f.write(b"apk content")
+
+        # Fake fixture tree: real files, digests computed and injected so
+        # the fixture transaction runs against honest bytes.
+        import hashlib as _hl
+        self.fixture_root = os.path.join(self.run_dir, "avd")
+        self.fixture_digests = {}
+        for rel in ("M2_Qual_Fixture.avd/hardware.ini",
+                    "M2_Qual_Fixture.avd/snapshots/m2_pristine/ram.bin",
+                    "M2_Qual_Fixture.avd/snapshots/m2_pristine/textures.bin"):
+            path = os.path.join(self.fixture_root, *rel.split("/"))
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            content = f"fixture-bytes:{rel}".encode()
+            with open(path, "wb") as f:
+                f.write(content)
+            self.fixture_digests[rel] = _hl.sha256(content).hexdigest()
 
         self.mock_runner = MagicMock()
         self.mock_starter = MagicMock()
@@ -95,6 +208,8 @@ class TestAdbHarness(unittest.TestCase):
             runner=self.mock_runner,
             starter=self.mock_starter,
             finisher=self.mock_finisher,
+            fixture_root=self.fixture_root,
+            fixture_digests=self.fixture_digests,
         )
         self.harness.adb_tool = ToolIdentity(name="adb", path="adb", version="1.0")
         self.harness.emulator_tool = ToolIdentity(name="emulator", path="emulator", version="1.0")
@@ -242,6 +357,8 @@ class TestAdbHarness(unittest.TestCase):
                 return _cr(stdout=b"1.0\n")
             if "transition_animation_scale" in cmd:
                 return _cr(stdout=b"1.0\n")
+            if "animator_duration_scale" in cmd:
+                return _cr(stdout=b"null\n")
             if "default_input_method" in cmd:
                 return _cr(stdout=EXPECTED_ENABLED_IMES[0].encode())
             return _cr()
@@ -313,92 +430,31 @@ class TestAdbHarness(unittest.TestCase):
         self.assertEqual(res.returncode, 1)
 
     def test_run_journey_success(self):
-
-        kb = ('<node resource-id="biz.pixelperfectstudios.personaspeak:id/keyboard_view" '
-              'class="android.widget.FrameLayout" bounds="[0,1300][1080,2400]"/>')
-        close = ('<node resource-id="com.android.settings:id/search_close_btn" '
-                 'content-desc="Clear" class="android.widget.ImageView" bounds="[950,200][1020,270]"/>')
-        cancel_btn = ('<node resource-id="biz.pixelperfectstudios.personaspeak:id/cancel_button" '
-                      'content-desc="Cancel" class="android.widget.Button" bounds="[580,2300][980,2380]"/>')
-
-        def side_effect(argv, **kwargs):
-            if "pull" in argv:
-                dest = argv[-1]
-                label = os.path.basename(dest)
-                if dest.endswith(".png"):
-                    _write_valid_png(dest)
-                    return _cr(rc=0, argv=argv)
-                if dest.endswith(".mp4"):
-                    _write_valid_mp4(dest)
-                    return _cr(rc=0, argv=argv)
-                if label.startswith("loading"):
-                    xml = f'<hierarchy><node text="Tea at six." resource-id="com.android.settings:id/search_action_bar" class="android.widget.EditText" bounds="[100,200][900,300]"/>{kb}{close}<node text="LOADING" resource-id="biz.pixelperfectstudios.personaspeak:id/panel_state" class="android.widget.TextView" bounds="[10,1810][1070,1850]"/>{cancel_btn}</hierarchy>'
-                elif label.startswith("review"):
-                    xml = f'<hierarchy><node text="Tea at six." resource-id="com.android.settings:id/search_action_bar" class="android.widget.EditText" bounds="[100,200][900,300]"/>{kb}{close}<node text="REVIEW" resource-id="biz.pixelperfectstudios.personaspeak:id/panel_state" class="android.widget.TextView" bounds="[10,1810][1070,1850]"/><node text="{CANDIDATE_REPHRASING}" resource-id="biz.pixelperfectstudios.personaspeak:id/candidate_text" class="android.widget.TextView" bounds="[10,1850][1070,1900]"/><node resource-id="biz.pixelperfectstudios.personaspeak:id/apply_button" content-desc="Apply" class="android.widget.Button" bounds="[100,2300][500,2380]"/>{cancel_btn}</hierarchy>'
-                elif "after_cancel" in label or "after_dismiss" in label:
-                    xml = f'<hierarchy><node text="Tea at six." resource-id="com.android.settings:id/search_action_bar" class="android.widget.EditText" bounds="[100,200][900,300]"/>{kb}</hierarchy>'
-                elif "after_apply" in label:
-                    xml = f'<hierarchy><node text="{CANDIDATE_REPHRASING}" resource-id="com.android.settings:id/search_action_bar" class="android.widget.EditText" bounds="[100,200][900,300]"/>{kb}</hierarchy>'
-                elif "after_stale" in label:
-                    xml = f'<hierarchy><node text="{STALE_TEXT}" resource-id="com.android.settings:id/search_action_bar" class="android.widget.EditText" bounds="[100,200][900,300]"/>{kb}</hierarchy>'
-                elif "clear" in label:
-                    xml = f'<hierarchy><node text="" resource-id="com.android.settings:id/search_action_bar" class="android.widget.EditText" bounds="[100,200][900,300]"/>{kb}</hierarchy>'
-                else:
-                    xml = f'<hierarchy><node text="" resource-id="com.android.settings:id/search_action_bar" class="android.widget.EditText" bounds="[100,200][900,300]"/>{kb}</hierarchy>'
-                with open(dest, "w") as f:
-                    f.write(xml)
-                return _cr(rc=0, argv=argv)
-            return _cr(rc=0, argv=argv)
-
-        self.mock_runner.side_effect = side_effect
+        self.mock_runner.side_effect = _journey_pull_writer()
         self.mock_starter.return_value = MagicMock()
         steps = self.harness.run_journey()
         operations = [s.operation for s in steps]
-        self.assertIn("launch_editor", operations)
-        self.assertIn("verify_loading_1", operations)
-        self.assertIn("cancel_loading", operations)
-        self.assertIn("verify_review_2", operations)
-        self.assertIn("apply_rephrasing", operations)
-        self.assertIn("verify_apply", operations)
-        self.assertIn("dismiss_rephrasing", operations)
-        self.assertIn("apply_stale", operations)
-        self.assertIn("verify_stale", operations)
-        self.assertIn("relaunch_settings", operations)
+        for expected in ("launch_editor", "pin_pristine_state",
+                         "pin_editor_focused_empty", "validate_key_geometry",
+                         "verify_loading_1", "cancel_loading",
+                         "verify_review_2", "apply_rephrasing",
+                         "verify_apply", "dismiss_rephrasing",
+                         "apply_stale", "verify_stale_candidate_retained",
+                         "dismiss_stale_candidate", "verify_stale_dismissed",
+                         "relaunch_settings"):
+            self.assertIn(expected, operations)
         for step in steps:
             self.assertEqual(step.cause, TerminalCause.COMPLETED, f"{step.operation} failed")
 
     def test_run_journey_rephrasing_mismatch(self):
-
-        kb = ('<node resource-id="biz.pixelperfectstudios.personaspeak:id/keyboard_view" '
-              'class="android.widget.FrameLayout" bounds="[0,1300][1080,2400]"/>')
-        close = ('<node resource-id="com.android.settings:id/search_close_btn" '
-                 'content-desc="Clear" class="android.widget.ImageView" bounds="[950,200][1020,270]"/>')
-        cancel_btn = ('<node resource-id="biz.pixelperfectstudios.personaspeak:id/cancel_button" '
-                      'content-desc="Cancel" class="android.widget.Button" bounds="[580,2300][980,2380]"/>')
+        writer = _journey_pull_writer()
 
         def side_effect(argv, **kwargs):
-            if "pull" in argv:
-                dest = argv[-1]
-                label = os.path.basename(dest)
-                if dest.endswith(".png"):
-                    _write_valid_png(dest)
-                    return _cr(rc=0, argv=argv)
-                if label.startswith("loading"):
-                    xml = f'<hierarchy><node text="Tea at six." resource-id="com.android.settings:id/search_action_bar" class="android.widget.EditText" bounds="[100,200][900,300]"/>{kb}{close}<node text="LOADING" resource-id="biz.pixelperfectstudios.personaspeak:id/panel_state" class="android.widget.TextView" bounds="[10,1810][1070,1850]"/>{cancel_btn}</hierarchy>'
-                elif label.startswith("review"):
-                    xml = f'<hierarchy><node text="Tea at six." resource-id="com.android.settings:id/search_action_bar" class="android.widget.EditText" bounds="[100,200][900,300]"/>{kb}{close}<node text="REVIEW" resource-id="biz.pixelperfectstudios.personaspeak:id/panel_state" class="android.widget.TextView" bounds="[10,1810][1070,1850]"/><node resource-id="biz.pixelperfectstudios.personaspeak:id/apply_button" content-desc="Apply" class="android.widget.Button" bounds="[100,2300][500,2380]"/>{cancel_btn}</hierarchy>'
-                elif "after_apply" in label:
-                    xml = f'<hierarchy><node text="wrong text" resource-id="com.android.settings:id/search_action_bar" class="android.widget.EditText" bounds="[100,200][900,300]"/>{kb}</hierarchy>'
-                elif "clear" in label:
-                    xml = f'<hierarchy><node text="" resource-id="com.android.settings:id/search_action_bar" class="android.widget.EditText" bounds="[100,200][900,300]"/>{kb}</hierarchy>'
-                elif "after_cancel" in label or "after_dismiss" in label:
-                    xml = f'<hierarchy><node text="Tea at six." resource-id="com.android.settings:id/search_action_bar" class="android.widget.EditText" bounds="[100,200][900,300]"/>{kb}</hierarchy>'
-                else:
-                    xml = f'<hierarchy><node text="Tea at six." resource-id="com.android.settings:id/search_action_bar" class="android.widget.EditText" bounds="[100,200][900,300]"/>{kb}</hierarchy>'
-                with open(dest, "w") as f:
-                    f.write(xml)
+            if "pull" in argv and "after_apply" in argv[-1]:
+                with open(argv[-1], "w") as f:
+                    f.write(_journey_xml("wrong text"))
                 return _cr(rc=0, argv=argv)
-            return _cr(rc=0, argv=argv)
+            return writer(argv, **kwargs)
 
         self.mock_runner.side_effect = side_effect
         self.mock_starter.return_value = MagicMock()
@@ -418,9 +474,175 @@ class TestAdbHarness(unittest.TestCase):
 
         self.mock_runner.side_effect = side_effect
         steps = self.harness.run_journey()
-        locate = [s for s in steps if s.operation == "locate_editor"]
+        locate = [s for s in steps if s.operation == "pin_pristine_state"]
         self.assertTrue(locate)
         self.assertEqual(locate[0].cause, TerminalCause.JOURNEY_FAILED)
+
+    def test_validate_fixture_digest_drift(self):
+        ram = os.path.join(
+            self.fixture_root, "M2_Qual_Fixture.avd",
+            "snapshots", "m2_pristine", "ram.bin")
+        with open(ram, "ab") as f:
+            f.write(b"drift")
+        prior = PriorDeviceState(
+            serial="emulator-5554", emulator_state="booted",
+            fingerprint=FINGERPRINT, api_level=API_LEVEL,
+            screen_width=SCREEN_WIDTH, screen_height=SCREEN_HEIGHT,
+            package_present=False, package_hash=None,
+            enabled_imes=[], default_ime="",
+        )
+        res = self.harness.validate_fixture(prior)
+        self.assertEqual(res.returncode, 1)
+        self.assertIn(b"digest drift", res.stderr)
+        self.assertIn(b"ram.bin", res.stderr)
+
+    def test_validate_fixture_missing_file(self):
+        hw = os.path.join(self.fixture_root, "M2_Qual_Fixture.avd",
+                          "hardware.ini")
+        os.unlink(hw)
+        prior = PriorDeviceState(
+            serial="emulator-5554", emulator_state="booted",
+            fingerprint=FINGERPRINT, api_level=API_LEVEL,
+            screen_width=SCREEN_WIDTH, screen_height=SCREEN_HEIGHT,
+            package_present=False, package_hash=None,
+            enabled_imes=[], default_ime="",
+        )
+        res = self.harness.validate_fixture(prior)
+        self.assertEqual(res.returncode, 1)
+        self.assertIn(b"fixture file missing", res.stderr)
+
+    def test_validate_fixture_animator_must_be_unset(self):
+        from android.scripts.m2_device.adb_harness import EXPECTED_ENABLED_IMES
+        prior = PriorDeviceState(
+            serial="emulator-5554", emulator_state="booted",
+            fingerprint=FINGERPRINT, api_level=API_LEVEL,
+            screen_width=SCREEN_WIDTH, screen_height=SCREEN_HEIGHT,
+            package_present=False, package_hash=None,
+            enabled_imes=list(EXPECTED_ENABLED_IMES),
+            default_ime=EXPECTED_ENABLED_IMES[0],
+        )
+
+        def side_effect(argv, **kwargs):
+            cmd = " ".join(argv)
+            if "animator_duration_scale" in cmd:
+                return _cr(stdout=b"1.0\n")  # set — fixture requires unset
+            return _cr(stdout=b"null\n")
+
+        self.mock_runner.side_effect = side_effect
+        res = self.harness.validate_fixture(prior)
+        self.assertEqual(res.returncode, 1)
+        self.assertIn(b"animator_duration_scale mismatch", res.stderr)
+
+    def _run_journey_with_override(self, label, xml):
+        writer = _journey_pull_writer()
+
+        def side_effect(argv, **kwargs):
+            if "pull" in argv and label in os.path.basename(argv[-1]):
+                with open(argv[-1], "w") as f:
+                    f.write(xml)
+                return _cr(rc=0, argv=argv)
+            return writer(argv, **kwargs)
+
+        self.mock_runner.side_effect = side_effect
+        self.mock_starter.return_value = MagicMock()
+        return self.harness.run_journey()
+
+    def test_run_journey_rejects_dirty_editor_at_pristine_pin(self):
+        steps = self._run_journey_with_override(
+            "journey.xml", _journey_xml("leftover text"))
+        pin = [s for s in steps if s.operation == "pin_pristine_state"]
+        self.assertTrue(pin)
+        self.assertEqual(pin[0].cause, TerminalCause.JOURNEY_FAILED)
+
+    def test_run_journey_rejects_unfocused_editor(self):
+        steps = self._run_journey_with_override(
+            "keyboard_check", _journey_xml("", focused=False))
+        pin = [s for s in steps if s.operation == "pin_editor_focused_empty"]
+        self.assertTrue(pin)
+        self.assertEqual(pin[0].cause, TerminalCause.JOURNEY_FAILED)
+
+    def test_run_journey_rejects_nonempty_editor_at_focus(self):
+        steps = self._run_journey_with_override(
+            "keyboard_check", _journey_xml("Tea at six.", focused=True))
+        pin = [s for s in steps if s.operation == "pin_editor_focused_empty"]
+        self.assertTrue(pin)
+        self.assertEqual(pin[0].cause, TerminalCause.JOURNEY_FAILED)
+
+    def _keys_xml_without(self, label):
+        keys = "".join(
+            f'<node resource-id="biz.pixelperfectstudios.personaspeak:id/key"'
+            f' content-desc="{lbl}" class="android.widget.Key"'
+            f' bounds="[{x1},{y1}][{x2},{y2}]"/>'
+            for lbl, x1, y1, x2, y2 in _KEY_GEOMETRY if lbl != label)
+        return _journey_xml("", focused=True).replace(KEY_NODES_XML, keys)
+
+    def test_key_geometry_rejects_duplicate_key(self):
+        import xml.etree.ElementTree as ET
+        first_node = KEY_NODES_XML[:KEY_NODES_XML.index("/>") + 2]
+        dup = _journey_xml("", focused=True).replace(
+            KEY_NODES_XML, KEY_NODES_XML + first_node)
+        steps = []
+        ok = self.harness._validate_key_geometry(steps, ET.fromstring(dup))
+        self.assertFalse(ok)
+        self.assertIn(b"matching nodes", steps[0].result.stderr)
+
+    def test_key_geometry_rejects_missing_key(self):
+        import xml.etree.ElementTree as ET
+        steps = []
+        ok = self.harness._validate_key_geometry(
+            steps, ET.fromstring(self._keys_xml_without("X")))
+        self.assertFalse(ok)
+        self.assertIn(b"key X", steps[0].result.stderr)
+
+    def test_key_geometry_rejects_displaced_key(self):
+        import xml.etree.ElementTree as ET
+        displaced = KEY_NODES_XML.replace(
+            'content-desc="T" class="android.widget.Key" bounds="[430,1330][520,1420]"',
+            'content-desc="T" class="android.widget.Key" bounds="[0,0][10,10]"')
+        xml = _journey_xml("", focused=True).replace(KEY_NODES_XML, displaced)
+        steps = []
+        ok = self.harness._validate_key_geometry(steps, ET.fromstring(xml))
+        self.assertFalse(ok)
+        self.assertIn(b"outside", steps[0].result.stderr)
+
+    def test_run_journey_stale_candidate_must_be_retained(self):
+        writer = _journey_pull_writer()
+
+        def side_effect(argv, **kwargs):
+            dest = os.path.basename(argv[-1]) if "pull" in argv else ""
+            if "after_stale" in dest and "dismiss" not in dest:
+                with open(argv[-1], "w") as f:
+                    f.write(_journey_xml(STALE_TEXT))  # candidate dropped
+                return _cr(rc=0, argv=argv)
+            return writer(argv, **kwargs)
+
+        self.mock_runner.side_effect = side_effect
+        self.mock_starter.return_value = MagicMock()
+        steps = self.harness.run_journey()
+        retained = [s for s in steps
+                    if s.operation == "verify_stale_candidate_retained"]
+        self.assertTrue(retained)
+        self.assertEqual(retained[0].cause, TerminalCause.JOURNEY_FAILED)
+        self.assertIn(b"not retained", retained[0].result.stderr)
+
+    def test_verify_restore_private_fact_mismatch(self):
+        self.harness._pristine_private = {
+            "editor_text": "", "editor_focused": False,
+            "panel_present": False}
+
+        def side_effect(argv, **kwargs):
+            if "pull" in argv:
+                with open(argv[-1], "w") as f:
+                    f.write(_journey_xml("leftover text"))
+                return _cr(rc=0, argv=argv)
+            return _cr(rc=0, argv=argv)
+
+        self.mock_runner.side_effect = side_effect
+        with patch.object(self.harness, "capture_prior_state",
+                          return_value=object()):
+            with self.assertRaises(RuntimeError) as cm:
+                self.harness.verify_restore()
+        self.assertIn("private facts", str(cm.exception))
 
     def test_capture_evidence_screencap_failure(self):
         self.mock_runner.return_value = _cr(rc=1)

--- a/android/scripts/tests/m2_device/test_adb_harness.py
+++ b/android/scripts/tests/m2_device/test_adb_harness.py
@@ -430,6 +430,8 @@ class TestAdbHarness(unittest.TestCase):
         self.mock_runner.side_effect = side_effect
         res = self.harness.validate_fixture(prior)
         self.assertEqual(res.returncode, 0)
+        self.assertIn(b"fake-only", res.stdout)
+        self.assertIn(b"not an accepted-fixture qualification", res.stdout)
 
     def test_validate_fixture_failure(self):
         # Fingerprint mismatch

--- a/android/scripts/tests/m2_device/test_architecture.py
+++ b/android/scripts/tests/m2_device/test_architecture.py
@@ -2,10 +2,11 @@
 
 Verifies that only allowed production modules exist in android/scripts/m2_device/
 and that their nonblank, non-comment line counts fit within the complexity budget:
-- adb_harness.py <= 1000 lines (raised 2026-08-16 for #63: fixture transaction,
-  pristine/editor pins, key-geometry validation, stale retention, private
-  restoration facts)
-- Total of all 6 modules combined <= 2500 lines (same #63 round)
+- adb_harness.py <= 1100 lines (raised to a round number 2026-08-16 at review
+  suggestion: 997/1000 left no headroom for the next change; the raise buys
+  the #64/#62 stages rather than one amendment each)
+- Total of all 6 modules combined <= 2700 lines (same rationale; #64 grows
+  evidence.py/cli.py)
 """
 
 import os
@@ -85,19 +86,21 @@ class TestArchitecture(unittest.TestCase):
             module_counts[name] = count
             total_lines += count
 
-        # adb_harness.py <= 1000 lines (2026-08-16 #63: fixture
-        # transaction, pins, key geometry, stale retention)
+        # adb_harness.py <= 1100 lines (2026-08-16: round-number raise at
+        # review suggestion — 997/1000 had no headroom; buys the #64/#62
+        # stages instead of one amendment per change)
         self.assertLessEqual(
             module_counts.get('adb_harness.py', 0),
-            1000,
-            f"adb_harness.py exceeds 1000 lines: {module_counts.get('adb_harness.py', 0)}"
+            1100,
+            f"adb_harness.py exceeds 1100 lines: {module_counts.get('adb_harness.py', 0)}"
         )
 
-        # total <= 2500 lines (2026-08-16 #63)
+        # total <= 2700 lines (2026-08-16: same rationale; #64 grows
+        # evidence.py and cli.py)
         self.assertLessEqual(
             total_lines,
-            2500,
-            f"Total production line count exceeds 2500 lines: {total_lines} ({module_counts})"
+            2700,
+            f"Total production line count exceeds 2700 lines: {total_lines} ({module_counts})"
         )
 
 

--- a/android/scripts/tests/m2_device/test_architecture.py
+++ b/android/scripts/tests/m2_device/test_architecture.py
@@ -2,11 +2,10 @@
 
 Verifies that only allowed production modules exist in android/scripts/m2_device/
 and that their nonblank, non-comment line counts fit within the complexity budget:
-- adb_harness.py <= 850 lines (raised 2026-08-16 for #65 review findings:
-  provisional-ownership gate, ledgered screenrecord boundary, bounded
-  fallback PID lifecycle)
-- Total of all 6 modules combined <= 2300 lines (same round; adds
-  SignalInterrupt, TerminateOutcome, group-extinction verification)
+- adb_harness.py <= 1000 lines (raised 2026-08-16 for #63: fixture transaction,
+  pristine/editor pins, key-geometry validation, stale retention, private
+  restoration facts)
+- Total of all 6 modules combined <= 2500 lines (same #63 round)
 """
 
 import os
@@ -86,21 +85,19 @@ class TestArchitecture(unittest.TestCase):
             module_counts[name] = count
             total_lines += count
 
-        # adb_harness.py <= 850 lines (2026-08-16 #65 correction round:
-        # provisional-ownership gate, ledgered screenrecord, bounded PID
-        # fallback)
+        # adb_harness.py <= 1000 lines (2026-08-16 #63: fixture
+        # transaction, pins, key geometry, stale retention)
         self.assertLessEqual(
             module_counts.get('adb_harness.py', 0),
-            850,
-            f"adb_harness.py exceeds 850 lines: {module_counts.get('adb_harness.py', 0)}"
+            1000,
+            f"adb_harness.py exceeds 1000 lines: {module_counts.get('adb_harness.py', 0)}"
         )
 
-        # total <= 2300 lines (2026-08-16 #65 correction round:
-        # SignalInterrupt, TerminateOutcome, group-extinction checks)
+        # total <= 2500 lines (2026-08-16 #63)
         self.assertLessEqual(
             total_lines,
-            2300,
-            f"Total production line count exceeds 2300 lines: {total_lines} ({module_counts})"
+            2500,
+            f"Total production line count exceeds 2500 lines: {total_lines} ({module_counts})"
         )
 
 

--- a/android/scripts/tests/m2_device/test_cli_capture.py
+++ b/android/scripts/tests/m2_device/test_cli_capture.py
@@ -4,6 +4,7 @@ R17: Proves the real CLI end-to-end with an isolated fake-only PATH.
 The CLI is invoked as a child process using an absolute Python interpreter.
 """
 
+import json
 import os
 import shutil
 import subprocess
@@ -23,6 +24,24 @@ class TestCliCapture(unittest.TestCase):
         os.makedirs(self.evidence_root, exist_ok=True)
         os.makedirs(self.repo_root, exist_ok=True)
 
+        # Fake AVD fixture tree with honestly computed digests; the
+        # fixture transaction in validate_fixture verifies these bytes.
+        import hashlib
+        self.fixture_root = os.path.join(self.test_dir, "avd")
+        self.fixture_digests_path = os.path.join(self.test_dir, "fixture_digests.json")
+        digests = {}
+        for rel in ("M2_Qual_Fixture.avd/hardware.ini",
+                    "M2_Qual_Fixture.avd/snapshots/m2_pristine/ram.bin",
+                    "M2_Qual_Fixture.avd/snapshots/m2_pristine/textures.bin"):
+            path = os.path.join(self.fixture_root, *rel.split("/"))
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            content = f"fake-fixture:{rel}".encode()
+            with open(path, "wb") as f:
+                f.write(content)
+            digests[rel] = hashlib.sha256(content).hexdigest()
+        with open(self.fixture_digests_path, "w") as f:
+            json.dump(digests, f)
+
         for args in (["git", "init"], ["git", "config", "user.email", "t@t"],
                       ["git", "config", "user.name", "T"], ["git", "add", "-A"],
                       ["git", "commit", "-m", "init"]):
@@ -32,7 +51,6 @@ class TestCliCapture(unittest.TestCase):
         with open(self.apk_path, "wb") as f:
             f.write(b"mock_apk_binary")
 
-        import hashlib
         self.apk_sha256 = hashlib.sha256(b"mock_apk_binary").hexdigest()
 
         self.bin_dir = os.path.abspath(
@@ -60,6 +78,7 @@ class TestCliCapture(unittest.TestCase):
             "MOCK_COMMANDS_LOG": self.log_path,
             "FAKE_ADB_STATE": os.path.join(self.test_dir, "edittext.state"),
             "FAKE_ADB_KEYBOARD": os.path.join(self.test_dir, "keyboard.state"),
+            "FAKE_ADB_FOCUS": os.path.join(self.test_dir, "focus.state"),
             "FAKE_ADB_REPHRASING": CANDIDATE_REPHRASING,
             "FAKE_GIT_HEAD": head,
             "PYTHONPATH": self.repo_root_abs,
@@ -68,13 +87,17 @@ class TestCliCapture(unittest.TestCase):
             f.write("")
         with open(env["FAKE_ADB_KEYBOARD"], "w") as f:
             f.write("")
+        with open(env["FAKE_ADB_FOCUS"], "w") as f:
+            f.write("")
         result = subprocess.run(
             [sys.executable, "-m", "android.scripts.m2_device.cli",
              "capture",
              "--evidence-root", self.evidence_root,
              "--repo-root", self.repo_root,
              "--apk-path", self.apk_path,
-             "--apk-sha256", self.apk_sha256],
+             "--apk-sha256", self.apk_sha256,
+             "--fixture-root", self.fixture_root,
+             "--fixture-digests", self.fixture_digests_path],
             env=env, capture_output=True, cwd=self.repo_root_abs, timeout=30,
         )
         return result
@@ -164,12 +187,13 @@ class TestCliCapture(unittest.TestCase):
             "MOCK_COMMANDS_LOG": self.log_path,
             "FAKE_ADB_STATE": os.path.join(self.test_dir, "edittext.state"),
             "FAKE_ADB_KEYBOARD": os.path.join(self.test_dir, "keyboard.state"),
+            "FAKE_ADB_FOCUS": os.path.join(self.test_dir, "focus.state"),
             "FAKE_ADB_REPHRASING": CANDIDATE_REPHRASING,
             "FAKE_GIT_HEAD": head,
             "PYTHONPATH": self.repo_root_abs,
         }
         env.update(extra_env)
-        for k in ("FAKE_ADB_STATE", "FAKE_ADB_KEYBOARD"):
+        for k in ("FAKE_ADB_STATE", "FAKE_ADB_KEYBOARD", "FAKE_ADB_FOCUS"):
             with open(env[k], "w") as f:
                 f.write("")
         return subprocess.run(
@@ -178,9 +202,25 @@ class TestCliCapture(unittest.TestCase):
              "--evidence-root", self.evidence_root,
              "--repo-root", self.repo_root,
              "--apk-path", self.apk_path,
-             "--apk-sha256", self.apk_sha256],
+             "--apk-sha256", self.apk_sha256,
+             "--fixture-root", self.fixture_root,
+             "--fixture-digests", self.fixture_digests_path],
             env=env, capture_output=True, cwd=self.repo_root_abs, timeout=30,
         )
+
+    def test_adversarial_fixture_drift(self):
+        # Corrupt one pinned snapshot file: the fixture transaction must
+        # fail closed before any mutation.
+        ram = os.path.join(
+            self.fixture_root, "M2_Qual_Fixture.avd",
+            "snapshots", "m2_pristine", "ram.bin")
+        with open(ram, "ab") as f:
+            f.write(b"drift")
+        result = self._run_cli()
+        self.assertNotEqual(result.returncode, 0,
+                            "CLI should fail on fixture digest drift")
+        combined = result.stderr.decode().lower()
+        self.assertIn("fixture", combined)
 
 
 if __name__ == "__main__":

--- a/android/scripts/tests/m2_device/test_cli_capture.py
+++ b/android/scripts/tests/m2_device/test_cli_capture.py
@@ -157,6 +157,18 @@ class TestCliCapture(unittest.TestCase):
 
         phases = [s["phase"] for s in record["steps"]]
 
+        # End-to-end mechanical boundary: an injected-digest run's
+        # persisted record must carry the fake-only verdict in the
+        # validate_fixture step itself — indistinguishable-from-pinned
+        # is what the boundary exists to prevent.
+        import base64
+        vf_steps = [s for s in record["steps"]
+                    if s["phase"] == "validate_fixture"]
+        self.assertTrue(vf_steps, "validate_fixture step missing")
+        vf_stdout = base64.b64decode(vf_steps[0]["result"]["stdout"])
+        self.assertIn(b"fake-only", vf_stdout)
+        self.assertIn(b"not an accepted-fixture qualification", vf_stdout)
+
         expected = ["preflight", "emulator_launch", "attach", "install",
                      "journey", "capture", "restore"]
         for i in range(len(expected) - 1):

--- a/docs/adr/0008-production-m2-journey-harness.md
+++ b/docs/adr/0008-production-m2-journey-harness.md
@@ -19,14 +19,18 @@ We amend the project complexity budget to exactly six production modules and at 
 - Static tests enforce these limits.
 
 Amended 2026-08-11 (issue #65 execution-boundary totality) to 750/2,100, amended
-2026-08-16 (issue #65 review findings) to 850/2,300, and amended again the same
-day (issue #63 fixture transaction) to `adb_harness.py` ≤ 1,000 and total ≤
-2,500. The #65 raises cover the provisional-ownership gate, the ledgered
-screenrecord boundary, bounded fallback PID termination, `SignalInterrupt`, and
-`TerminateOutcome` group-extinction verification; the #63 raise covers the
-fixture-byte transaction, pristine/editor pins, key-geometry validation, stale
-candidate retention, and private restoration facts. The budget's purpose — a
-small, reviewable, stdlib-only instrument — is unchanged.
+2026-08-16 (issue #65 review findings) to 850/2,300, again the same day (issue
+#63 fixture transaction) to 1,000/2,500, and once more that day to the round
+numbers `adb_harness.py` ≤ 1,100 and total ≤ 2,700 — the fourth raise was taken
+at review suggestion because 997/1,000 left no headroom and per-change
+amendments cost more than one deliberate round-number raise covering the
+remaining #64/#62 stages. The #65 raises cover the provisional-ownership gate,
+the ledgered screenrecord boundary, bounded fallback PID termination,
+`SignalInterrupt`, and `TerminateOutcome` group-extinction verification; the
+#63 raises cover the fixture-byte transaction, pristine/editor pins,
+key-geometry validation, stale candidate retention, and private restoration
+facts. The budget's purpose — a small, reviewable, stdlib-only instrument —
+is unchanged.
 
 ### 2. UI-Automation Mechanism
 We use subprocess-driven, argv-only commands dispatching to `adb shell input tap`, hierarchy XML dumps parsed with Python's standard library `xml.etree.ElementTree`, package/IME commands, `screencap`, and `screenrecord`.

--- a/docs/adr/0008-production-m2-journey-harness.md
+++ b/docs/adr/0008-production-m2-journey-harness.md
@@ -18,12 +18,15 @@ We amend the project complexity budget to exactly six production modules and at 
 - The remaining five files (`cli.py`, `commands.py`, `orchestrator.py`, `evidence.py`, `records.py`) have a remaining budget of 1,150 lines.
 - Static tests enforce these limits.
 
-Amended 2026-08-11 (issue #65 execution-boundary totality) to 750/2,100, and
-amended again 2026-08-16 (issue #65 review findings) to `adb_harness.py` ≤ 850
-and total ≤ 2,300. The second raise covers the provisional-ownership gate, the
-ledgered screenrecord boundary, bounded fallback PID termination,
-`SignalInterrupt`, and `TerminateOutcome` group-extinction verification. The
-budget's purpose — a small, reviewable, stdlib-only instrument — is unchanged.
+Amended 2026-08-11 (issue #65 execution-boundary totality) to 750/2,100, amended
+2026-08-16 (issue #65 review findings) to 850/2,300, and amended again the same
+day (issue #63 fixture transaction) to `adb_harness.py` ≤ 1,000 and total ≤
+2,500. The #65 raises cover the provisional-ownership gate, the ledgered
+screenrecord boundary, bounded fallback PID termination, `SignalInterrupt`, and
+`TerminateOutcome` group-extinction verification; the #63 raise covers the
+fixture-byte transaction, pristine/editor pins, key-geometry validation, stale
+candidate retention, and private restoration facts. The budget's purpose — a
+small, reviewable, stdlib-only instrument — is unchanged.
 
 ### 2. UI-Automation Mechanism
 We use subprocess-driven, argv-only commands dispatching to `adb shell input tap`, hierarchy XML dumps parsed with Python's standard library `xml.etree.ElementTree`, package/IME commands, `screencap`, and `screenrecord`.


### PR DESCRIPTION
## What

Stage 2 of the #69 tracker — issue #63: the qualification journey stops taking its preconditions on faith and starts proving them. Fake-only; no device; `records.py` untouched (private facts stay runtime-local by design).

## Pre-mutation pins (all fail-closed)

- **Fixture transaction:** the pinned snapshot bytes (`hardware.ini`, `ram.bin`, `textures.bin`) are digest-verified against the accepted #56 pins before any mutation; missing or drifted files fail closed with the offending file named. Production uses the pinned digests; fake-only runs inject honestly computed ones via new `--fixture-root` / `--fixture-digests` CLI flags (so the *mechanism* is what the fakes prove, never the pinned values themselves).
- **Animator scale** joins window/transition as a pinned `unset` (`null`).
- **Editor pristine pin:** observed empty and unfocused before the journey touches anything — the observed facts become the runtime-private restoration baseline (text / focus / panel presence). `verify_restore` re-observes after the snapshot reload and compares against that baseline; private facts never enter the public record, only the comparison verdict does.

## Coordinate honesty

Every pinned ASK coordinate must land inside **exactly one uniquely identified observed key** (content-desc label → bounds). Missing, duplicated, malformed, or non-containing geometry fails closed before the first tap. The pinned coordinates are now *proven*, not trusted.

## Explicit stale with retained candidate

Applying a candidate whose source changed must make zero mutations **and retain the candidate in REVIEW for an explicit dismiss** — never silently drop it. The journey now verifies retention (`verify_stale_candidate_retained`), screenshots the retained state, and dismisses explicitly (`dismiss_stale_candidate`, `verify_stale_dismissed`).

## Fake toolchain matches the product state machine

Focus modeling (editor tap → focused), per-key bounds in hierarchy dumps, animator answer, `emu snapshot load` reverts editor/keyboard/focus to pristine, and stale-apply retains the candidate. This is what lets restoration verification mean something at the CLI level.

## Evidence

- Local: suite **286/286, run twice** (12 new adversarial regressions: digest drift, missing fixture file, animator set, dirty/unfocused/nonempty editor pins, duplicate/missing/displaced key geometry, stale-candidate-not-retained, private-fact restoration mismatch, plus a real CLI fixture-drift run).
- Budgets: amended to 1,000 / 2,500 in `test_architecture.py` with a dated ADR-0008 note (actual: adb_harness 979, total 2,439).
- Hosted: appended at this head when the run completes.

Closes #63 when merged. #64/#62 remain queued.