### PR TITLE
fix(m2_device): record apksigner identity in the capture tool set

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,17 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-08-19 — The fourth tool finally signs the guest book
+
+- The signer gate gained an apksigner in PR #76's second round, but the
+  capture record's tool identities never learned its name — the run
+  could prove the APK's certificate while staying mum about which
+  binary vouched for it. The recorded tool set now includes apksigner
+  alongside adb and emulator, so a qualification record names every
+  tool whose verdict it carries.
+
+---
+
 ## 2026-08-19 — The pins meet the actual fixture and admit they'd never met before
 
 - Seven instrument constants were fake-echo values — strings the test

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -255,7 +255,9 @@ class AdbHarness:
         if status_res.stdout.decode("utf-8").strip():
             raise RuntimeError("repository not clean — uncommitted changes")
         apk_sha = commands.digest_file(self.apk_path)
-        tools = [self.adb_tool, self.emulator_tool]
+        # apksigner is mandatory after preflight; its identity rides in
+        # the recorded tool set because it carries the signer gate.
+        tools = [self.adb_tool, self.emulator_tool, self.apksigner_tool]
         if self.build_tools_tool is not None:
             tools.append(self.build_tools_tool)
         # A run over injected (fake-only) digests is mechanically barred

--- a/android/scripts/tests/m2_device/test_adb_harness.py
+++ b/android/scripts/tests/m2_device/test_adb_harness.py
@@ -266,7 +266,9 @@ class TestAdbHarness(unittest.TestCase):
         ctx = self.harness.capture_context()
         self.assertEqual(ctx.repo_head, "abc123git")
         self.assertTrue(ctx.apk_sha256)
-        self.assertEqual(len(ctx.tools), 2)
+        self.assertEqual(len(ctx.tools), 3)
+        self.assertEqual(
+            [t.name for t in ctx.tools], ["adb", "emulator", "apksigner"])
         # setUp injects fake-only digests → the run must be mechanically
         # barred from claiming the accepted fixture receipt.
         self.assertEqual(ctx.fixture_receipt_digest, "")


### PR DESCRIPTION
## What

One gap found during #55 pre-run preparation: PR #76 round 2 made apksigner a mandatory, version-pinned instrument (the cryptographic signer gate), but capture_context still recorded only adb and emulator in the run's tool identities. A qualification record would carry the signer gate's verdict without naming the tool that produced it — and #55 requires accepted tool identities in the record while forbidding code changes in the qualification PR itself. Three lines in adb_harness.py plus the assertion that now names all three tools.

## Why now

The qualification run happens at the exact head this PR lands on; anything the run's record needs must be in main before capture authority is consumed. Found in static preparation — no device contact, no capture authority, counted-failure count untouched.

## Evidence (exact head f0b99cae0976c9c0132393ea24e81176ed3251e9)

- Suite, repo root, python3 -m unittest discover -s android/scripts/tests/m2_device: 342/342 OK twice.
- Budgets unchanged: adb_harness.py 1015/1100, total 2634/2700 (comment lines do not count).
- records.py untouched. No new dependencies. No device contact.

## Definition of done

- Non-author review via the API endpoint (reicodes-pixelperfect or ghostinprod-pixelperfect — whoever arrives first; both are established independent reviewers).
- Patchnote committed. CI green at exact head before merge.
