### PR TITLE
fix(issue-63): fail closed on unreadable hierarchies, keep the record when tools lie about rc

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,22 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-08-19 — The journey stops believing in hierarchies it never read
+
+- A pull that returned rc=0 with unparsable — or entirely absent — XML
+  used to record a COMPLETED hierarchy step, quietly truncate the
+  journey, and let the failure resurface later dressed as a missing
+  screenshot. Every hierarchy read now fails closed as a
+  `journey_failed` step ("hierarchy missing or unparsable") instead of
+  vouching for facts it could not parse. The absent-file variant is
+  worse than it sounds: its exception escaped `run_journey` unwrapped,
+  and the run ended with cleanup performed but no capture record at
+  all — receipts now survive hostile tools that lie about rc. Found by
+  the #62 acceptance matrix doing exactly its job; regression tests
+  ride along for both vectors.
+
+---
+
 ## 2026-08-16 — Cleanup learns to check the name badge before it swings
 
 - The six remaining execution-boundary findings from the 2026-08-13 review

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -509,8 +509,14 @@ class AdbHarness:
             return pull, None
         try:
             return pull, ET.parse(local).getroot()
-        except ET.ParseError:
-            return pull, None
+        except (ET.ParseError, OSError):
+            if pull.timed_out:
+                return pull, None
+            # The transport claims success but the artifact is missing
+            # or unparsable: fail closed as a journey failure. A clean
+            # wrapper rc never certifies facts that could not be read.
+            return self._fail(
+                label, b"hierarchy missing or unparsable"), None
 
     def _step(
         self, steps: list[StepRecord], op: str, result: CommandResult,

--- a/android/scripts/tests/m2_device/test_adb_harness.py
+++ b/android/scripts/tests/m2_device/test_adb_harness.py
@@ -327,6 +327,51 @@ class TestAdbHarness(unittest.TestCase):
         self.assertFalse(
             [s for s in steps if s.operation.startswith("tap_key")])
 
+    def test_run_journey_fails_closed_on_unparsable_first_hierarchy(self):
+        # Same contract for the first journey dump: a clean wrapper rc
+        # never certifies unreadable facts — the journey must fail, not
+        # record COMPLETED and truncate silently.
+        writer = _journey_pull_writer()
+
+        def side_effect(argv, **kwargs):
+            if "pull" in argv and "journey.xml" in argv[-1]:
+                with open(argv[-1], "w") as f:
+                    f.write("<not-xml")
+                return _cr(rc=0, argv=argv)
+            return writer(argv, **kwargs)
+
+        self.mock_runner.side_effect = side_effect
+        self.mock_starter.return_value = MagicMock()
+        steps = self.harness.run_journey()
+        failed = [s for s in steps if s.operation == "dump_hierarchy"]
+        self.assertTrue(failed)
+        self.assertEqual(failed[0].cause, TerminalCause.JOURNEY_FAILED)
+        self.assertIn(b"hierarchy missing or unparsable",
+                      failed[0].result.stderr)
+        self.assertFalse(
+            [s for s in steps if s.operation.startswith("tap_key")],
+            "taps must not run on unparsable journey facts")
+
+    def test_run_journey_fails_closed_on_silent_hierarchy_pull(self):
+        # Hostile pull: rc=0 with no file written. The journey fails
+        # closed with a recorded step — no exception may escape
+        # run_journey and cost the run its capture record.
+        writer = _journey_pull_writer()
+
+        def side_effect(argv, **kwargs):
+            if "pull" in argv and "window_dump.xml" in argv[-2]:
+                return _cr(rc=0, argv=argv)
+            return writer(argv, **kwargs)
+
+        self.mock_runner.side_effect = side_effect
+        self.mock_starter.return_value = MagicMock()
+        steps = self.harness.run_journey()
+        failed = [s for s in steps if s.operation == "dump_hierarchy"]
+        self.assertTrue(failed)
+        self.assertEqual(failed[0].cause, TerminalCause.JOURNEY_FAILED)
+        self.assertIn(b"hierarchy missing or unparsable",
+                      failed[0].result.stderr)
+
     def test_launch_emulator(self):
         self.mock_starter.return_value = MagicMock()
         res = self.harness.launch_emulator()


### PR DESCRIPTION
Correction to the #63 child (merged as #71), found by the #62 CLI acceptance matrix mid-build. No production file outside the journey's hierarchy read path is touched; records.py untouched; no new dependencies.

## The defect (two vectors, one concern)

journey hierarchies were the only evidence the harness accepted on faith:

1. Unparsable-but-rc=0 XML: _dump_hierarchy returned the clean pull result with root=None. Every call site recorded a COMPLETED step for facts that could not be read, silently truncated the journey, and let the failure resurface later misattributed as capture_failed (missing screenshots). Stage 2's review round fixed exactly this for the keyboard_check dump only; the other sites kept the hole.
2. Silent pull (rc=0, no file written): ET.parse raised FileNotFoundError out of run_journey — the one phase invoked without an exception wrapper — so the run performed cleanup but wrote no capture record at all. Receipt preservation failed under a lying tool.

Vector 2 was verified end-to-end through the real CLI with a hostile fake adb before writing the fix: run dir contained artifacts/ only, no capture-record.json.

## The fix

One point, in _dump_hierarchy (adb_harness.py): when the pull transport is clean but the artifact is missing or unparsable, the returned result is a synthesized failure ("hierarchy missing or unparsable") instead of the raw clean result. Every call site now fails closed uniformly; the keyboard_check call-site synthesis stays as defense in depth. run_journey can no longer leak a parse exception (both vectors return recorded steps), so the missing wrapper is no longer reachable.

## Evidence

- Suite: python3 -m unittest discover -s android/scripts/tests/m2_device — 314/314 OK, run twice (23.4s / 22.2s). Exact head e25ffd2.
- New regressions (harness level, riding in this PR): test_run_journey_fails_closed_on_unparsable_first_hierarchy, test_run_journey_fails_closed_on_silent_hierarchy_pull. Both red on 86cb627, green on e25ffd2.
- Line budgets (ADR-0008): adb_harness.py 987/1100; six-module total 2606/2700. No amendment needed.

## Notes for reviewers

- The #62 matrix tests that exposed this (test_matrix_malformed_xml_fails_journey_closed and a silent-pull variant) land in the acceptance PR that follows on top of this merge; they are intentionally NOT in this PR to keep the correction scoped to the owning child.
- Considered and rejected here: wrapping _journey in a generic exception trap in orchestrator.py. With both reachable vectors closed inside _dump_hierarchy the wrapper has no reachable trigger, and it would change semantics for every harness exception; smaller blast radius wins.
- Boundary note (no code change): a hung emulator -list-avds still classifies as tool_failure rather than timeout, because preflight returns its own summary result and the timeout classification only survives on phases that return the transport result. Fail-closed either way; noted for the record.
