### PR TITLE
fix(m2_device): derive instrument pins from the receipt and the probe

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -29,6 +29,14 @@ Newest first, like all respectable patch notes.
   lives — inside the snapshot, not at the AVD top level. Fakes, tests,
   and both exact goldens updated to match reality; the journey is now
   runnable on the actual fixture instead of merely on its admirers.
+- Review round 2 caught the signer pin admiring itself: the dumpsys
+  digest is a 32-bit hash, collision-trivial and checked as a loose
+  substring. The signer gate is now cryptographic — the canonical APK's
+  certificate SHA-256, pinned from apksigner verify --print-certs and
+  compared as an exact line before the device is ever asked to install.
+  The 32-bit value stays on as device-side corroboration, honestly
+  labeled. Wrong-certificate and missing-digest regressions ride along;
+  a mismatch now stops the install rather than following it.
 
 ---
 

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,28 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-08-19 — The pins meet the actual fixture and admit they'd never met before
+
+- Seven instrument constants were fake-echo values — strings the test
+  fakes printed at the harness, which then pinned its own echo. The
+  2026-08-19 capability probe against the real pinned fixture replaced
+  every one of them with receipt- or device-derived facts: the emulator
+  pin is 36.6.11 (the version that demonstrably loads the pinned
+  snapshot), the launch argv gains `-gpu swiftshader_indirect` (without
+  it the 36.x default renderer refuses the snapshot and the emulator
+  cold-boots into the wrong state), the density probe reads
+  `qemu.sf.lcd_density` because `ro.sf.lcd_density` is empty on this
+  image, `versionName` is 1.13.1 (the vendored keyboard's numbering,
+  not a PersonaSpeak release number), the signer pin is the real
+  on-device PackageSignatures digest, the enabled-IME baseline is the
+  receipt's list (Gboard plus the Google TTS voice service), and the
+  fixture transaction hashes `hardware.ini` where the receipt says it
+  lives — inside the snapshot, not at the AVD top level. Fakes, tests,
+  and both exact goldens updated to match reality; the journey is now
+  runnable on the actual fixture instead of merely on its admirers.
+
+---
+
 ## 2026-08-19 — The except clause signs an affidavit about its own breadth
 
 - The hierarchy reader's `OSError` catch is deliberately wider than

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -75,28 +75,39 @@ ASK_KEY_COORDS: dict[str, tuple[int, int]] = {
 }
 KEYBOARD_EXPECTED_BOUNDS = "[0,1300][1080,2400]"
 
-EXPECTED_VERSION_NAME = "0.1.0"
+# Package identity as the device reports it (2026-08-19 capability probe on
+# the pinned fixture; versionName is the vendored keyboard's own numbering).
+EXPECTED_VERSION_NAME = "1.13.1"
 EXPECTED_VERSION_CODE = "1"
-EXPECTED_SIGNER = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+# On-device PackageSignatures digest of the canonical APK's signing cert,
+# as dumpsys prints it (probe-derived; stable for a given certificate).
+EXPECTED_SIGNER = "847f3baa"
 EXPECTED_ADB_VERSION = "1.0.41"
-EXPECTED_EMULATOR_VERSION = "33.1.24.0"
+# Local instrument, probe-proven to load the pinned m2_pristine snapshot
+# under the software renderer (prep ran 34.2.16; that version is no longer
+# installable, and the pin must name the tool that actually runs).
+EXPECTED_EMULATOR_VERSION = "36.6.11"
 SYSTEM_IMAGE_ID = "google/sdk_gphone64_arm64/emu64a:14"
 FIXTURE_RECEIPT_DIGEST = (
     "dad6f7ac3b3c10ac7b88dfe2397746acb11ee6a42957cf2d1fee7afe1325bdb0"
 )
 EXPECTED_BUILD_TOOLS_VERSION = "34.0.0"
+# IME baseline exactly as the accepted #56 receipt and the live fixture
+# both record it: Gboard LatinIME plus the Google TTS voice service.
 EXPECTED_ENABLED_IMES = [
     "com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME",
-    "com.google.android.inputmethod.latin/com.google.android.apps.inputmethod.latin.MockVoiceIME",
+    "com.google.android.tts/com.google.android.apps.speech.tts.googletts.settings.asr.voiceime.VoiceInputMethodService",
 ]
 EXPECTED_EDITOR_CLASS = "android.widget.EditText"
 ANIMATOR_SCALE = "null"  # fixture pins animator unset
 
 # Fixture transaction: the snapshot files whose exact bytes the
 # accepted #56 receipt pins. Defaults are the pinned digests; fake-only
-# runs inject digests computed from their own fixture files.
+# runs inject digests computed from their own fixture files. hardware.ini
+# is a snapshot content file (receipt: snapshot/files/hardware.ini), not
+# an AVD-top-level file — the real fixture has it only under the snapshot.
 FIXTURE_FILES = {
-    "M2_Qual_Fixture.avd/hardware.ini": HARDWARE_INI_HASH,
+    "M2_Qual_Fixture.avd/snapshots/m2_pristine/hardware.ini": HARDWARE_INI_HASH,
     "M2_Qual_Fixture.avd/snapshots/m2_pristine/ram.bin": RAM_BIN_HASH,
     "M2_Qual_Fixture.avd/snapshots/m2_pristine/textures.bin": TEXTURES_BIN_HASH,
 }
@@ -164,6 +175,11 @@ class AdbHarness:
         return [
             self.emulator_tool.path, "-avd", AVD_NAME,
             "-snapshot", SNAPSHOT_NAME, "-no-snapshot-save", "-port", "5554",
+            # The pinned snapshot was saved under the software renderer;
+            # under the 36.x default (gfxstream) the load is refused and
+            # the emulator cold-boots instead, failing the run's
+            # preconditions. The renderer must match the saved one.
+            "-gpu", "swiftshader_indirect",
         ]
 
     @staticmethod
@@ -418,7 +434,7 @@ class AdbHarness:
             (("getprop", "persist.sys.timezone"), TIMEZONE),
             (("getprop", "ro.product.locale"), LOCALE),
             (("getprop", "ro.product.cpu.abi"), ABI),
-            (("getprop", "ro.sf.lcd_density"), str(SCREEN_DPI)),
+            (("getprop", "qemu.sf.lcd_density"), str(SCREEN_DPI)),
             (("settings", "get", "global", "window_animation_scale"), ANIMATION_SCALE),
             (("settings", "get", "global", "transition_animation_scale"), ANIMATION_SCALE),
             (("settings", "get", "global", "animator_duration_scale"), ANIMATOR_SCALE),

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -79,9 +79,18 @@ KEYBOARD_EXPECTED_BOUNDS = "[0,1300][1080,2400]"
 # the pinned fixture; versionName is the vendored keyboard's own numbering).
 EXPECTED_VERSION_NAME = "1.13.1"
 EXPECTED_VERSION_CODE = "1"
-# On-device PackageSignatures digest of the canonical APK's signing cert,
-# as dumpsys prints it (probe-derived; stable for a given certificate).
+# On-device PackageSignatures digest of the canonical APK's signing
+# cert, as dumpsys prints it. Corroboration only: this is a 32-bit
+# Signature.hashCode, not a cryptographic digest, so it can never be
+# the signer gate — EXPECTED_SIGNER_CERT_SHA256 below is that gate.
 EXPECTED_SIGNER = "847f3baa"
+# The signer gate: SHA-256 of the canonical APK's signing certificate,
+# compared as an exact line of `apksigner verify --print-certs` output.
+EXPECTED_SIGNER_CERT_SHA256 = (
+    "0f62f45e45adda3af137ac4d9cb48f642975d9c1a35c52e61f8df41188cfc807"
+)
+# build-tools 34.0.0's apksigner self-reports this version string.
+EXPECTED_APKSIGNER_VERSION = "0.9"
 EXPECTED_ADB_VERSION = "1.0.41"
 # Local instrument, probe-proven to load the pinned m2_pristine snapshot
 # under the software renderer (prep ran 34.2.16; that version is no longer
@@ -146,6 +155,7 @@ class AdbHarness:
             self.fixture_digests.update(fixture_digests)
         self.adb_tool: ToolIdentity | None = None
         self.emulator_tool: ToolIdentity | None = None
+        self.apksigner_tool: ToolIdentity | None = None
         self.build_tools_tool: ToolIdentity | None = None
         self.emulator_process: commands.ManagedProcess | None = None
         self.screenrecord_process: commands.ManagedProcess | None = None
@@ -200,10 +210,13 @@ class AdbHarness:
         try:
             self.adb_tool = commands.resolve_tool("adb")
             self.emulator_tool = commands.resolve_tool("emulator")
+            self.apksigner_tool = commands.resolve_tool("apksigner")
             if EXPECTED_ADB_VERSION not in self.adb_tool.version:
                 return self._fail("preflight", f"adb version mismatch: {self.adb_tool.version}".encode())
             if EXPECTED_EMULATOR_VERSION not in self.emulator_tool.version:
                 return self._fail("preflight", f"emulator version mismatch: {self.emulator_tool.version}".encode())
+            if EXPECTED_APKSIGNER_VERSION not in self.apksigner_tool.version:
+                return self._fail("preflight", f"apksigner version mismatch: {self.apksigner_tool.version}".encode())
             if self.adb_tool.digest is None or self.emulator_tool.digest is None:
                 return self._fail("preflight", b"tool digest unavailable")
             avds = self.runner([self.emulator_tool.path, "-list-avds"], timeout=10)
@@ -488,6 +501,27 @@ class AdbHarness:
             f" {FIXTURE_RECEIPT_DIGEST[:12]}.".encode())
 
     def install_apk(self) -> CommandResult:
+        # The signer gate runs before any device mutation: a certificate
+        # mismatch must stop the install, not follow it.
+        if self.apksigner_tool is None:
+            return self._fail("install_apk", b"apksigner tool unresolved")
+        certs = self.runner(
+            [self.apksigner_tool.path, "verify", "--print-certs",
+             self.apk_path], timeout=60.0)
+        if certs.timed_out:
+            return self._fail("install_apk", b"apksigner verify timed out")
+        if certs.returncode != 0:
+            return self._fail(
+                "install_apk", f"apksigner rc={certs.returncode}".encode())
+        expected_line = (
+            "Signer #1 certificate SHA-256 digest: "
+            f"{EXPECTED_SIGNER_CERT_SHA256}")
+        if expected_line not in certs.stdout.decode(
+                "utf-8", errors="replace").splitlines():
+            return self._fail(
+                "install_apk",
+                b"signer certificate mismatch: apksigner SHA-256 digest "
+                b"does not exactly match the pinned certificate")
         res = self._host("install", "-r", self.apk_path, timeout=120.0)
         if res.returncode != 0:
             return res

--- a/android/scripts/tests/m2_device/fixtures/bin/adb
+++ b/android/scripts/tests/m2_device/fixtures/bin/adb
@@ -210,7 +210,7 @@ elif "getprop ro.build.version.sdk" in cmd:
     print("34")
 elif "getprop ro.product.cpu.abi" in cmd:
     print("arm64-v8a")
-elif "getprop ro.sf.lcd_density" in cmd:
+elif "getprop qemu.sf.lcd_density" in cmd:
     print("420")
 elif "settings get global window_animation_scale" in cmd:
     print("1.0")
@@ -225,7 +225,7 @@ elif "wm size" in cmd:
 elif "pm path" in cmd:
     pass
 elif "settings get secure enabled_input_methods" in cmd:
-    print("com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME:com.google.android.inputmethod.latin/com.google.android.apps.inputmethod.latin.MockVoiceIME")
+    print("com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME:com.google.android.tts/com.google.android.apps.speech.tts.googletts.settings.asr.voiceime.VoiceInputMethodService")
 elif "settings get secure default_input_method" in cmd:
     print("com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME")
 elif "getprop persist.sys.timezone" in cmd:
@@ -238,9 +238,9 @@ elif "install" in cmd and "pull" not in cmd:
     if os.environ.get("FAKE_ADB_INSTALL_FAIL"):
         sys.exit(1)
 elif "dumpsys package" in cmd and "personaspeak" in cmd:
-    print("versionName=0.1.0")
+    print("versionName=1.13.1")
     print("versionCode=1")
-    print("signatures=[Signature [a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2]]")
+    print("signatures=PackageSignatures{c441f2a version:2, signatures:[847f3baa], past signatures:[]}")
 elif "wait-for-device" in cmd:
     pass
 elif "uiautomator dump" in cmd:

--- a/android/scripts/tests/m2_device/fixtures/bin/apksigner
+++ b/android/scripts/tests/m2_device/fixtures/bin/apksigner
@@ -1,7 +1,24 @@
 #!/usr/bin/env python3
-import os, sys
-log = os.environ.get("MOCK_COMMANDS_LOG")
-if log:
-    with open(log, "a") as f:
-        f.write(f"FORBIDDEN apksigner: {' '.join(sys.argv[1:])}\n")
-sys.exit(1)
+import os
+import sys
+
+log_path = os.environ.get("MOCK_COMMANDS_LOG")
+if log_path:
+    with open(log_path, "a") as f:
+        f.write(f"apksigner: {' '.join(sys.argv[1:])}\n")
+
+if "--version" in sys.argv or "-version" in sys.argv:
+    print("0.9")
+    sys.exit(0)
+
+if "verify" in sys.argv and "--print-certs" in sys.argv:
+    if os.environ.get("FAKE_APKSIGNER_CERT_BOGUS"):
+        print("Signer #1 certificate DN: CN=Impostor, O=Nowhere, C=XX")
+        print("Signer #1 certificate SHA-256 digest: " + "deadbeef" * 8)
+    else:
+        print("Signer #1 certificate DN: C=US, O=Android, CN=Android Debug")
+        print("Signer #1 certificate SHA-256 digest: "
+              "0f62f45e45adda3af137ac4d9cb48f642975d9c1a35c52e61f8df41188cfc807")
+    sys.exit(0)
+
+sys.exit(0)

--- a/android/scripts/tests/m2_device/fixtures/bin/emulator
+++ b/android/scripts/tests/m2_device/fixtures/bin/emulator
@@ -13,7 +13,7 @@ if "-version" in sys.argv or "--version" in sys.argv:
     if os.environ.get("FAKE_EMU_VERSION_BOGUS"):
         print("Android emulator version 0.0.0")
     else:
-        print("Android emulator version 33.1.24.0")
+        print("Android emulator version 36.6.11.0 (build_id 15507667)")
     sys.exit(0)
 
 if "-list-avds" in sys.argv:

--- a/android/scripts/tests/m2_device/run_fake_capture_cli.py
+++ b/android/scripts/tests/m2_device/run_fake_capture_cli.py
@@ -48,7 +48,7 @@ def main():
     fixture_root = os.path.join(test_dir, "avd")
     digests_path = os.path.join(test_dir, "fixture_digests.json")
     digests = {}
-    for rel in ("M2_Qual_Fixture.avd/hardware.ini",
+    for rel in ("M2_Qual_Fixture.avd/snapshots/m2_pristine/hardware.ini",
                 "M2_Qual_Fixture.avd/snapshots/m2_pristine/ram.bin",
                 "M2_Qual_Fixture.avd/snapshots/m2_pristine/textures.bin"):
         path = os.path.join(fixture_root, *rel.split("/"))

--- a/android/scripts/tests/m2_device/test_acceptance_matrix.py
+++ b/android/scripts/tests/m2_device/test_acceptance_matrix.py
@@ -50,6 +50,7 @@ REPO_ROOT_ABS = os.path.abspath(os.path.join(HERE, "..", "..", "..", ".."))
 GOLDEN_CONTACTS = (
     "adb: --version",
     "emulator: --version",
+    "apksigner: --version",
     "emulator: -list-avds",
     "git: rev-parse HEAD",
     "git: status --porcelain",
@@ -70,6 +71,7 @@ GOLDEN_CONTACTS = (
     "adb: -s emulator-5554 shell settings get global transition_animation_scale",
     "adb: -s emulator-5554 shell settings get global animator_duration_scale",
     "adb: -s emulator-5554 shell settings get secure default_input_method",
+    "apksigner: verify --print-certs <T>/mock_app.apk",
     "adb: -s emulator-5554 install -r <T>/mock_app.apk",
     "adb: -s emulator-5554 shell dumpsys package biz.pixelperfectstudios.personaspeak",
     "adb: -s emulator-5554 shell screenrecord --time-limit 30 /sdcard/journey.mp4",
@@ -564,7 +566,7 @@ class TestAcceptanceMatrix(unittest.TestCase):
     def _assert_contacts_fake_only(self):
         for line in self._contacts():
             self.assertTrue(
-                line.startswith(("adb: ", "emulator: ", "git: ")),
+                line.startswith(("adb: ", "emulator: ", "apksigner: ", "git: ")),
                 f"contact with unknown tool: {line}")
 
     # ---------- happy path ----------

--- a/android/scripts/tests/m2_device/test_acceptance_matrix.py
+++ b/android/scripts/tests/m2_device/test_acceptance_matrix.py
@@ -53,7 +53,7 @@ GOLDEN_CONTACTS = (
     "emulator: -list-avds",
     "git: rev-parse HEAD",
     "git: status --porcelain",
-    "emulator: -avd M2_Qual_Fixture -snapshot m2_pristine -no-snapshot-save -port 5554",
+    "emulator: -avd M2_Qual_Fixture -snapshot m2_pristine -no-snapshot-save -port 5554 -gpu swiftshader_indirect",
     "adb: -s emulator-5554 wait-for-device",
     "adb: -s emulator-5554 shell getprop sys.boot_completed",
     "adb: -s emulator-5554 shell getprop ro.build.fingerprint",
@@ -65,7 +65,7 @@ GOLDEN_CONTACTS = (
     "adb: -s emulator-5554 shell getprop persist.sys.timezone",
     "adb: -s emulator-5554 shell getprop ro.product.locale",
     "adb: -s emulator-5554 shell getprop ro.product.cpu.abi",
-    "adb: -s emulator-5554 shell getprop ro.sf.lcd_density",
+    "adb: -s emulator-5554 shell getprop qemu.sf.lcd_density",
     "adb: -s emulator-5554 shell settings get global window_animation_scale",
     "adb: -s emulator-5554 shell settings get global transition_animation_scale",
     "adb: -s emulator-5554 shell settings get global animator_duration_scale",
@@ -207,7 +207,7 @@ GOLDEN_CONTACTS = (
 
 # argv of every ledgered command (normalized) + its kind token.
 GOLDEN_LEDGER_ARGV = (
-    ["<BIN>/emulator", "-avd", "M2_Qual_Fixture", "-snapshot", "m2_pristine", "-no-snapshot-save", "-port", "5554", "launch"],
+    ["<BIN>/emulator", "-avd", "M2_Qual_Fixture", "-snapshot", "m2_pristine", "-no-snapshot-save", "-port", "5554", "-gpu", "swiftshader_indirect", "launch"],
     ["<BIN>/adb", "-s", "emulator-5554", "wait-for-device", "host"],
     ["<BIN>/adb", "-s", "emulator-5554", "shell", "getprop", "sys.boot_completed", "shell"],
     ["<BIN>/adb", "-s", "emulator-5554", "shell", "getprop", "ro.build.fingerprint", "shell"],
@@ -219,7 +219,7 @@ GOLDEN_LEDGER_ARGV = (
     ["<BIN>/adb", "-s", "emulator-5554", "shell", "getprop", "persist.sys.timezone", "shell"],
     ["<BIN>/adb", "-s", "emulator-5554", "shell", "getprop", "ro.product.locale", "shell"],
     ["<BIN>/adb", "-s", "emulator-5554", "shell", "getprop", "ro.product.cpu.abi", "shell"],
-    ["<BIN>/adb", "-s", "emulator-5554", "shell", "getprop", "ro.sf.lcd_density", "shell"],
+    ["<BIN>/adb", "-s", "emulator-5554", "shell", "getprop", "qemu.sf.lcd_density", "shell"],
     ["<BIN>/adb", "-s", "emulator-5554", "shell", "settings", "get", "global", "window_animation_scale", "shell"],
     ["<BIN>/adb", "-s", "emulator-5554", "shell", "settings", "get", "global", "transition_animation_scale", "shell"],
     ["<BIN>/adb", "-s", "emulator-5554", "shell", "settings", "get", "global", "animator_duration_scale", "shell"],
@@ -392,7 +392,7 @@ class TestAcceptanceMatrix(unittest.TestCase):
         self.fixture_root = os.path.join(self.test_dir, "avd")
         self.digests_path = os.path.join(self.test_dir, "fixture_digests.json")
         self._fixture_rels = (
-            "M2_Qual_Fixture.avd/hardware.ini",
+            "M2_Qual_Fixture.avd/snapshots/m2_pristine/hardware.ini",
             "M2_Qual_Fixture.avd/snapshots/m2_pristine/ram.bin",
             "M2_Qual_Fixture.avd/snapshots/m2_pristine/textures.bin",
         )

--- a/android/scripts/tests/m2_device/test_adb_harness.py
+++ b/android/scripts/tests/m2_device/test_adb_harness.py
@@ -19,6 +19,7 @@ from android.scripts.m2_device.adb_harness import (
     AVD_NAME,
     CANDIDATE_REPHRASING,
     EXPECTED_SIGNER,
+    EXPECTED_SIGNER_CERT_SHA256,
     EXPECTED_VERSION_CODE,
     EXPECTED_VERSION_NAME,
     FINGERPRINT,
@@ -213,6 +214,7 @@ class TestAdbHarness(unittest.TestCase):
         )
         self.harness.adb_tool = ToolIdentity(name="adb", path="adb", version="1.0")
         self.harness.emulator_tool = ToolIdentity(name="emulator", path="emulator", version="1.0")
+        self.harness.apksigner_tool = ToolIdentity(name="apksigner", path="apksigner", version="0.9")
 
     def tearDown(self):
         self.tmp_dir.cleanup()
@@ -222,10 +224,13 @@ class TestAdbHarness(unittest.TestCase):
     @patch("android.scripts.m2_device.commands.resolve_tool")
     def test_preflight_success(self, mock_resolve, mock_socket_cls):
         def fake_resolve(name, **kwargs):
+            if name == "apksigner":
+                version = "0.9"
+            else:
+                version = (f"Android {'Debug Bridge' if name == 'adb' else 'emulator'} "
+                           f"version {'1.0.41' if name == 'adb' else '36.6.11.0'}")
             return ToolIdentity(
-                name=name, path=f"/bin/{name}",
-                version=f"Android {'Debug Bridge' if name == 'adb' else 'emulator'} version "
-                        f"{'1.0.41' if name == 'adb' else '36.6.11.0'}",
+                name=name, path=f"/bin/{name}", version=version,
                 digest="abc123",
             )
         mock_resolve.side_effect = fake_resolve
@@ -499,6 +504,10 @@ class TestAdbHarness(unittest.TestCase):
 
         def side_effect(argv, **kwargs):
             cmd = " ".join(argv)
+            if "apksigner" in cmd:
+                return _cr(rc=0, stdout=(
+                    f"Signer #1 certificate SHA-256 digest: {EXPECTED_SIGNER_CERT_SHA256}\n"
+                ).encode())
             if "dumpsys" in cmd:
                 return _cr(rc=0, stdout=(
                     f"versionName={EXPECTED_VERSION_NAME}\n"
@@ -516,6 +525,10 @@ class TestAdbHarness(unittest.TestCase):
             cmd = " ".join(argv)
             if "install" in cmd and "pull" not in cmd:
                 return _cr(rc=0, stdout=b"Success")
+            if "apksigner" in cmd:
+                return _cr(rc=0, stdout=(
+                    f"Signer #1 certificate SHA-256 digest: {EXPECTED_SIGNER_CERT_SHA256}\n"
+                ).encode())
             if "dumpsys" in cmd:
                 return _cr(rc=0, stdout=(
                     f"versionName={EXPECTED_VERSION_NAME}\n"
@@ -532,6 +545,10 @@ class TestAdbHarness(unittest.TestCase):
     def test_install_apk_host_failure(self):
         def side_effect(argv, **kwargs):
             cmd = " ".join(argv)
+            if "apksigner" in cmd:
+                return _cr(rc=0, stdout=(
+                    f"Signer #1 certificate SHA-256 digest: {EXPECTED_SIGNER_CERT_SHA256}\n"
+                ).encode())
             if "install" in cmd and "pull" not in cmd:
                 return _cr(rc=1, stderr=b"device not found")
             return _cr(rc=0)
@@ -539,6 +556,39 @@ class TestAdbHarness(unittest.TestCase):
         self.mock_runner.side_effect = side_effect
         res = self.harness.install_apk()
         self.assertEqual(res.returncode, 1)
+
+    def test_install_apk_rejects_wrong_signer_certificate(self):
+        # A different certificate digest must fail closed before the
+        # device is ever asked to install (review finding, PR 76).
+        def side_effect(argv, **kwargs):
+            cmd = " ".join(argv)
+            if "apksigner" in cmd:
+                return _cr(rc=0, stdout=(
+                    "Signer #1 certificate SHA-256 digest: "
+                    + "deadbeef" * 8 + "\n").encode())
+            return _cr(rc=0)
+
+        self.mock_runner.side_effect = side_effect
+        res = self.harness.install_apk()
+        self.assertEqual(res.returncode, 1)
+        self.assertIn(b"signer certificate mismatch", res.stderr)
+        for call in self.mock_runner.call_args_list:
+            self.assertNotIn(
+                "install", " ".join(call.args[0]),
+                "device install ran despite signer mismatch")
+
+    def test_install_apk_rejects_missing_digest_line(self):
+        # rc=0 from the tool but no digest line at all is not a pass.
+        def side_effect(argv, **kwargs):
+            cmd = " ".join(argv)
+            if "apksigner" in cmd:
+                return _cr(rc=0, stdout=b"Signer #1 certificate DN: C=US\n")
+            return _cr(rc=0)
+
+        self.mock_runner.side_effect = side_effect
+        res = self.harness.install_apk()
+        self.assertEqual(res.returncode, 1)
+        self.assertIn(b"signer certificate mismatch", res.stderr)
 
     def test_run_journey_success(self):
         self.mock_runner.side_effect = _journey_pull_writer()

--- a/android/scripts/tests/m2_device/test_adb_harness.py
+++ b/android/scripts/tests/m2_device/test_adb_harness.py
@@ -188,7 +188,7 @@ class TestAdbHarness(unittest.TestCase):
         import hashlib as _hl
         self.fixture_root = os.path.join(self.run_dir, "avd")
         self.fixture_digests = {}
-        for rel in ("M2_Qual_Fixture.avd/hardware.ini",
+        for rel in ("M2_Qual_Fixture.avd/snapshots/m2_pristine/hardware.ini",
                     "M2_Qual_Fixture.avd/snapshots/m2_pristine/ram.bin",
                     "M2_Qual_Fixture.avd/snapshots/m2_pristine/textures.bin"):
             path = os.path.join(self.fixture_root, *rel.split("/"))
@@ -225,7 +225,7 @@ class TestAdbHarness(unittest.TestCase):
             return ToolIdentity(
                 name=name, path=f"/bin/{name}",
                 version=f"Android {'Debug Bridge' if name == 'adb' else 'emulator'} version "
-                        f"{'1.0.41' if name == 'adb' else '33.1.24.0'}",
+                        f"{'1.0.41' if name == 'adb' else '36.6.11.0'}",
                 digest="abc123",
             )
         mock_resolve.side_effect = fake_resolve
@@ -392,7 +392,7 @@ class TestAdbHarness(unittest.TestCase):
         gboard = (
             "com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME"
         )
-        enabled_imes = f"{gboard}:com.android.inputmethod.latin/com.google.android.apps.inputmethod.latin.MockVoiceIME"
+        enabled_imes = f"{gboard}:com.google.android.tts/com.google.android.apps.speech.tts.googletts.settings.asr.voiceime.VoiceInputMethodService"
 
         def side_effect(argv, **kwargs):
             cmd = " ".join(argv)
@@ -460,7 +460,7 @@ class TestAdbHarness(unittest.TestCase):
                 return _cr(stdout=LOCALE.encode())
             if "ro.product.cpu.abi" in cmd:
                 return _cr(stdout=ABI.encode())
-            if "ro.sf.lcd_density" in cmd:
+            if "qemu.sf.lcd_density" in cmd:
                 return _cr(stdout=b"420\n")
             if "window_animation_scale" in cmd:
                 return _cr(stdout=b"1.0\n")
@@ -503,7 +503,7 @@ class TestAdbHarness(unittest.TestCase):
                 return _cr(rc=0, stdout=(
                     f"versionName={EXPECTED_VERSION_NAME}\n"
                     f"versionCode={EXPECTED_VERSION_CODE}\n"
-                    f"signatures=[Signature [{EXPECTED_SIGNER}]]\n"
+                    f"signatures=PackageSignatures{{c441f2a version:2, signatures:[{EXPECTED_SIGNER}], past signatures:[]}}\n"
                 ).encode())
             return _cr(rc=0)
 
@@ -520,7 +520,7 @@ class TestAdbHarness(unittest.TestCase):
                 return _cr(rc=0, stdout=(
                     f"versionName={EXPECTED_VERSION_NAME}\n"
                     f"versionCode={EXPECTED_VERSION_CODE}\n"
-                    f"signatures=[Signature [{EXPECTED_SIGNER}]]\n"
+                    f"signatures=PackageSignatures{{c441f2a version:2, signatures:[{EXPECTED_SIGNER}], past signatures:[]}}\n"
                 ).encode())
             return _cr(rc=0)
 
@@ -609,7 +609,7 @@ class TestAdbHarness(unittest.TestCase):
 
     def test_validate_fixture_missing_file(self):
         hw = os.path.join(self.fixture_root, "M2_Qual_Fixture.avd",
-                          "hardware.ini")
+                          "snapshots", "m2_pristine", "hardware.ini")
         os.unlink(hw)
         prior = PriorDeviceState(
             serial="emulator-5554", emulator_state="booted",
@@ -986,7 +986,7 @@ class TestScreenrecordBoundary(unittest.TestCase):
             proc=real_proc,
             argv=["/usr/bin/emulator", "-avd", "M2_Qual_Fixture",
                   "-snapshot", "m2_pristine", "-no-snapshot-save",
-                  "-port", "5554"],
+                  "-port", "5554", "-gpu", "swiftshader_indirect"],
             start_utc="2026-08-16T12:00:00Z", new_session=True)
         try:
             res = self.harness.launch_emulator()

--- a/android/scripts/tests/m2_device/test_cli_capture.py
+++ b/android/scripts/tests/m2_device/test_cli_capture.py
@@ -30,7 +30,7 @@ class TestCliCapture(unittest.TestCase):
         self.fixture_root = os.path.join(self.test_dir, "avd")
         self.fixture_digests_path = os.path.join(self.test_dir, "fixture_digests.json")
         digests = {}
-        for rel in ("M2_Qual_Fixture.avd/hardware.ini",
+        for rel in ("M2_Qual_Fixture.avd/snapshots/m2_pristine/hardware.ini",
                     "M2_Qual_Fixture.avd/snapshots/m2_pristine/ram.bin",
                     "M2_Qual_Fixture.avd/snapshots/m2_pristine/textures.bin"):
             path = os.path.join(self.fixture_root, *rel.split("/"))

--- a/docs/adr/0008-production-m2-journey-harness.md
+++ b/docs/adr/0008-production-m2-journey-harness.md
@@ -30,7 +30,11 @@ preconditions. The density probe reads `qemu.sf.lcd_density`
 (`ro.sf.lcd_density` is empty on this image); `versionName` is 1.13.1 (the
 vendored keyboard's numbering); the signer pin is the on-device
 PackageSignatures digest; the enabled-IME baseline is the receipt's list.
-Line budgets are unchanged.
+Review round 2 (PR #76) hardened the signer gate: the dumpsys value is a
+32-bit Signature.hashCode kept only as device-side corroboration, while the
+gate itself is the signing certificate's SHA-256 pinned from
+`apksigner verify --print-certs` and compared as an exact output line
+before any install mutation. The budget limits are unchanged.
 
 Amended 2026-08-11 (issue #65 execution-boundary totality) to 750/2,100, amended
 2026-08-16 (issue #65 review findings) to 850/2,300, again the same day (issue

--- a/docs/adr/0008-production-m2-journey-harness.md
+++ b/docs/adr/0008-production-m2-journey-harness.md
@@ -18,6 +18,20 @@ We amend the project complexity budget to exactly six production modules and at 
 - The remaining five files (`cli.py`, `commands.py`, `orchestrator.py`, `evidence.py`, `records.py`) have a remaining budget of 1,150 lines.
 - Static tests enforce these limits.
 
+Amended 2026-08-19 (Stage 5 pre-run probe, issue #55): the instrument pins
+were re-derived from the accepted #56 receipt and the live fixture, replacing
+fake-echo values the fakes had printed back into the harness. The emulator pin
+became 36.6.11 (the prep ran 34.2.16 per the #56 archive, but that version is
+no longer installable; the probe proved 36.6.11 loads the pinned snapshot).
+The launch argv gained `-gpu swiftshader_indirect`: the snapshot was saved
+under the software renderer, and under the 36.x default (gfxstream) the load
+is refused and the emulator cold-boots instead, failing the run's
+preconditions. The density probe reads `qemu.sf.lcd_density`
+(`ro.sf.lcd_density` is empty on this image); `versionName` is 1.13.1 (the
+vendored keyboard's numbering); the signer pin is the on-device
+PackageSignatures digest; the enabled-IME baseline is the receipt's list.
+Line budgets are unchanged.
+
 Amended 2026-08-11 (issue #65 execution-boundary totality) to 750/2,100, amended
 2026-08-16 (issue #65 review findings) to 850/2,300, again the same day (issue
 #63 fixture transaction) to 1,000/2,500, and once more that day to the round


### PR DESCRIPTION
## What

Seven instrument constants in adb_harness.py were fake-echo values — strings the test fakes printed at the harness, which then pinned its own echo. The 2026-08-19 owner-authorized capability probe against the real pinned fixture (plus the accepted #56 receipt) replaces every one with a derived fact. No device contact in this PR itself; every new value cites the probe or the receipt.

The seven corrections (probe facts in tracker #69 checkpoint 22):

1. EXPECTED_EMULATOR_VERSION 33.1.24.0 -> 36.6.11. The probe booted the staged fixture on the local 36.6.11.0 and m2_pristine loaded in 474 ms. The prep ran 34.2.16 (00-source-avd-identity.txt:95 records Pkg.Dependencies=emulator#34.2.16), but that version is no longer installable via sdkmanager; the pin now names the tool that actually runs.
2. Launch argv gains -gpu swiftshader_indirect. The snapshot was saved under the software renderer; under the 36.x default (gfxstream) the load is REFUSED ("different renderer configured") and the emulator cold-boots instead, silently failing every run precondition. One line, load-bearing. Both exact goldens (contact ledger, ledgered argv) updated accordingly.
3. Density probe ro.sf.lcd_density -> qemu.sf.lcd_density. The ro. property is empty on this image; qemu.sf.lcd_density (and wm density) both report the pinned 420.
4. EXPECTED_VERSION_NAME 0.1.0 -> 1.13.1. The device reports versionName=1.13.1 (the vendored keyboard's own numbering); versionCode=1 was already correct.
5. EXPECTED_SIGNER placeholder -> 847f3baa, the real on-device PackageSignatures digest of the canonical APK's signing cert, as dumpsys actually prints it (signatures=PackageSignatures{c441f2a version:2, signatures:[847f3baa], past signatures:[]}). The fake's Signature[..] format never existed on a real device; fakes now print the real shape.
6. EXPECTED_ENABLED_IMES[1] -> com.google.android.tts/...VoiceInputMethodService, exactly the receipt's baseline and exactly what the live fixture reports. The old MockVoiceIME entry was fake-echo.
7. FIXTURE_FILES hardware.ini key -> M2_Qual_Fixture.avd/snapshots/m2_pristine/hardware.ini. The receipt pins hardware.ini as a snapshot content file (snapshot/files/hardware.ini, digest 076562d6...); the real fixture has it only there, and the old AVD-top-level key would have failed closed with "fixture file missing".

Also: ADR-0008 gains a dated 2026-08-19 amendment recording the re-derivation and the renderer constraint; budgets unchanged.

## Why a separate PR

#55's qualification PR may contain no orchestrator or product change — its own rule. These corrections are orchestrator changes found in pre-run preflight and the capability probe, so they land here first. No capture authority was consumed; the counted-failure count in #47 remains zero.

## Evidence (exact head c8fa02b)

- Suite, repo root, python3 -m unittest discover -s android/scripts/tests/m2_device: 340/340 OK, run 1 (78.0s); 340/340 OK, run 2 (76.9s).
- Line budgets (ADR-0008 counting, enforced in-suite): adb_harness.py 988/1100; six-module total 2607/2700. No amendment needed beyond the dated pin note.
- Goldens updated, not deleted: both exact goldens changed only in the launch contact/argv row (the -gpu pair) and the density query row — stated here per the golden rule.
- records.py untouched. No new dependencies. No device/AVD contact in this PR.

## Definition of done

- Non-author review requested via the API endpoint: reicodes-pixelperfect (owner-sanctioned different-model-family channel).
- Patchnote committed in this PR; ADR amended in this PR.
- CI at the exact head green before merge; head change invalidates approval.
