### PR TITLE
fix(m2_device): recognize absent-package pm path exit 1 as pristine state

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -22,7 +22,11 @@ Newest first, like all respectable patch notes.
   stops the run. The fake adb used to exit 0 here, which is how 342
   green tests certified a harness that could never boot its own
   fixture; it now lies no more. Regressions ride along, and the
-  acceptance matrix documents its one honest nonzero exit.
+  acceptance matrix documents its one honest nonzero exit. Review round
+  2 caught the present-package path reading a variable that no longer
+  existed — absence had been taught so well that presence forgot its
+  own name — so a dirty-fixture run would have crashed instead of
+  hashing the installed APK. Both paths now have their regression.
 
 ---
 

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,22 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-08-19 — Absence acquires an exit code the harness can respect
+
+- The first real qualification attempt stopped itself at
+  prior_state_unavailable, and the reason was almost philosophical: pm
+  path for a missing package exits 1 on a real device, and the pristine
+  fixture's entire point is that the package is missing. The harness
+  read that exit code as "cannot determine state" — correct instinct,
+  wrong target. Absence (exit 1, no output) is now recognized as the
+  pristine state it is; exit 1 WITH output remains unknown and still
+  stops the run. The fake adb used to exit 0 here, which is how 342
+  green tests certified a harness that could never boot its own
+  fixture; it now lies no more. Regressions ride along, and the
+  acceptance matrix documents its one honest nonzero exit.
+
+---
+
 ## 2026-08-19 — The fourth tool finally signs the guest book
 
 - The signer gate gained an apksigner in PR #76's second round, but the

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -404,8 +404,24 @@ class AdbHarness:
             if not m:
                 return None
             sw, sh = int(m.group(1)), int(m.group(2))
-            pkg = _query("pm", "path", KEYBOARD_PACKAGE)
-            package_present = pkg.startswith("package:")
+            # pm path for an absent package exits 1 with empty output —
+            # that is the pristine fixture's REQUIRED state, not an
+            # error (the fake toolkit used to exit 0 here, hiding the
+            # difference). rc=1 with output stays unknown state, which
+            # must stop the run rather than guess.
+            pkg_res = self._shell("pm", "path", KEYBOARD_PACKAGE)
+            if pkg_res.remote_rc is None:
+                raise commands.RemoteAmbiguousError("pm path")
+            pkg_out = pkg_res.transport.stdout.decode(
+                "utf-8", errors="replace").strip()
+            pkg_err = pkg_res.transport.stderr.decode(
+                "utf-8", errors="replace").strip()
+            if pkg_res.remote_rc == 0:
+                package_present = pkg_out.startswith("package:")
+            elif pkg_res.remote_rc == 1 and not pkg_out and not pkg_err:
+                package_present = False
+            else:
+                return None
             package_hash = None
             if package_present:
                 dev_path = pkg.split(":", 1)[1].strip()

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -424,7 +424,7 @@ class AdbHarness:
                 return None
             package_hash = None
             if package_present:
-                dev_path = pkg.split(":", 1)[1].strip()
+                dev_path = pkg_out.split(":", 1)[1].strip()
                 h = _query("sha256sum", dev_path)
                 if h:
                     package_hash = h.split()[0]

--- a/android/scripts/tests/m2_device/fixtures/bin/adb
+++ b/android/scripts/tests/m2_device/fixtures/bin/adb
@@ -223,7 +223,8 @@ elif "settings get secure default_input_method" in cmd:
 elif "wm size" in cmd:
     print("Physical size: 1080x2400")
 elif "pm path" in cmd:
-    pass
+    # Absent package on a real device: exit 1, no output.
+    sys.exit(1)
 elif "settings get secure enabled_input_methods" in cmd:
     print("com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME:com.google.android.tts/com.google.android.apps.speech.tts.googletts.settings.asr.voiceime.VoiceInputMethodService")
 elif "settings get secure default_input_method" in cmd:

--- a/android/scripts/tests/m2_device/test_acceptance_matrix.py
+++ b/android/scripts/tests/m2_device/test_acceptance_matrix.py
@@ -600,9 +600,19 @@ class TestAcceptanceMatrix(unittest.TestCase):
         normalized = [[self._normalize(a) for a in e["argv"]] + [e["kind"]]
                       for e in ledger]
         self.assertEqual(normalized, [list(x) for x in GOLDEN_LEDGER_ARGV])
+        # One documented nonzero exception: pm path for the absent
+        # target package exits 1 on a real device — that IS the pristine
+        # state — and the fake mirrors it. Every other entry stays clean.
+        pm_path_argv_prefix = ("<BIN>/adb", "-s", "emulator-5554",
+                               "shell", "pm", "path")
         for e in ledger:
-            self.assertEqual(e["transport_rc"], 0,
-                             f"nonzero transport rc: {e['argv']}")
+            norm = tuple(self._normalize(a) for a in e["argv"])
+            if norm[:len(pm_path_argv_prefix)] == pm_path_argv_prefix:
+                self.assertEqual(e["transport_rc"], 1,
+                                 f"pm path must reflect absence: {e['argv']}")
+            else:
+                self.assertEqual(e["transport_rc"], 0,
+                                 f"nonzero transport rc: {e['argv']}")
             self.assertFalse(e["timed_out"])
 
         # Primary outcome: every recorded step completed, canonical set

--- a/android/scripts/tests/m2_device/test_adb_harness.py
+++ b/android/scripts/tests/m2_device/test_adb_harness.py
@@ -414,7 +414,7 @@ class TestAdbHarness(unittest.TestCase):
                     stdout=f"Physical size: {SCREEN_WIDTH}x{SCREEN_HEIGHT}\n".encode()
                 )
             if "pm path" in cmd:
-                return _cr(stdout=b"")  # Not present
+                return _cr(rc=1)  # absent on a real device: exit 1, empty output
             if "settings get secure enabled_input_methods" in cmd:
                 return _cr(stdout=enabled_imes.encode())
             if "settings get secure default_input_method" in cmd:
@@ -433,6 +433,58 @@ class TestAdbHarness(unittest.TestCase):
         self.assertFalse(state.package_present)
         self.assertEqual(len(state.enabled_imes), 2)
         self.assertEqual(state.default_ime, gboard)
+
+    def test_capture_prior_state_absent_package_rc1(self):
+        # Regression (first counted failure, run 20260819T005731Z): the
+        # pristine fixture's REQUIRED state is package-absent, and real
+        # pm path exits 1 for it. That must yield prior state with
+        # package_present False, not prior_state_unavailable.
+        gboard = (
+            "com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME"
+        )
+
+        def side_effect(argv, **kwargs):
+            cmd = " ".join(argv)
+            if "getprop sys.boot_completed" in cmd:
+                return _cr(stdout=b"1\n")
+            if "getprop ro.build.fingerprint" in cmd:
+                return _cr(stdout=FINGERPRINT.encode())
+            if "getprop ro.build.version.sdk" in cmd:
+                return _cr(stdout=f"{API_LEVEL}\n".encode())
+            if "wm size" in cmd:
+                return _cr(stdout=f"Physical size: {SCREEN_WIDTH}x{SCREEN_HEIGHT}\n".encode())
+            if "pm path" in cmd:
+                return _cr(rc=1)  # absent: the real device's answer
+            if "settings get secure enabled_input_methods" in cmd:
+                return _cr(stdout=gboard.encode())
+            if "settings get secure default_input_method" in cmd:
+                return _cr(stdout=gboard.encode())
+            return _cr()
+
+        self.mock_runner.side_effect = side_effect
+        state = self.harness.capture_prior_state()
+        self.assertIsNotNone(state)
+        self.assertFalse(state.package_present)
+
+    def test_capture_prior_state_pm_path_unknown_stops(self):
+        # rc=1 WITH output is not absence — unknown state stops the run.
+        def side_effect(argv, **kwargs):
+            cmd = " ".join(argv)
+            if "getprop sys.boot_completed" in cmd:
+                return _cr(stdout=b"1\n")
+            if "getprop ro.build.fingerprint" in cmd:
+                return _cr(stdout=FINGERPRINT.encode())
+            if "getprop ro.build.version.sdk" in cmd:
+                return _cr(stdout=f"{API_LEVEL}\n".encode())
+            if "wm size" in cmd:
+                return _cr(stdout=f"Physical size: {SCREEN_WIDTH}x{SCREEN_HEIGHT}\n".encode())
+            if "pm path" in cmd:
+                return _cr(rc=1, stdout=b"error: device still settling\n")
+            return _cr()
+
+        self.mock_runner.side_effect = side_effect
+        state = self.harness.capture_prior_state()
+        self.assertIsNone(state)
 
     def test_capture_prior_state_empty_streams(self):
         self.mock_runner.return_value = _cr(stdout=b"")

--- a/android/scripts/tests/m2_device/test_adb_harness.py
+++ b/android/scripts/tests/m2_device/test_adb_harness.py
@@ -466,6 +466,42 @@ class TestAdbHarness(unittest.TestCase):
         self.assertIsNotNone(state)
         self.assertFalse(state.package_present)
 
+    def test_capture_prior_state_present_package_hashes(self):
+        # Review round 2: the present-package path must still parse the
+        # apk path and hash the on-device APK (rc=0, package: output).
+        gboard = (
+            "com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME"
+        )
+        dev_apk = ("/data/app/~~abc/biz.pixelperfectstudios.personaspeak-xyz/base.apk")
+        sha = "ab" * 32
+
+        def side_effect(argv, **kwargs):
+            cmd = " ".join(argv)
+            if "getprop sys.boot_completed" in cmd:
+                return _cr(stdout=b"1\n")
+            if "getprop ro.build.fingerprint" in cmd:
+                return _cr(stdout=FINGERPRINT.encode())
+            if "getprop ro.build.version.sdk" in cmd:
+                return _cr(stdout=f"{API_LEVEL}\n".encode())
+            if "wm size" in cmd:
+                return _cr(stdout=f"Physical size: {SCREEN_WIDTH}x{SCREEN_HEIGHT}\n".encode())
+            if "pm path" in cmd:
+                return _cr(rc=0, stdout=f"package:{dev_apk}\n".encode())
+            if "sha256sum" in cmd:
+                self.assertIn(dev_apk, cmd)
+                return _cr(rc=0, stdout=f"{sha}  {dev_apk}\n".encode())
+            if "settings get secure enabled_input_methods" in cmd:
+                return _cr(stdout=gboard.encode())
+            if "settings get secure default_input_method" in cmd:
+                return _cr(stdout=gboard.encode())
+            return _cr()
+
+        self.mock_runner.side_effect = side_effect
+        state = self.harness.capture_prior_state()
+        self.assertIsNotNone(state)
+        self.assertTrue(state.package_present)
+        self.assertEqual(state.package_hash, sha)
+
     def test_capture_prior_state_pm_path_unknown_stops(self):
         # rc=1 WITH output is not absence — unknown state stops the run.
         def side_effect(argv, **kwargs):


### PR DESCRIPTION
## What

The first real qualification attempt (run 20260819T005731Z, head 9b9fb67) consumed capture authority and terminated on an instrument defect — **the first counted failure under #47's rule; the count now stands at 1 of the 2 allowed**. The owner was told immediately; this PR is the mandated separate fix before any fresh capture.

The defect: on a real device, pm path for an absent package exits 1 with empty output. The pristine fixture's required state is exactly that absence — the personaspeak package must NOT be installed. capture_prior_state read exit 1 as prior-state-unavailable and stopped. Correct instinct, wrong target: the run failed at 8 ledger entries, pre-mutation, with verified cleanup (restore attempted, owned emulator SIGKILLed, port closure verified, record preserved, pinned fixture digests unchanged post-run).

The fix: rc=1 with empty output and empty stderr reads as absence; rc=1 WITH output stays unknown state and stops the run; rc=0 parses stdout as before. The fake adb used to exit 0 for pm path — which is how 342 green tests certified a harness that could not capture prior state on its own fixture; the fake now exits 1 like the device.

## Evidence (exact head 6d0f9400c7f273e2bdad6a1dbd649faff05fc62e)

- Regression: test_capture_prior_state_absent_package_rc1 — absence yields prior state with package_present False, not prior_state_unavailable (this is the exact first-counted-failure scenario).
- Regression: test_capture_prior_state_pm_path_unknown_stops — rc=1 with output yields None (unknown stops mutation).
- Happy-path prior-state test now stubs the device's real answer (rc=1).
- Acceptance matrix: the one legitimate nonzero ledger rc (pm path, both the prior-state and post-restore entries) is documented and pinned to exactly rc=1; every other entry stays rc=0.
- Suite 342 -> 344, green twice: python3 -m unittest discover -s android/scripts/tests/m2_device.
- Budgets: adb_harness.py 1026/1100, total 2645/2700. ADR-0008 limits unchanged.
- records.py untouched. No new dependencies. No device contact in this PR.

## Definition of done

- Non-author review via API (reicodes-pixelperfect and ghostinprod-pixelperfect requested).
- Patchnote committed. CI green at exact head before merge.
