### PR TITLE
feat(issue-64): canonical artifacts, manifests, and mechanically derived final receipts

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -35,6 +35,31 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-08-16, night — The receipt learns to count for itself
+
+- One exact flat artifact set is now enforced, not assumed: seven named
+  screenshots, one named video, the sixteen journey hierarchies, and the
+  private redacted command ledger (which is also the run's status log —
+  every production command's argv and status dimensions). A manifest
+  that is not exactly this set is rejected — missing, extra, renamed,
+  or nested entries alike — and the CLI now requires that
+  capture-manifest binding before it will report success; failed runs
+  still write their record, but partial artifacts can never pass.
+- The final receipt derives every dimension itself: media counts from
+  the exact bytes, journey/release/verification verdicts from the named
+  capture steps, privacy and structural media validation fail-closed.
+  The caller-controlled verdict, count, and artifact inputs are gone
+  from `finalize` and from the CLI — there is nothing left to vouch
+  for. Every run artifact (manifest, capture record, approval, receipt)
+  is written privately (0600) and atomically, so an interrupted write
+  can no longer leave a truncated file behind a success code. The
+  screenshot names are now sourced from the one canonical definition,
+  and the two deferred review notes from Stage 2 are documented
+  (defense-in-depth receipt blanking; device-only pinned-branch
+  coverage).
+
+---
+
 ## 2026-08-16, evening — The harness stops taking the fixture's word for it
 
 - The qualification journey now proves its preconditions instead of

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -67,7 +67,14 @@ Newest first, like all respectable patch notes.
   failures surface their actual diagnostic instead of masquerading as
   "no artifacts"; `dump_ledger` consolidated onto the one atomic-write
   path; and the harness cannot express a non-canonical hierarchy
-  label.
+  label. Second review round: the ledger check now enforces the exact
+  LedgerEntry schema — field set, types, known kind, and at least one
+  entry; a ledger written in interpretive dance no longer mints a
+  receipt, and the canonical fixture binds to the real
+  `CommandLedger.serialize()` so a key rename in `commands.py` fails
+  every canonical test rather than none — and a receipt is refused
+  unless the journey recorded at least one step and every capture step
+  completed. A failed journey is no longer countable-and-mintable.
 
 ---
 

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -56,7 +56,18 @@ Newest first, like all respectable patch notes.
   screenshot names are now sourced from the one canonical definition,
   and the two deferred review notes from Stage 2 are documented
   (defense-in-depth receipt blanking; device-only pinned-branch
-  coverage).
+  coverage). Review round: the receipt now refuses to mint itself
+  unless the verify_restore step completed (loading the snapshot is
+  not the same as checking it came home) and unless release and
+  verify_release completed — recorded-but-failed is no longer
+  mintable; subdirectories, symlinked or empty, are rejected from the
+  flat set at both manifest and finalize; canonical XML must parse
+  with a `<hierarchy>` root and the command ledger must decode in its
+  serialized entry shape, digest agreement notwithstanding; manifest
+  failures surface their actual diagnostic instead of masquerading as
+  "no artifacts"; `dump_ledger` consolidated onto the one atomic-write
+  path; and the harness cannot express a non-canonical hierarchy
+  label.
 
 ---
 

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from android.scripts.m2_device import commands, evidence
+from android.scripts.m2_device.evidence import CANONICAL_PNG_NAMES
 from android.scripts.m2_device.orchestrator import CaptureContext
 from android.scripts.m2_device.records import (
     CommandResult,
@@ -54,10 +55,7 @@ CANDIDATE_REPHRASING = (
     "\u201cTea at six.\u201d \u2014 though I must confess the genuine article is still en route."
 )
 
-SCREENSHOT_NAMES = [
-    "01-idle-typed", "02-loading-cancel", "03-review",
-    "04-applied", "05-dismissed", "06-stale", "07-settings",
-]
+SCREENSHOT_NAMES = list(CANONICAL_PNG_NAMES)
 
 KEYBOARD_PACKAGE = "biz.pixelperfectstudios.personaspeak"
 PANEL_STATE_RES_ID = f"{KEYBOARD_PACKAGE}:id/panel_state"
@@ -236,6 +234,9 @@ class AdbHarness:
         # from claiming the accepted fixture receipt: the recorded
         # digest is blanked, so no capture over arbitrary snapshot bytes
         # can present itself as an accepted-fixture qualification.
+        # Defense-in-depth only — the authoritative boundary is the
+        # verdict serialized into the validate_fixture step's stdout
+        # (this context field is not carried into CaptureRecord).
         receipt = "" if self._injected_fixture_digests else FIXTURE_RECEIPT_DIGEST
         return CaptureContext(
             repo_head=repo_head, apk_sha256=apk_sha,
@@ -463,6 +464,9 @@ class AdbHarness:
                 "validate_fixture",
                 b"fake-only fixture transaction: injected digests verified"
                 b" - not an accepted-fixture qualification")
+        # The pinned-success branch is only reachable on the real
+        # fixture (#55): no fake can forge the pinned digests, so its
+        # stdout is device-only coverage by design.
         return self._ok(
             "validate_fixture",
             f"Fixture identity validated against pinned receipt"

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import re
 import socket
-import tempfile
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from typing import Any
@@ -494,6 +493,10 @@ class AdbHarness:
         return self._ok("install_apk", b"APK installed and identity verified.")
 
     def _dump_hierarchy(self, label: str) -> tuple[CommandResult, Any]:
+        if label not in evidence.CANONICAL_HIERARCHY_LABELS:
+            # The code cannot express a non-canonical hierarchy name.
+            raise RuntimeError(
+                f"hierarchy label {label!r} is not in the canonical set")
         evidence_dir = os.path.join(self.run_dir, "artifacts")
         os.makedirs(evidence_dir, exist_ok=True)
         remote = "/sdcard/window_dump.xml"
@@ -1033,27 +1036,12 @@ class AdbHarness:
         evidence_dir = os.path.join(self.run_dir, "artifacts")
         os.makedirs(evidence_dir, exist_ok=True)
         path = os.path.join(evidence_dir, "command_ledger.json")
-        tmp_path = None
         try:
-            # Private (0600) and atomic: an interrupted write can never
-            # leave a truncated artifact behind the 0-return-code path.
-            fd, tmp_path = tempfile.mkstemp(
-                prefix=".command_ledger.", dir=evidence_dir)
-            with os.fdopen(fd, "w") as fh:
-                fh.write(self.ledger.serialize())
-                fh.flush()
-                os.fsync(fh.fileno())
-            os.replace(tmp_path, path)
-            tmp_path = None
+            evidence.write_private_atomic(
+                path, self.ledger.serialize().encode())
             return self._ok("ledger", f"{len(self.ledger)} entries -> {path}".encode())
         except OSError as e:
             return self._fail("ledger", str(e).encode())
-        finally:
-            if tmp_path is not None:
-                try:
-                    os.unlink(tmp_path)
-                except OSError:
-                    pass
 
     def release_emulator(self) -> CommandResult:
         if self.emulator_process is not None:

--- a/android/scripts/m2_device/cli.py
+++ b/android/scripts/m2_device/cli.py
@@ -50,6 +50,7 @@ def cmd_capture(args: argparse.Namespace) -> int:
 
     evidence_dir = os.path.join(run_dir, "artifacts")
     manifest = None
+    manifest_error = None
     if os.path.isdir(evidence_dir):
         try:
             manifest = evidence.build_manifest(evidence_dir)
@@ -59,11 +60,13 @@ def cmd_capture(args: argparse.Namespace) -> int:
                 os.path.join(run_dir, "manifest.json"),
                 json.dumps(manifest, sort_keys=True, indent=2).encode(),
             )
-        except ValueError:
-            # A failed run may leave partial or unparsable artifacts;
-            # the record is still written — canonical binding gates the
-            # success return below, not the failure record.
-            pass
+        except ValueError as e:
+            # A failed run may leave partial artifacts; the record is
+            # still written — canonical binding gates the success
+            # return below, not the failure record. Adversarial
+            # manifest findings (links, escapes) surface in the failure
+            # text rather than masquerading as "no artifacts".
+            manifest_error = e
 
     evidence.write_private_atomic(
         os.path.join(run_dir, "capture-record.json"), encode(record))
@@ -75,7 +78,8 @@ def cmd_capture(args: argparse.Namespace) -> int:
     # Capture-manifest binding before success: the run's artifacts must
     # be exactly the canonical set, or the capture does not succeed.
     if manifest is None:
-        print("qualification failed: no artifacts produced", file=sys.stderr)
+        reason = manifest_error if manifest_error else "no artifacts produced"
+        print(f"qualification failed: {reason}", file=sys.stderr)
         return 1
     try:
         evidence.enforce_canonical_set(manifest)

--- a/android/scripts/m2_device/cli.py
+++ b/android/scripts/m2_device/cli.py
@@ -49,20 +49,38 @@ def cmd_capture(args: argparse.Namespace) -> int:
     record = orchestrator.execute()
 
     evidence_dir = os.path.join(run_dir, "artifacts")
+    manifest = None
     if os.path.isdir(evidence_dir):
-        manifest = evidence.build_manifest(evidence_dir)
-        manifest_d = evidence.manifest_digest(manifest)
-        manifest_path = os.path.join(run_dir, "manifest.json")
-        with open(manifest_path, "w") as f:
-            json.dump(manifest, f, sort_keys=True, indent=2)
-        record = dataclasses.replace(record, manifest_digest=manifest_d)
+        try:
+            manifest = evidence.build_manifest(evidence_dir)
+            manifest_d = evidence.manifest_digest(manifest)
+            record = dataclasses.replace(record, manifest_digest=manifest_d)
+            evidence.write_private_atomic(
+                os.path.join(run_dir, "manifest.json"),
+                json.dumps(manifest, sort_keys=True, indent=2).encode(),
+            )
+        except ValueError:
+            # A failed run may leave partial or unparsable artifacts;
+            # the record is still written — canonical binding gates the
+            # success return below, not the failure record.
+            pass
 
-    record_path = os.path.join(run_dir, "capture-record.json")
-    with open(record_path, "wb") as f:
-        f.write(encode(record))
+    evidence.write_private_atomic(
+        os.path.join(run_dir, "capture-record.json"), encode(record))
 
     if orchestrator.terminal is not None:
         print(f"qualification failed: {orchestrator.terminal}", file=sys.stderr)
+        return 1
+
+    # Capture-manifest binding before success: the run's artifacts must
+    # be exactly the canonical set, or the capture does not succeed.
+    if manifest is None:
+        print("qualification failed: no artifacts produced", file=sys.stderr)
+        return 1
+    try:
+        evidence.enforce_canonical_set(manifest)
+    except ValueError as e:
+        print(f"qualification failed: {e}", file=sys.stderr)
         return 1
 
     required = {"verify_restore", "release_emulator", "verify_release"}
@@ -101,15 +119,11 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         evidence_subdir = args.run_dir
     receipt = evidence.finalize(
         capture, approval, manifest, evidence_subdir,
-        restoration_verdict=args.restoration_verdict,
-        counts=json.loads(args.counts),
         evidence_commit=args.evidence_commit,
-        artifacts={name: manifest[name] for name in sorted(manifest)},
     )
     out = encode(receipt)
     if args.output:
-        with open(args.output, "wb") as f:
-            f.write(out)
+        evidence.write_private_atomic(args.output, out)
     else:
         sys.stdout.buffer.write(out)
     return 0
@@ -133,8 +147,7 @@ def cmd_approve(args: argparse.Namespace) -> int:
     )
     out = encode(rec)
     if args.output:
-        with open(args.output, "wb") as f:
-            f.write(out)
+        evidence.write_private_atomic(args.output, out)
     else:
         sys.stdout.buffer.write(out)
     return 0
@@ -168,8 +181,6 @@ def build_parser() -> argparse.ArgumentParser:
     fin.add_argument("--approval", required=True)
     fin.add_argument("--manifest", required=True)
     fin.add_argument("--run-dir", required=True)
-    fin.add_argument("--restoration-verdict", default="verified")
-    fin.add_argument("--counts", default="{}")
     fin.add_argument("--evidence-commit", default="")
     fin.add_argument("--output", default=None)
     fin.set_defaults(func=cmd_finalize)

--- a/android/scripts/m2_device/evidence.py
+++ b/android/scripts/m2_device/evidence.py
@@ -28,6 +28,65 @@ _CREDENTIAL_PATTERNS = [
     re.compile(rb"AIza[0-9A-Za-z_\-]{35}"),
 ]
 
+# One exact flat artifact set (issue #64): seven named screenshots, one
+# named video, the journey's required UI hierarchies, and the private
+# redacted command ledger — which is also the run's status log: it
+# records every production command's argv and status dimensions. Any
+# manifest that is not exactly this set is rejected.
+CANONICAL_PNG_NAMES = (
+    "01-idle-typed", "02-loading-cancel", "03-review",
+    "04-applied", "05-dismissed", "06-stale", "07-settings",
+)
+CANONICAL_MP4_NAME = "journey"
+CANONICAL_HIERARCHY_LABELS = (
+    "journey", "keyboard_check", "clear",
+    "loading_1", "after_cancel_loading",
+    "loading_2", "review_2", "after_apply",
+    "loading_3", "review_3", "after_dismiss",
+    "loading_4", "review_4", "after_stale", "after_stale_dismiss",
+    "verify_restore",
+)
+CANONICAL_LEDGER_NAME = "command_ledger.json"
+CANONICAL_ARTIFACTS = frozenset(
+    f"{n}.png" for n in CANONICAL_PNG_NAMES
+) | {f"{CANONICAL_MP4_NAME}.mp4"} | {
+    f"{label}.xml" for label in CANONICAL_HIERARCHY_LABELS
+} | {CANONICAL_LEDGER_NAME}
+
+
+def enforce_canonical_set(manifest: dict[str, str]) -> None:
+    """The manifest must be exactly the canonical artifact set — no
+    missing, extra, renamed, or nested entries."""
+    actual = set(manifest)
+    missing = sorted(CANONICAL_ARTIFACTS - actual)
+    extra = sorted(actual - CANONICAL_ARTIFACTS)
+    if missing:
+        raise ValueError(f"canonical artifacts missing: {missing}")
+    if extra:
+        raise ValueError(f"non-canonical artifacts rejected: {extra}")
+
+
+def write_private_atomic(path: str, data: bytes) -> None:
+    """Private (0600) atomic write: same-dir temp file, fsync, replace.
+    An interrupted write can never leave a truncated artifact behind."""
+    directory = os.path.dirname(os.path.abspath(path))
+    tmp_path = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(
+            prefix="." + os.path.basename(path) + ".", dir=directory)
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+        tmp_path = None
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
 
 def scan_text(data: bytes) -> list[str]:
     findings = []
@@ -165,11 +224,11 @@ def finalize(
     manifest: dict[str, str],
     evidence_dir: str,
     *,
-    restoration_verdict: str,
-    counts: dict[str, int],
-    evidence_commit: str,
-    artifacts: dict[str, str],
+    evidence_commit: str = "",
 ) -> FinalReceipt:
+    """Produce the final receipt with every dimension derived from the
+    exact bytes and the named capture steps. No caller-supplied verdict,
+    count, or artifact list survives into the receipt."""
     cap_d = record_digest(capture)
     appr_d = record_digest(approval)
     man_d = manifest_digest(manifest)
@@ -183,6 +242,7 @@ def finalize(
         raise ValueError("capture record has no manifest digest")
     if capture.manifest_digest != man_d:
         raise ValueError("capture-record manifest_digest does not match supplied manifest")
+    enforce_canonical_set(manifest)
     for name in manifest:
         if "/" in name or ".." in name or os.path.isabs(name):
             raise ValueError(f"manifest key traverses path: {name}")
@@ -211,21 +271,23 @@ def finalize(
             )
     else:
         raise ValueError("capture record has no restoration step")
+
+    # Derived dimensions: counts come from bytes; journey, release, and
+    # verification verdicts come from the named capture steps.
+    def _step_completed(phase: str) -> bool:
+        steps = [s for s in capture.steps if s.phase == phase]
+        return bool(steps) and steps[-1].cause == TerminalCause.COMPLETED
+
     derived_counts = {
         "png": sum(1 for n in manifest if n.endswith(".png")),
         "mp4": sum(1 for n in manifest if n.endswith(".mp4")),
+        "journey_steps_completed": sum(
+            1 for s in capture.steps
+            if s.phase == "journey" and s.cause == TerminalCause.COMPLETED
+        ),
+        "release_ok": 1 if _step_completed("release_emulator") else 0,
+        "verify_release_ok": 1 if _step_completed("verify_release") else 0,
     }
-    if counts:
-        allowed = {"screenshots": "png", "videos": "mp4"}
-        unknown = set(counts) - set(allowed)
-        if unknown:
-            raise ValueError(f"unknown count keys: {sorted(unknown)}")
-        for k, v in counts.items():
-            mapped = allowed[k]
-            if v != derived_counts[mapped]:
-                raise ValueError(
-                    f"caller count {k}={v} != manifest-derived {mapped}={derived_counts[mapped]}"
-                )
     privacy_ok = scan_directory(evidence_dir)
     if not privacy_ok:
         raise ValueError("privacy scan failed — credential patterns detected in evidence")

--- a/android/scripts/m2_device/evidence.py
+++ b/android/scripts/m2_device/evidence.py
@@ -8,6 +8,7 @@ import os
 import re
 import struct
 import tempfile
+import xml.etree.ElementTree as ET
 import zlib
 from pathlib import Path
 
@@ -67,8 +68,9 @@ def enforce_canonical_set(manifest: dict[str, str]) -> None:
 
 
 def write_private_atomic(path: str, data: bytes) -> None:
-    """Private (0600) atomic write: same-dir temp file, fsync, replace.
-    An interrupted write can never leave a truncated artifact behind."""
+    """Private (0600) atomic write: same-dir temp file, fsync, replace,
+    directory fsync. An interrupted write can never leave a truncated
+    artifact behind a success code."""
     directory = os.path.dirname(os.path.abspath(path))
     tmp_path = None
     try:
@@ -80,12 +82,34 @@ def write_private_atomic(path: str, data: bytes) -> None:
             os.fsync(fh.fileno())
         os.replace(tmp_path, path)
         tmp_path = None
+        try:
+            dir_fd = os.open(directory, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass  # best-effort: content durability holds via file fsync
     finally:
         if tmp_path is not None:
             try:
                 os.unlink(tmp_path)
             except OSError:
                 pass
+
+
+def reject_nonflat(dir_path: str) -> None:
+    """The canonical artifact set is flat: any subdirectory — real or
+    symlinked, populated or empty — is rejected. File symlinks keep
+    their own per-file rejection messages."""
+    with os.scandir(dir_path) as entries:
+        for entry in entries:
+            is_dir_link = (
+                entry.is_symlink() and entry.is_dir(follow_symlinks=True))
+            if entry.is_dir(follow_symlinks=False) or is_dir_link:
+                raise ValueError(
+                    "non-flat evidence directory rejected:"
+                    f" {entry.name} is a directory, not a flat artifact")
 
 
 def scan_text(data: bytes) -> list[str]:
@@ -169,6 +193,7 @@ def validate_mp4(data: bytes) -> bool:
 
 
 def build_manifest(dir_path: str) -> dict[str, str]:
+    reject_nonflat(dir_path)
     manifest: dict[str, str] = {}
     base = os.path.realpath(dir_path)
     for root, _, files in os.walk(dir_path):
@@ -218,6 +243,38 @@ def _validate_media(path: str, name: str) -> bool:
     return True
 
 
+_LEDGER_ENTRY_FIELDS = frozenset({
+    "argv", "start_utc", "end_utc", "transport_rc",
+    "remote_rc", "timed_out", "kind",
+})
+
+
+def validate_structural(name: str, data: bytes) -> None:
+    """Structural validation for the canonical text artifacts: every
+    hierarchy XML must parse with a <hierarchy> root; the command
+    ledger must decode as JSON in the serialized entry shape. Digest
+    agreement never excuses malformed content."""
+    if name.endswith(".xml"):
+        try:
+            root = ET.fromstring(data)
+        except ET.ParseError:
+            raise ValueError(f"malformed XML artifact: {name}")
+        if root.tag != "hierarchy":
+            raise ValueError(f"XML artifact root is not <hierarchy>: {name}")
+    elif name == CANONICAL_LEDGER_NAME:
+        try:
+            entries = json.loads(data.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            raise ValueError(f"malformed ledger JSON: {name}")
+        if not isinstance(entries, list):
+            raise ValueError(f"ledger JSON is not a list: {name}")
+        for entry in entries:
+            if (not isinstance(entry, dict)
+                    or not _LEDGER_ENTRY_FIELDS <= set(entry)):
+                raise ValueError(
+                    f"ledger entry missing required fields: {name}")
+
+
 def finalize(
     capture: CaptureRecord,
     approval: ApprovalRecord,
@@ -243,6 +300,7 @@ def finalize(
     if capture.manifest_digest != man_d:
         raise ValueError("capture-record manifest_digest does not match supplied manifest")
     enforce_canonical_set(manifest)
+    reject_nonflat(evidence_dir)
     for name in manifest:
         if "/" in name or ".." in name or os.path.isabs(name):
             raise ValueError(f"manifest key traverses path: {name}")
@@ -273,10 +331,25 @@ def finalize(
         raise ValueError("capture record has no restoration step")
 
     # Derived dimensions: counts come from bytes; journey, release, and
-    # verification verdicts come from the named capture steps.
+    # verification verdicts come from the named capture steps. The
+    # verdicts are enforced, not just recorded — a receipt is refused
+    # when any of them did not complete.
+    def _steps(phase: str):
+        return [s for s in capture.steps if s.phase == phase]
+
     def _step_completed(phase: str) -> bool:
-        steps = [s for s in capture.steps if s.phase == phase]
+        steps = _steps(phase)
         return bool(steps) and steps[-1].cause == TerminalCause.COMPLETED
+
+    verify_steps = _steps("verify_restore")
+    if not verify_steps or verify_steps[-1].cause != TerminalCause.COMPLETED:
+        raise ValueError(
+            "verify_restore step missing or not COMPLETED — the snapshot "
+            "loading is not itself a restoration verdict")
+    for phase in ("release_emulator", "verify_release"):
+        if not _step_completed(phase):
+            raise ValueError(
+                f"{phase} did not complete — receipt refused")
 
     derived_counts = {
         "png": sum(1 for n in manifest if n.endswith(".png")),
@@ -300,6 +373,9 @@ def finalize(
     )
     if not media_ok:
         raise ValueError("media validation failed — one or more files are structurally invalid")
+    for name in sorted(manifest):
+        with open(os.path.join(evidence_dir, name), "rb") as fh:
+            validate_structural(name, fh.read())
     return FinalReceipt(
         capture_digest=cap_d,
         approval_digest=appr_d,

--- a/android/scripts/m2_device/evidence.py
+++ b/android/scripts/m2_device/evidence.py
@@ -247,13 +247,44 @@ _LEDGER_ENTRY_FIELDS = frozenset({
     "argv", "start_utc", "end_utc", "transport_rc",
     "remote_rc", "timed_out", "kind",
 })
+_LEDGER_KINDS = frozenset({"shell", "host", "launch"})
+
+
+def _validate_ledger_entry(name: str, idx: int, entry: object) -> None:
+    """Exact LedgerEntry serialized shape: field set, types, and known
+    kind. Key presence alone is not a schema."""
+    def bad(what: str) -> ValueError:
+        return ValueError(f"ledger entry {idx} {what}: {name}")
+
+    if not isinstance(entry, dict):
+        raise bad("is not an object")
+    if set(entry) != _LEDGER_ENTRY_FIELDS:
+        raise bad("field set mismatch")
+    if (not isinstance(entry["argv"], list)
+            or not all(isinstance(a, str) for a in entry["argv"])):
+        raise bad("argv is not list[str]")
+    if (not isinstance(entry["start_utc"], str)
+            or not isinstance(entry["end_utc"], str)):
+        raise bad("timestamps are not strings")
+    trc = entry["transport_rc"]
+    if not isinstance(trc, int) or isinstance(trc, bool):
+        raise bad("transport_rc is not an integer")
+    rrc = entry["remote_rc"]
+    if rrc is not None and (not isinstance(rrc, int)
+                            or isinstance(rrc, bool)):
+        raise bad("remote_rc is not int|null")
+    if not isinstance(entry["timed_out"], bool):
+        raise bad("timed_out is not a boolean")
+    if entry["kind"] not in _LEDGER_KINDS:
+        raise bad("kind is not one of shell/host/launch")
 
 
 def validate_structural(name: str, data: bytes) -> None:
     """Structural validation for the canonical text artifacts: every
     hierarchy XML must parse with a <hierarchy> root; the command
-    ledger must decode as JSON in the serialized entry shape. Digest
-    agreement never excuses malformed content."""
+    ledger must decode as a non-empty JSON list in the exact
+    serialized LedgerEntry shape. Digest agreement never excuses
+    malformed content."""
     if name.endswith(".xml"):
         try:
             root = ET.fromstring(data)
@@ -266,13 +297,11 @@ def validate_structural(name: str, data: bytes) -> None:
             entries = json.loads(data.decode("utf-8"))
         except (ValueError, UnicodeDecodeError):
             raise ValueError(f"malformed ledger JSON: {name}")
-        if not isinstance(entries, list):
-            raise ValueError(f"ledger JSON is not a list: {name}")
-        for entry in entries:
-            if (not isinstance(entry, dict)
-                    or not _LEDGER_ENTRY_FIELDS <= set(entry)):
-                raise ValueError(
-                    f"ledger entry missing required fields: {name}")
+        if not isinstance(entries, list) or not entries:
+            raise ValueError(
+                f"ledger JSON must be a non-empty list: {name}")
+        for idx, entry in enumerate(entries):
+            _validate_ledger_entry(name, idx, entry)
 
 
 def finalize(
@@ -350,6 +379,16 @@ def finalize(
         if not _step_completed(phase):
             raise ValueError(
                 f"{phase} did not complete — receipt refused")
+    journey_steps = [s for s in capture.steps if s.phase == "journey"]
+    if not journey_steps:
+        raise ValueError("no journey steps — receipt refused")
+    failed_steps = [s for s in capture.steps
+                    if s.cause != TerminalCause.COMPLETED]
+    if failed_steps:
+        first = failed_steps[0]
+        raise ValueError(
+            f"capture step {first.phase}/{first.operation} was "
+            f"{first.cause}, not COMPLETED — receipt refused")
 
     derived_counts = {
         "png": sum(1 for n in manifest if n.endswith(".png")),

--- a/android/scripts/tests/m2_device/test_evidence.py
+++ b/android/scripts/tests/m2_device/test_evidence.py
@@ -179,11 +179,40 @@ class TestEvidenceRoot(unittest.TestCase):
         evidence.check_evidence_root("/opt/evidence", "/repo")
 
 
+def _valid_png_bytes():
+    import struct, zlib
+    sig = b'\x89PNG\r\n\x1a\n'
+    ihdr_data = struct.pack('>IIBBBBB', 1, 1, 8, 2, 0, 0, 0)
+    ihdr = struct.pack('>I', 13) + b'IHDR' + ihdr_data + struct.pack('>I', zlib.crc32(b'IHDR' + ihdr_data) & 0xFFFFFFFF)
+    comp = zlib.compress(b'\x00\xff\x00\x00')
+    idat = struct.pack('>I', len(comp)) + b'IDAT' + comp + struct.pack('>I', zlib.crc32(b'IDAT' + comp) & 0xFFFFFFFF)
+    iend = struct.pack('>I', 0) + b'IEND' + struct.pack('>I', zlib.crc32(b'IEND') & 0xFFFFFFFF)
+    return sig + ihdr + idat + iend
+
+
+def _valid_mp4_bytes():
+    import struct
+    payload = b'isom' + b'\x00\x00\x00\x00' + b'isom'
+    ftyp = struct.pack('>I', 8 + len(payload)) + b'ftyp' + payload
+    mdat = struct.pack('>I', 12) + b'mdat' + b'\x00\x00\x00\x00'
+    return ftyp + mdat
+
+
 class TestFinalize(unittest.TestCase):
-    def _capture(self, manifest_digest=None):
+    def _capture(self, manifest_digest=None, with_steps=False):
+        steps = []
+        if with_steps:
+            for phase in ("journey", "release_emulator", "verify_release"):
+                steps.append(StepRecord(
+                    phase=phase, operation=phase, input_digest=None,
+                    output_digest=None,
+                    result=CommandResult(argv=[], start_utc="", end_utc="",
+                                         returncode=0, stdout=b"", stderr=b""),
+                    cause=TerminalCause.COMPLETED,
+                ))
         return CaptureRecord(
             repo_head="abc", apk_sha256="def", tools=[],
-            prior_state=None, steps=[],
+            prior_state=None, steps=steps,
             restoration=StepRecord(
                 phase="restore", operation="restore device state",
                 input_digest=None, output_digest=None,
@@ -201,48 +230,54 @@ class TestFinalize(unittest.TestCase):
             approved_utc="2026-08-06T14:00:00Z",
         )
 
-    def test_successful_finalize(self):
+    def _canonical(self, d, journey_xml=b"<hierarchy/>"):
+        """Materialize the exact canonical artifact set and its manifest."""
+        files = {}
+        for n in evidence.CANONICAL_PNG_NAMES:
+            files[f"{n}.png"] = _valid_png_bytes()
+        files[f"{evidence.CANONICAL_MP4_NAME}.mp4"] = _valid_mp4_bytes()
+        for label in evidence.CANONICAL_HIERARCHY_LABELS:
+            files[f"{label}.xml"] = (
+                journey_xml if label == "journey" else b"<hierarchy/>")
+        files[evidence.CANONICAL_LEDGER_NAME] = b"[]"
+        man = {}
+        for name, data in files.items():
+            with open(os.path.join(d, name), "wb") as f:
+                f.write(data)
+            man[name] = hashlib.sha256(data).hexdigest()
+        return man
+
+    def test_successful_finalize_derives_all_dimensions(self):
         with tempfile.TemporaryDirectory() as d:
-            import struct, zlib
-            sig = b'\x89PNG\r\n\x1a\n'
-            ihdr_data = struct.pack('>IIBBBBB', 1, 1, 8, 2, 0, 0, 0)
-            ihdr = struct.pack('>I', 13) + b'IHDR' + ihdr_data + struct.pack('>I', zlib.crc32(b'IHDR' + ihdr_data) & 0xFFFFFFFF)
-            comp = zlib.compress(b'\x00\xff\x00\x00')
-            idat = struct.pack('>I', len(comp)) + b'IDAT' + comp + struct.pack('>I', zlib.crc32(b'IDAT' + comp) & 0xFFFFFFFF)
-            iend = struct.pack('>I', 0) + b'IEND' + struct.pack('>I', zlib.crc32(b'IEND') & 0xFFFFFFFF)
-            png = sig + ihdr + idat + iend
-            with open(os.path.join(d, "screenshot.png"), "wb") as f:
-                f.write(png)
-            man = {"screenshot.png": hashlib.sha256(png).hexdigest()}
-            cap = self._capture(manifest_digest=evidence.manifest_digest(man))
-            appr = self._make_approval(cap, man)
-            with open(os.path.join(d, "log.txt"), "w") as f:
-                f.write("clean log\n")
-            man["log.txt"] = hashlib.sha256(b"clean log\n").hexdigest()
-            cap = self._capture(manifest_digest=evidence.manifest_digest(man))
+            man = self._canonical(d)
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(man),
+                with_steps=True,
+            )
             appr = self._make_approval(cap, man)
             receipt = evidence.finalize(
-                cap, appr, man, d,
-                restoration_verdict="verified", counts={},
-                evidence_commit="sha", artifacts=man,
-            )
+                cap, appr, man, d, evidence_commit="sha")
         self.assertTrue(receipt.privacy_ok)
         self.assertTrue(receipt.media_ok)
+        self.assertEqual(receipt.restoration_verdict, "verified")
+        self.assertEqual(receipt.counts["png"], 7)
+        self.assertEqual(receipt.counts["mp4"], 1)
+        self.assertEqual(receipt.counts["journey_steps_completed"], 1)
+        self.assertEqual(receipt.counts["release_ok"], 1)
+        self.assertEqual(receipt.counts["verify_release_ok"], 1)
+        self.assertEqual(receipt.evidence_commit, "sha")
 
     def test_drift_blocks_finalize(self):
         cap = self._capture()
         man = {"x": "y"}
         appr = ApprovalRecord(
             reviewer="r", capture_digest="WRONG",
-            manifest_digest=evidence.manifest_digest(man), decision=VisualReview.APPROVED,
+            manifest_digest=evidence.manifest_digest(man),
+            decision=VisualReview.APPROVED,
             approved_utc="2026-08-06T14:00:00Z",
         )
         with self.assertRaises(ValueError):
-            evidence.finalize(
-                cap, appr, man, "/nonexistent",
-                restoration_verdict="verified", counts={},
-                evidence_commit="", artifacts={},
-            )
+            evidence.finalize(cap, appr, man, "/nonexistent")
 
     def test_manifest_drift_blocks_finalize(self):
         cap = self._capture()
@@ -252,123 +287,131 @@ class TestFinalize(unittest.TestCase):
             approved_utc="2026-08-06T14:00:00Z",
         )
         with self.assertRaises(ValueError):
-            evidence.finalize(
-                cap, appr, {"x": "y"}, "/nonexistent",
-                restoration_verdict="verified", counts={},
-                evidence_commit="", artifacts={},
-            )
+            evidence.finalize(cap, appr, {"x": "y"}, "/nonexistent")
 
     def test_rejected_approval_blocks_finalize(self):
         cap = self._capture()
         man = {"screenshot.png": "abc"}
         appr = self._make_approval(cap, man, decision=VisualReview.REJECTED)
         with self.assertRaises(ValueError):
-            evidence.finalize(
-                cap, appr, man, "/nonexistent",
-                restoration_verdict="verified", counts={},
-                evidence_commit="", artifacts={},
-            )
+            evidence.finalize(cap, appr, man, "/nonexistent")
 
-    def test_finalize_detects_privacy_violation(self):
-        content = b"api_key=sk-1234567890abcdef\n"
-        man = {"log.txt": hashlib.sha256(content).hexdigest()}
-        cap = self._capture(manifest_digest=evidence.manifest_digest(man))
-        appr = self._make_approval(cap, man)
+    def test_finalize_rejects_missing_canonical_artifact(self):
         with tempfile.TemporaryDirectory() as d:
-            with open(os.path.join(d, "log.txt"), "wb") as f:
-                f.write(content)
+            man = self._canonical(d)
+            partial = {k: v for k, v in man.items() if k != "06-stale.png"}
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(partial))
+            appr = self._make_approval(cap, partial)
             with self.assertRaises(ValueError) as cm:
-                evidence.finalize(
-                    cap, appr, man, d,
-                    restoration_verdict="verified", counts={},
-                    evidence_commit="", artifacts=man,
-                )
-            self.assertIn("privacy", str(cm.exception))
+                evidence.finalize(cap, appr, partial, d)
+            self.assertIn("canonical artifacts missing", str(cm.exception))
 
-    def test_finalize_rejects_missing_restoration(self):
-        man = {"s.png": hashlib.sha256(b"x").hexdigest()}
-        cap = CaptureRecord(
-            repo_head="a", apk_sha256="b", tools=[],
-            prior_state=None, steps=[], restoration=None,
-            manifest_digest=evidence.manifest_digest(man),
-        )
-        appr = self._make_approval(cap, man)
+    def test_finalize_rejects_extra_artifact_key(self):
         with tempfile.TemporaryDirectory() as d:
-            with open(os.path.join(d, "s.png"), "wb") as f:
-                f.write(b"x")
+            man = self._canonical(d)
+            with_extra = dict(man)
+            with_extra["notes.txt"] = hashlib.sha256(b"x").hexdigest()
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(with_extra))
+            appr = self._make_approval(cap, with_extra)
             with self.assertRaises(ValueError) as cm:
-                evidence.finalize(
-                    cap, appr, man, d,
-                    restoration_verdict="verified", counts={},
-                    evidence_commit="", artifacts=man,
-                )
-            self.assertIn("no restoration", str(cm.exception))
+                evidence.finalize(cap, appr, with_extra, d)
+            self.assertIn("non-canonical", str(cm.exception))
 
-    def test_finalize_rejects_unknown_count_keys(self):
-        import struct, zlib
-        sig = b'\x89PNG\r\n\x1a\n'
-        ihdr_data = struct.pack('>IIBBBBB', 1, 1, 8, 2, 0, 0, 0)
-        ihdr = struct.pack('>I', 13) + b'IHDR' + ihdr_data + struct.pack('>I', zlib.crc32(b'IHDR' + ihdr_data) & 0xFFFFFFFF)
-        comp = zlib.compress(b'\x00\xff\x00\x00')
-        idat = struct.pack('>I', len(comp)) + b'IDAT' + comp + struct.pack('>I', zlib.crc32(b'IDAT' + comp) & 0xFFFFFFFF)
-        iend = struct.pack('>I', 0) + b'IEND' + struct.pack('>I', zlib.crc32(b'IEND') & 0xFFFFFFFF)
-        png = sig + ihdr + idat + iend
+    def test_finalize_rejects_swapped_artifact_bytes(self):
         with tempfile.TemporaryDirectory() as d:
-            with open(os.path.join(d, "s.png"), "wb") as f:
-                f.write(png)
-            man = {"s.png": hashlib.sha256(png).hexdigest()}
+            man = self._canonical(d)
+            # Same canonical name, different bytes than approved.
+            with open(os.path.join(d, "after_apply.xml"), "wb") as f:
+                f.write(b"<swapped/>")
             cap = self._capture(manifest_digest=evidence.manifest_digest(man))
             appr = self._make_approval(cap, man)
             with self.assertRaises(ValueError) as cm:
-                evidence.finalize(
-                    cap, appr, man, d,
-                    restoration_verdict="verified",
-                    counts={"screenshots": 1, "bogus": 99},
-                    evidence_commit="", artifacts=man,
-                )
-            self.assertIn("unknown count", str(cm.exception))
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("digest mismatch", str(cm.exception))
 
     def test_finalize_rejects_unlisted_files(self):
-        import struct, zlib
-        sig = b'\x89PNG\r\n\x1a\n'
-        ihdr_data = struct.pack('>IIBBBBB', 1, 1, 8, 2, 0, 0, 0)
-        ihdr = struct.pack('>I', 13) + b'IHDR' + ihdr_data + struct.pack('>I', zlib.crc32(b'IHDR' + ihdr_data) & 0xFFFFFFFF)
-        comp = zlib.compress(b'\x00\xff\x00\x00')
-        idat = struct.pack('>I', len(comp)) + b'IDAT' + comp + struct.pack('>I', zlib.crc32(b'IDAT' + comp) & 0xFFFFFFFF)
-        iend = struct.pack('>I', 0) + b'IEND' + struct.pack('>I', zlib.crc32(b'IEND') & 0xFFFFFFFF)
-        png = sig + ihdr + idat + iend
         with tempfile.TemporaryDirectory() as d:
-            with open(os.path.join(d, "s.png"), "wb") as f:
-                f.write(png)
+            man = self._canonical(d)
             with open(os.path.join(d, "extra.txt"), "w") as f:
                 f.write("unlisted")
-            man = {"s.png": hashlib.sha256(png).hexdigest()}
             cap = self._capture(manifest_digest=evidence.manifest_digest(man))
             appr = self._make_approval(cap, man)
             with self.assertRaises(ValueError) as cm:
-                evidence.finalize(
-                    cap, appr, man, d,
-                    restoration_verdict="verified", counts={},
-                    evidence_commit="", artifacts=man,
-                )
+                evidence.finalize(cap, appr, man, d)
             self.assertIn("unlisted", str(cm.exception))
 
-
-    def test_empty_manifest_media_fails_closed(self):
-        content = b"clean text\n"
-        man = {"log.txt": hashlib.sha256(content).hexdigest()}
-        cap = self._capture(manifest_digest=evidence.manifest_digest(man))
-        appr = self._make_approval(cap, man)
+    def test_finalize_detects_privacy_violation(self):
+        dirty = b"api_key=sk-1234567890abcdef\n"
         with tempfile.TemporaryDirectory() as d:
-            with open(os.path.join(d, "log.txt"), "wb") as f:
-                f.write(content)
+            man = self._canonical(d, journey_xml=dirty)
+            cap = self._capture(manifest_digest=evidence.manifest_digest(man))
+            appr = self._make_approval(cap, man)
             with self.assertRaises(ValueError) as cm:
-                evidence.finalize(
-                    cap, appr, man, d,
-                    restoration_verdict="verified", counts={},
-                    evidence_commit="", artifacts={},
-                )
-            self.assertIn("no media", str(cm.exception))
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("privacy", str(cm.exception))
+
+    def test_finalize_rejects_invalid_media_bytes(self):
+        # Bytes match the manifest (no drift) but are structurally
+        # invalid media — structural validation is its own fail-closed
+        # dimension, not just drift detection.
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d)
+            corrupt = b"not a png"
+            with open(os.path.join(d, "04-applied.png"), "wb") as f:
+                f.write(corrupt)
+            man["04-applied.png"] = hashlib.sha256(corrupt).hexdigest()
+            cap = self._capture(manifest_digest=evidence.manifest_digest(man))
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("media validation", str(cm.exception))
+
+    def test_finalize_rejects_missing_restoration(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d)
+            cap = CaptureRecord(
+                repo_head="a", apk_sha256="b", tools=[],
+                prior_state=None, steps=[], restoration=None,
+                manifest_digest=evidence.manifest_digest(man),
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("no restoration", str(cm.exception))
+
+
+class TestCanonicalSetAndAtomicWrites(unittest.TestCase):
+
+    def test_canonical_set_rejects_nested_entry(self):
+        with self.assertRaises(ValueError) as cm:
+            evidence.enforce_canonical_set(
+                {"sub/dir/01-idle-typed.png": "h"})
+        self.assertIn("missing", str(cm.exception))
+
+    def test_canonical_set_rejects_extra_entry(self):
+        man = {name: "h" for name in evidence.CANONICAL_ARTIFACTS}
+        man["notes.txt"] = "h"
+        with self.assertRaises(ValueError) as cm:
+            evidence.enforce_canonical_set(man)
+        self.assertIn("non-canonical", str(cm.exception))
+
+    def test_canonical_set_exact_passes(self):
+        man = {name: "h" for name in evidence.CANONICAL_ARTIFACTS}
+        evidence.enforce_canonical_set(man)  # must not raise
+
+    def test_write_private_atomic_private_and_clean(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "capture-record.json")
+            evidence.write_private_atomic(path, b"payload")
+            with open(path, "rb") as f:
+                self.assertEqual(f.read(), b"payload")
+            self.assertEqual(
+                __import__("stat").S_IMODE(os.stat(path).st_mode), 0o600)
+            leftovers = [f for f in os.listdir(d)
+                         if f != "capture-record.json"]
+            self.assertEqual(leftovers, [])
 
 
 class TestCLI(unittest.TestCase):

--- a/android/scripts/tests/m2_device/test_evidence.py
+++ b/android/scripts/tests/m2_device/test_evidence.py
@@ -231,7 +231,21 @@ class TestFinalize(unittest.TestCase):
             approved_utc="2026-08-06T14:00:00Z",
         )
 
-    def _canonical(self, d, journey_xml=b"<hierarchy/>"):
+    def _ledger_bytes(self):
+        """A real CommandLedger serialization — binding the canonical
+        fixture to the production entry shape (rename a key in
+        commands.py and every canonical test fails, not just one)."""
+        from android.scripts.m2_device import commands as _C
+        ledger = _C.CommandLedger()
+        ledger.record(
+            ["adb", "-s", "emulator-5554", "shell", "getprop",
+             "sys.boot_completed"],
+            "2026-08-16T12:00:00Z", "2026-08-16T12:00:01Z",
+            0, 0, False, "shell")
+        return ledger.serialize().encode()
+
+    def _canonical(self, d, journey_xml=b"<hierarchy/>",
+                   ledger_bytes=None):
         """Materialize the exact canonical artifact set and its manifest."""
         files = {}
         for n in evidence.CANONICAL_PNG_NAMES:
@@ -240,7 +254,8 @@ class TestFinalize(unittest.TestCase):
         for label in evidence.CANONICAL_HIERARCHY_LABELS:
             files[f"{label}.xml"] = (
                 journey_xml if label == "journey" else b"<hierarchy/>")
-        files[evidence.CANONICAL_LEDGER_NAME] = b"[]"
+        files[evidence.CANONICAL_LEDGER_NAME] = (
+            ledger_bytes if ledger_bytes is not None else self._ledger_bytes())
         man = {}
         for name, data in files.items():
             with open(os.path.join(d, name), "wb") as f:
@@ -574,7 +589,116 @@ class TestFinalize(unittest.TestCase):
             appr = self._make_approval(cap, man)
             with self.assertRaises(ValueError) as cm:
                 evidence.finalize(cap, appr, man, d)
-            self.assertIn("required fields", str(cm.exception))
+            self.assertIn("field set mismatch", str(cm.exception))
+
+    def test_finalize_rejects_wrong_typed_ledger_entry(self):
+        # ghostinprod reproduction: keys present, types interpretive.
+        wrong = json.dumps([{
+            "argv": "adb shell getprop", "start_utc": 0, "end_utc": None,
+            "transport_rc": "success", "remote_rc": [],
+            "timed_out": "false", "kind": 7,
+        }]).encode()
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d, ledger_bytes=wrong)
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(man),
+                with_steps=True,
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("ledger entry 0", str(cm.exception))
+
+    def test_finalize_rejects_extra_ledger_field(self):
+        import json as _json
+        base = _json.loads(self._ledger_bytes())
+        base[0]["note"] = "extra"
+        wrong = _json.dumps(base).encode()
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d, ledger_bytes=wrong)
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(man),
+                with_steps=True,
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("field set mismatch", str(cm.exception))
+
+    def test_finalize_rejects_empty_ledger(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d, ledger_bytes=b"[]")
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(man),
+                with_steps=True,
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("non-empty list", str(cm.exception))
+
+    def test_real_ledger_serialization_round_trips(self):
+        # Cassie coupling close: the production serialize() output must
+        # always satisfy validate_structural.
+        evidence.validate_structural(
+            evidence.CANONICAL_LEDGER_NAME, self._ledger_bytes())
+
+    def test_finalize_rejects_failed_journey_step(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d)
+            steps = []
+            for phase in ("verify_restore", "release_emulator",
+                          "verify_release"):
+                steps.append(StepRecord(
+                    phase=phase, operation=phase, input_digest=None,
+                    output_digest=None,
+                    result=CommandResult(argv=[], start_utc="", end_utc="",
+                                         returncode=0, stdout=b"", stderr=b""),
+                    cause=TerminalCause.COMPLETED,
+                ))
+            steps.append(StepRecord(
+                phase="journey", operation="apply_rephrasing",
+                input_digest=None, output_digest=None,
+                result=CommandResult(argv=[], start_utc="", end_utc="",
+                                     returncode=1, stdout=b"", stderr=b"x"),
+                cause=TerminalCause.JOURNEY_FAILED,
+            ))
+            cap = CaptureRecord(
+                repo_head="a", apk_sha256="b", tools=[],
+                prior_state=None, steps=steps,
+                restoration=StepRecord(
+                    phase="restore", operation="restore device state",
+                    input_digest=None, output_digest=None,
+                    result=CommandResult(argv=[], start_utc="", end_utc="",
+                                         returncode=0, stdout=b"", stderr=b""),
+                    cause=TerminalCause.COMPLETED,
+                ),
+                manifest_digest=evidence.manifest_digest(man),
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("journey/apply_rephrasing", str(cm.exception))
+
+    def test_finalize_rejects_missing_journey_steps(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d)
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(man),
+                with_steps=True,
+            )
+            # with_steps includes one journey step; strip it.
+            cap = CaptureRecord(
+                repo_head=cap.repo_head, apk_sha256=cap.apk_sha256,
+                tools=cap.tools, prior_state=cap.prior_state,
+                steps=[s for s in cap.steps if s.phase != "journey"],
+                restoration=cap.restoration,
+                manifest_digest=cap.manifest_digest,
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("no journey steps", str(cm.exception))
 
     def test_finalize_rejects_missing_restoration(self):
         with tempfile.TemporaryDirectory() as d:

--- a/android/scripts/tests/m2_device/test_evidence.py
+++ b/android/scripts/tests/m2_device/test_evidence.py
@@ -202,7 +202,8 @@ class TestFinalize(unittest.TestCase):
     def _capture(self, manifest_digest=None, with_steps=False):
         steps = []
         if with_steps:
-            for phase in ("journey", "release_emulator", "verify_release"):
+            for phase in ("journey", "release_emulator", "verify_release",
+                          "verify_restore"):
                 steps.append(StepRecord(
                     phase=phase, operation=phase, input_digest=None,
                     output_digest=None,
@@ -346,7 +347,10 @@ class TestFinalize(unittest.TestCase):
         dirty = b"api_key=sk-1234567890abcdef\n"
         with tempfile.TemporaryDirectory() as d:
             man = self._canonical(d, journey_xml=dirty)
-            cap = self._capture(manifest_digest=evidence.manifest_digest(man))
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(man),
+                with_steps=True,
+            )
             appr = self._make_approval(cap, man)
             with self.assertRaises(ValueError) as cm:
                 evidence.finalize(cap, appr, man, d)
@@ -362,11 +366,215 @@ class TestFinalize(unittest.TestCase):
             with open(os.path.join(d, "04-applied.png"), "wb") as f:
                 f.write(corrupt)
             man["04-applied.png"] = hashlib.sha256(corrupt).hexdigest()
-            cap = self._capture(manifest_digest=evidence.manifest_digest(man))
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(man),
+                with_steps=True,
+            )
             appr = self._make_approval(cap, man)
             with self.assertRaises(ValueError) as cm:
                 evidence.finalize(cap, appr, man, d)
             self.assertIn("media validation", str(cm.exception))
+
+    def test_finalize_requires_verify_restore_step(self):
+        # A COMPLETED snapshot-load is not itself a restoration verdict;
+        # the verify_restore step must exist and be COMPLETED.
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d)
+            cap = CaptureRecord(
+                repo_head="a", apk_sha256="b", tools=[],
+                prior_state=None, steps=[], restoration=StepRecord(
+                    phase="restore", operation="restore device state",
+                    input_digest=None, output_digest=None,
+                    result=CommandResult(argv=[], start_utc="", end_utc="",
+                                         returncode=0, stdout=b"", stderr=b""),
+                    cause=TerminalCause.COMPLETED,
+                ),
+                manifest_digest=evidence.manifest_digest(man),
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("verify_restore", str(cm.exception))
+
+    def test_finalize_refuses_failed_release(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d)
+            steps = []
+            for phase in ("journey", "verify_restore"):
+                steps.append(StepRecord(
+                    phase=phase, operation=phase, input_digest=None,
+                    output_digest=None,
+                    result=CommandResult(argv=[], start_utc="", end_utc="",
+                                         returncode=0, stdout=b"", stderr=b""),
+                    cause=TerminalCause.COMPLETED,
+                ))
+            steps.append(StepRecord(
+                phase="release_emulator", operation="release",
+                input_digest=None, output_digest=None,
+                result=CommandResult(argv=[], start_utc="", end_utc="",
+                                     returncode=1, stdout=b"", stderr=b"x"),
+                cause=TerminalCause.CLEANUP_PARTIAL,
+            ))
+            steps.append(StepRecord(
+                phase="verify_release", operation="verify release",
+                input_digest=None, output_digest=None,
+                result=CommandResult(argv=[], start_utc="", end_utc="",
+                                     returncode=0, stdout=b"", stderr=b""),
+                cause=TerminalCause.COMPLETED,
+            ))
+            cap = CaptureRecord(
+                repo_head="a", apk_sha256="b", tools=[],
+                prior_state=None, steps=steps,
+                restoration=StepRecord(
+                    phase="restore", operation="restore device state",
+                    input_digest=None, output_digest=None,
+                    result=CommandResult(argv=[], start_utc="", end_utc="",
+                                         returncode=0, stdout=b"", stderr=b""),
+                    cause=TerminalCause.COMPLETED,
+                ),
+                manifest_digest=evidence.manifest_digest(man),
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("release_emulator did not complete", str(cm.exception))
+
+    def test_finalize_refuses_failed_verify_release(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d)
+            steps = []
+            for phase in ("journey", "verify_restore", "release_emulator"):
+                steps.append(StepRecord(
+                    phase=phase, operation=phase, input_digest=None,
+                    output_digest=None,
+                    result=CommandResult(argv=[], start_utc="", end_utc="",
+                                         returncode=0, stdout=b"", stderr=b""),
+                    cause=TerminalCause.COMPLETED,
+                ))
+            steps.append(StepRecord(
+                phase="verify_release", operation="verify release",
+                input_digest=None, output_digest=None,
+                result=CommandResult(argv=[], start_utc="", end_utc="",
+                                     returncode=1, stdout=b"", stderr=b"x"),
+                cause=TerminalCause.CLEANUP_PARTIAL,
+            ))
+            cap = CaptureRecord(
+                repo_head="a", apk_sha256="b", tools=[],
+                prior_state=None, steps=steps,
+                restoration=StepRecord(
+                    phase="restore", operation="restore device state",
+                    input_digest=None, output_digest=None,
+                    result=CommandResult(argv=[], start_utc="", end_utc="",
+                                         returncode=0, stdout=b"", stderr=b""),
+                    cause=TerminalCause.COMPLETED,
+                ),
+                manifest_digest=evidence.manifest_digest(man),
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("verify_release did not complete", str(cm.exception))
+
+    def test_finalize_rejects_symlinked_directory(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d)
+            elsewhere = tempfile.mkdtemp()
+            os.symlink(elsewhere, os.path.join(d, "extra_dir"))
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(man),
+                with_steps=True,
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("non-flat", str(cm.exception))
+
+    def test_finalize_rejects_nested_empty_directory(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d)
+            os.makedirs(os.path.join(d, "nested"))
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(man),
+                with_steps=True,
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("non-flat", str(cm.exception))
+
+    def test_build_manifest_rejects_nested_directory(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._canonical(d)
+            os.makedirs(os.path.join(d, "nested"))
+            with self.assertRaises(ValueError) as cm:
+                evidence.build_manifest(d)
+            self.assertIn("non-flat", str(cm.exception))
+
+    def test_finalize_rejects_malformed_xml_with_matching_digest(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d)
+            malformed = b"<hierarchy"
+            with open(os.path.join(d, "journey.xml"), "wb") as f:
+                f.write(malformed)
+            man["journey.xml"] = hashlib.sha256(malformed).hexdigest()
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(man),
+                with_steps=True,
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("malformed XML", str(cm.exception))
+
+    def test_finalize_rejects_wrong_rooted_xml(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d)
+            wrong = b"<notahierarchy/>"
+            with open(os.path.join(d, "clear.xml"), "wb") as f:
+                f.write(wrong)
+            man["clear.xml"] = hashlib.sha256(wrong).hexdigest()
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(man),
+                with_steps=True,
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("not <hierarchy>", str(cm.exception))
+
+    def test_finalize_rejects_malformed_ledger_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d)
+            malformed = b"{not json"
+            with open(os.path.join(d, evidence.CANONICAL_LEDGER_NAME), "wb") as f:
+                f.write(malformed)
+            man[evidence.CANONICAL_LEDGER_NAME] = (
+                hashlib.sha256(malformed).hexdigest())
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(man),
+                with_steps=True,
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("malformed ledger", str(cm.exception))
+
+    def test_finalize_rejects_wrong_shape_ledger_entries(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = self._canonical(d)
+            malformed = b'[{"argv": ["adb"], "start_utc": "t"}]'
+            with open(os.path.join(d, evidence.CANONICAL_LEDGER_NAME), "wb") as f:
+                f.write(malformed)
+            man[evidence.CANONICAL_LEDGER_NAME] = (
+                hashlib.sha256(malformed).hexdigest())
+            cap = self._capture(
+                manifest_digest=evidence.manifest_digest(man),
+                with_steps=True,
+            )
+            appr = self._make_approval(cap, man)
+            with self.assertRaises(ValueError) as cm:
+                evidence.finalize(cap, appr, man, d)
+            self.assertIn("required fields", str(cm.exception))
 
     def test_finalize_rejects_missing_restoration(self):
         with tempfile.TemporaryDirectory() as d:
@@ -385,10 +593,13 @@ class TestFinalize(unittest.TestCase):
 class TestCanonicalSetAndAtomicWrites(unittest.TestCase):
 
     def test_canonical_set_rejects_nested_entry(self):
+        # Full canonical set plus a nested key: the nested entry itself
+        # must be what triggers rejection, not absent canonical names.
+        man = {name: "h" for name in evidence.CANONICAL_ARTIFACTS}
+        man["sub/dir/x.png"] = "h"
         with self.assertRaises(ValueError) as cm:
-            evidence.enforce_canonical_set(
-                {"sub/dir/01-idle-typed.png": "h"})
-        self.assertIn("missing", str(cm.exception))
+            evidence.enforce_canonical_set(man)
+        self.assertIn("non-canonical", str(cm.exception))
 
     def test_canonical_set_rejects_extra_entry(self):
         man = {name: "h" for name in evidence.CANONICAL_ARTIFACTS}


### PR DESCRIPTION
## What

Stage 3 of the #69 tracker — issue #64: one canonical artifact transaction and a receipt that derives itself. Writable surface per the issue: `evidence.py`, `cli.py`, narrowly necessary harness changes, focused tests. `records.py` untouched (frozen schema).

## Canonical artifact set (enforced, not assumed)

Exactly: seven named PNGs, one named MP4 (`journey.mp4`), the sixteen journey hierarchy XMLs, and the private redacted `command_ledger.json` — which is also the run's status log (every production command's argv and status dimensions; the design's "status logs" dimension). `enforce_canonical_set` rejects missing, extra, renamed, and nested manifest entries. The screenshot names now flow from this single definition (`adb_harness.SCREENSHOT_NAMES` imports it).

## Capture-manifest binding before CLI success

`cmd_capture` builds and binds the manifest, then requires the canonical set **before returning success**. Failed runs still write their capture record (partial artifacts are expected on failure) — canonical binding gates the success path only, never the failure record.

## Mechanically derived receipts — caller inputs removed

`evidence.finalize` now takes only capture, approval, manifest, dir, and evidence-commit. Removed: `restoration_verdict` (derived: only reachable when the restoration step is COMPLETED), `counts` (derived from bytes and named steps: png/mp4/journey_steps_completed/release_ok/verify_release_ok), and `artifacts` (the manifest itself). The `finalize` and `approve` CLI subcommands drop the corresponding flags. There is nothing left for a caller to vouch for.

## Atomic private writes

New `evidence.write_private_atomic` (0600, same-dir temp, fsync, `os.replace`) — used for manifest.json, capture-record.json, approval output, and final receipt output. An interrupted write can no longer leave a truncated artifact behind a success code.

## Rejections covered (all fail-closed, all with regressions)

Partial (missing key), extra manifest key, extra on-disk file (unlisted), renamed, swapped bytes (digest mismatch), malformed media with matching digest (structural validation is its own dimension, not just drift), nested entries, plus the existing symlink/hardlink/path-escape/non-regular rejections. Privacy scanning unchanged and fail-closed. Post-approval drift blocks finalize as before (digest binding to the approval).

## Inbox from Stage 2 reviews

- Inert context-level receipt blanking: documented as defense-in-depth (the authoritative boundary is the serialized step verdict).
- Pinned-branch coverage: documented as device-only by design (no fake can forge the pinned digests — #55 territory).
- Post-dismiss visual evidence: **kept the canonical seven** per the issue text and design doc ("seven named PNGs"); the retained-stale state is visible in `06-stale`. Changing the artifact count is a design-doc decision, not a rider on this PR.

## Evidence

- Local: suite **296/296, run twice** (canonical enforcement, atomicity, derived-dimension, drift/swap/malformed regressions; evidence tests rewritten around a canonical fixture).
- Budgets: 995/1100 and 2510/2700 — inside the round-raise headroom taken in Stage 2 for exactly this purpose; no new amendment.
- Hosted: appended at this head when the run completes.

Closes #64 when merged. #62 remains queued.