### PR TITLE
docs(issue-55): state the deliberate breadth of the hierarchy OSError catch

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,18 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-08-19 — The except clause signs an affidavit about its own breadth
+
+- The hierarchy reader's `OSError` catch is deliberately wider than
+  `FileNotFoundError`, and now says so in a comment: permission errors,
+  disk full, any I/O failure on the artifact counts as an unreadable
+  artifact, which is the fail-closed verdict the harness is contractually
+  obliged to reach. Zero behavior change — the comment is the entire
+  diff, landed as the review nit carried from #73 so #55's qualification
+  PR stays pure evidence.
+
+---
+
 ## 2026-08-19 — The acceptance matrix arrives, and the fake toolkit learns to misbehave on cue
 
 - The fake-only acceptance matrix (issue #62) now drives the real

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -515,6 +515,9 @@ class AdbHarness:
             # The transport claims success but the artifact is missing
             # or unparsable: fail closed as a journey failure. A clean
             # wrapper rc never certifies facts that could not be read.
+            # OSError is deliberately wide, not just FileNotFoundError:
+            # permission, disk-full, any artifact I/O failure is an
+            # unreadable artifact, which is exactly the fail-closed verdict.
             return self._fail(
                 label, b"hierarchy missing or unparsable"), None
 


### PR DESCRIPTION
## What

One comment in the hierarchy reader, that is the entire production diff. The except in _dump_hierarchy catches OSError — not just FileNotFoundError — and now says so in place: permission errors, disk full, any I/O failure on the hierarchy artifact counts as an unreadable artifact, and unreadable is the fail-closed verdict the harness is obliged to reach.

## Why it rides alone

This is the non-blocking nit from #73's review (reicodes-pixelperfect relaying antigravity-opus): the catch's deliberate breadth deserved a comment, but Stage 4 could not take a post-approval diff and #55's qualification PR may contain no orchestrator or product change — its own rule, so the nit cannot ride in it. Stage 5's order of operations lands it here first, as a separate small PR.

## Evidence (exact head bc9ef26)

- Suite, repo root, python3 -m unittest discover -s android/scripts/tests/m2_device: 340/340 OK, run 1 (77.6s); 340/340 OK, run 2 (78.6s).
- Line budgets: adb_harness.py 987/1100, six-module total 2606/2700 — unchanged; ADR-0008 counting excludes comments, and test_line_budgets enforces it inside the suite that just passed twice.
- records.py untouched. No new dependencies. No goldens touched. No device/AVD contact (the chain's boundary holds; this PR is comments and a patchnote).

## Definition of done

- Non-author review requested via the API endpoint: reicodes-pixelperfect (the owner-sanctioned different-model-family channel used through Stage 4).
- Patchnote committed to PATCHNOTES.md in this PR.
- CI at the exact head green before merge; head change invalidates approval and this PR gets re-run, not patched in place.
