### PR TITLE
m2_device: read the touchable region, speak the avd console grammar (attempt-1 defects, probe-pinned)

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,30 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-08-20 — The instrument learns how a real device phrases things
+
+- Qualification attempt 1 under the replacement (run 20260819T203941Z)
+  got further than any run before it — IME enabled and selected, editor
+  focused, binding proven live — and then failed on two defects that
+  only real hardware could expose, both since pinned by an
+  owner-authorized probe. First: the real API-34 dumpsys window output
+  has no mFrame line at all; the keyboard's visible geometry lives in
+  the touchable region, which is where the parser now reads it (compact
+  top 1378 exact, Review expands it to 1283 — the review signal, in the
+  device's own words). Failed window checks now carry the raw block in
+  the record, so the next format drift is diagnosable without another
+  probe. Second: the emulator 36.x console moved the snapshot family
+  under avd, and it announces a rejected load with a KO line while
+  reporting success on the exit-code channel; restore now speaks the
+  avd grammar and believes stdout over returncode. The fake toolkit
+  mirrors both real formats, rejects the dead command form exactly as
+  the real console does, and the fake's Review expansion moved to the
+  real 1283. Five new regressions pin the parser to the probe's actual
+  bytes. The console's parting gift remains on record: it lied about
+  the exit code, so now nothing trusts it.
+
+---
+
 ## 2026-08-19 — The journey-facts layer, rebuilt on channels that exist
 
 - The overseer-approved replacement (#79, PR #80) is implemented. The

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -92,10 +92,13 @@ REWRITE_TAP = (116, 1452)
 CANCEL_TAP = (180, 1452)
 APPLY_TAP = (105, 1452)
 DISMISS_TAP = (328, 1452)
-# InputMethod window frame (dumpsys window): the compact row tops out
-# at y=1378; Review expands upward past y=1330. Frame top below the
-# compact line means the panel grew — the machine-visible half of the
-# review-ready signal; the candidate surface itself is screenshot-bound.
+# InputMethod window geometry (dumpsys window): the compact row's
+# touchable region tops out at y=1378; Review expands it upward past
+# y=1330. A region top below the compact line means the panel grew —
+# the machine-visible half of the review-ready signal; the candidate
+# surface itself is screenshot-bound. (API 34 publishes this only as the
+# touchable region; the window frame itself is fill-parent in both
+# states — probe 2026-08-20.)
 IME_COMPACT_TOP = 1378
 IME_EXPANDED_MAX_TOP = 1330
 # FakeProvider's fixture latency is 400ms; the host sleeps past it
@@ -681,8 +684,9 @@ class AdbHarness:
 
     def _ime_window_frame(self, steps, tag: str) -> tuple[int, int] | None:
         """dumpsys window: the InputMethod window owned by our package,
-        shown and drawn. Returns (top, bottom) of its frame, or None on
-        any refusal — never a guessed frame."""
+        shown and drawn. Returns (top, bottom) of its touchable region —
+        the visible keyboard area — or None on any refusal, never a
+        guessed frame."""
         res = self._shell("dumpsys", "window", "windows")
         if self._ambiguous(res) or self._rc_of(res) != 0:
             self._step(steps, f"verify_ime_window_{tag}", res)
@@ -700,17 +704,32 @@ class AdbHarness:
                     "mViewVisibility=0x0", "isReadyForDisplay()=true",
                     "shown=true")):
                 errors.append("window not shown")
+            # The real block (API 34, emulator 36.6.11 — probe
+            # 2026-08-20) carries no mFrame line: the window frame is
+            # fill-parent in both panel states. The visible keyboard
+            # geometry lives in the touchable region, which moves with
+            # the panel — that region is the review signal's source.
             fm = re.search(
-                r"mFrame=\[(-?\d+),(-?\d+)\]\[(-?\d+),(-?\d+)\]", block)
+                r"touchable region=SkRegion\("
+                r"\((-?\d+),(-?\d+),(-?\d+),(-?\d+)\)\)", block)
             if fm is None:
-                errors.append("frame absent")
+                errors.append("touchable region absent")
             if errors:
-                self._step(steps, f"verify_ime_window_{tag}",
-                           self._fail("window", "; ".join(errors).encode()))
+                # The raw block rides in the failure record so a format
+                # drift is diagnosable from the record alone.
+                self._step(
+                    steps, f"verify_ime_window_{tag}",
+                    self._fail(
+                        "window",
+                        ("; ".join(errors) + "\n" + block[:8192]).encode()))
                 return None
             return int(fm.group(2)), int(fm.group(4))
-        self._step(steps, f"verify_ime_window_{tag}",
-                   self._fail("window", b"no InputMethod window"))
+        self._step(
+            steps, f"verify_ime_window_{tag}",
+            self._fail(
+                "window",
+                b"no InputMethod window\n"
+                + out[:8192].encode("utf-8", "replace")))
         return None
 
     def _verify_window_state(self, steps, tag: str, expanded: bool) -> bool:
@@ -1072,7 +1091,21 @@ class AdbHarness:
             except Exception:
                 pass
             self.screenrecord_process = None
-        return self._host("emu", "snapshot", "load", SNAPSHOT_NAME, timeout=30.0)
+        # The 36.x console nests the snapshot family under `avd` (probe
+        # 2026-08-20): the bare top-level form draws "KO: unknown
+        # command". Console KOs arrive with returncode 0, so stdout —
+        # not rc — is the verdict.
+        res = self._host("emu", "avd", "snapshot", "load", SNAPSHOT_NAME,
+                         timeout=30.0)
+        out = res.stdout.decode("utf-8", errors="replace")
+        if res.returncode == 0 and "KO:" in out:
+            return CommandResult(
+                argv=res.argv, start_utc=res.start_utc,
+                end_utc=res.end_utc, returncode=1, stdout=res.stdout,
+                stderr=("console rejected restore: "
+                        + out.strip()).encode(),
+            )
+        return res
 
     def verify_restore(self) -> PriorDeviceState:
         state = self.capture_prior_state()

--- a/android/scripts/tests/m2_device/fixtures/bin/adb
+++ b/android/scripts/tests/m2_device/fixtures/bin/adb
@@ -52,7 +52,7 @@ APPLY_TAP = (105, 1452)
 DISMISS_TAP = (328, 1452)
 TAP_SLOP = 54  # half a 108px key cell
 COMPACT_TOP = 1378
-EXPANDED_TOP = 1260
+EXPANDED_TOP = 1283
 
 
 def _read(path):
@@ -208,34 +208,44 @@ def _dumpsys_input_method():
 
 
 def _dumpsys_window():
+    # Mirrors the real API-34 dump (probe 2026-08-20,
+    # ~/m2-probe-20260820/dumpsys_window_{compact,expanded}.txt): no
+    # mFrame lines exist — each block carries a fill-parent Frames: line,
+    # and the InputMethod block's touchable region moves with the panel.
+    settings_block = (
+        "  Window #7 Window{213d245 u0 com.android.settings/com.android.settings.Settings}:\n"
+        "    mOwnerUid=1000 showForAllUsers=false package=com.android.settings appop=NONE\n"
+        "    mViewVisibility=0x0 mHaveFrame=true mObscured=false\n"
+        "    mHasSurface=true isReadyForDisplay()=true mWindowRemovalAllowed=false\n"
+        "    Frames: parent=[0,128][1080,2400] display=[0,128][1080,2400] frame=[0,128][1080,2400] last=[0,128][1080,2400] insetsChanged=false\n"
+        "    touchable region=SkRegion((0,0,1080,2400))\n"
+        "    WindowStateAnimator{b1c2d3 Settings}:\n"
+        "      Surface: shown=true layer=0 alpha=1.0 rect=(0.0,0.0)  transform=(1.0, 0.0, 0.0, 0.0)\n"
+        "      mDrawState=HAS_DRAWN       mLastHidden=false\n"
+    )
     if os.environ.get("FAKE_ADB_IME_WINDOW_MISSING") or not _ime_bound():
-        return (
-            "  Window #1 Window{abc123 u0 com.android.settings/com.android.settings.Settings}:\n"
-            "    mOwnerUid=1000 package=com.android.settings\n"
-            "    mViewVisibility=0x0\n"
-            "    isReadyForDisplay()=true\n"
-            "    mFrame=[0,0][1080,2400]\n"
-            "    HAS_DRAWN\n"
-        )
+        return settings_block
     _advance_loading()
     if _panel_expanded() and not os.environ.get("FAKE_ADB_WINDOW_NEVER_EXPANDS"):
         top = EXPANDED_TOP
     else:
         top = COMPACT_TOP
-    return (
-        "  Window #1 Window{abc123 u0 com.android.settings/com.android.settings.Settings}:\n"
-        "    mOwnerUid=1000 package=com.android.settings\n"
-        "    mViewVisibility=0x0\n"
-        "    isReadyForDisplay()=true\n"
-        "    mFrame=[0,0][1080,2400]\n"
-        "    HAS_DRAWN\n"
-        "  Window #4 Window{d4e5f6 u0 InputMethod}:\n"
-        f"    mOwnerUid=10198 mShowToOwnerOnly=true package={KEYBOARD_PACKAGE} userId=0\n"
-        "    mAttrs=WM.LayoutParams{(0,0)(fillxfh) gr=#11 sim=#32 ty=INPUT_METHOD fmt=-3}\n"
-        "    mViewVisibility=0x0 mHaveFrame=true\n"
-        "    isReadyForDisplay()=true\n"
-        f"    mFrame=[0,{top}][1080,2400]\n"
-        "    HAS_DRAWN\n"
+    return settings_block + (
+        "  Window #8 Window{d035f22 u0 InputMethod}:\n"
+        "    mDisplayId=0 rootTaskId=1 mSession=Session{38d43d5 4903:u0a10192} mClient=android.os.BinderProxy@2b264ed\n"
+        "    mOwnerUid=10192 showForAllUsers=false package=" + KEYBOARD_PACKAGE + " appop=NONE\n"
+        "    mAttrs={(0,0)(fillxfill) gr=BOTTOM CENTER_VERTICAL sim={adjust=pan} ty=INPUT_METHOD fmt=TRANSPARENT wanim=0x1030056 receive insets ignoring z-order\n"
+        "    Requested w=1080 h=2272 mLayoutSeq=176\n"
+        "    mIsImWindow=true mIsWallpaper=false mIsFloatingLayer=true\n"
+        "    mViewVisibility=0x0 mHaveFrame=true mObscured=false\n"
+        "    mGivenContentInsets=[0,1250][0,0] mGivenVisibleInsets=[0,1250][0,0]\n"
+        f"    touchable region=SkRegion((0,{top},1080,2400))\n"
+        "    mHasSurface=true isReadyForDisplay()=true mWindowRemovalAllowed=false\n"
+        "    Frames: parent=[0,128][1080,2400] display=[0,128][1080,2400] frame=[0,128][1080,2400] last=[0,128][1080,2400] insetsChanged=false\n"
+        "    WindowStateAnimator{a8b0090 InputMethod}:\n"
+        "      mSurface=Surface(name=InputMethod)/@0x6bb4d89\n"
+        "      Surface: shown=true layer=0 alpha=1.0 rect=(0.0,0.0)  transform=(1.0, 0.0, 0.0, 0.0)\n"
+        "      mDrawState=HAS_DRAWN       mLastHidden=false\n"
     )
 
 
@@ -450,13 +460,25 @@ elif cmd.startswith("shell ") or (
     for segment in payload.replace("&&", ";").split(";"):
         if segment.strip():
             _run_shell_segment(segment.strip())
-elif "emu snapshot load" in cmd:
+elif "emu avd snapshot load" in cmd:
+    # The 36.x console grammar: snapshots live under `avd` (probe
+    # 2026-08-20). The bare top-level form below is the form the real
+    # console rejects.
     if os.environ.get("FAKE_ADB_RESTORE_FAIL"):
         sys.exit(2)
+    if os.environ.get("FAKE_ADB_RESTORE_KO"):
+        # The console's lie class: a KO line on stdout with rc 0.
+        print("KO: unknown command, try 'help'")
+        sys.exit(0)
     if not os.environ.get("FAKE_ADB_RESTORE_NORESET"):
         _reset_to_pristine()
     if _wm_flag:
         _write(_wm_flag, "1")
+elif "emu snapshot load" in cmd:
+    # No top-level snapshot command on the real 36.x console; the KO
+    # arrives with rc 0, which is exactly why the harness reads stdout.
+    print("KO: unknown command, try 'help'")
+    sys.exit(0)
 elif "emu kill" in cmd:
     pass
 elif "pull" in sys.argv:

--- a/android/scripts/tests/m2_device/test_acceptance_matrix.py
+++ b/android/scripts/tests/m2_device/test_acceptance_matrix.py
@@ -227,7 +227,7 @@ GOLDEN_CONTACTS = (
     "adb: -s emulator-5554 shell screencap -p /sdcard/07-settings.png",
     "adb: -s emulator-5554 pull /sdcard/07-settings.png <RUN>/artifacts/07-settings.png",
     "adb: -s emulator-5554 pull /sdcard/journey.mp4 <RUN>/artifacts/journey.mp4",
-    "adb: -s emulator-5554 emu snapshot load m2_pristine",
+    "adb: -s emulator-5554 emu avd snapshot load m2_pristine",
     "adb: -s emulator-5554 shell getprop sys.boot_completed",
     "adb: -s emulator-5554 shell getprop ro.build.fingerprint",
     "adb: -s emulator-5554 shell getprop ro.build.version.sdk",
@@ -413,7 +413,7 @@ GOLDEN_LEDGER_ARGV = (
     ["<BIN>/adb", "-s", "emulator-5554", "pull", "/sdcard/07-settings.png", "<RUN>/artifacts/07-settings.png", "host"],
     ["<BIN>/adb", "-s", "emulator-5554", "shell", "screenrecord", "--time-limit", "30", "/sdcard/journey.mp4", "shell"],
     ["<BIN>/adb", "-s", "emulator-5554", "pull", "/sdcard/journey.mp4", "<RUN>/artifacts/journey.mp4", "host"],
-    ["<BIN>/adb", "-s", "emulator-5554", "emu", "snapshot", "load", "m2_pristine", "host"],
+    ["<BIN>/adb", "-s", "emulator-5554", "emu", "avd", "snapshot", "load", "m2_pristine", "host"],
     ["<BIN>/adb", "-s", "emulator-5554", "shell", "getprop", "sys.boot_completed", "shell"],
     ["<BIN>/adb", "-s", "emulator-5554", "shell", "getprop", "ro.build.fingerprint", "shell"],
     ["<BIN>/adb", "-s", "emulator-5554", "shell", "getprop", "ro.build.version.sdk", "shell"],
@@ -977,6 +977,27 @@ class TestAcceptanceMatrix(unittest.TestCase):
         restore = self._last(record, "restore")
         self.assertEqual(restore.cause, TerminalCause.CLEANUP_PARTIAL)
         self.assertEqual(restore.result.returncode, 2)
+        verify = self._last(record, "verify_restore")
+        self.assertEqual(verify.cause, TerminalCause.RESTORATION_MISMATCH)
+        self.assertEqual(self._last(record, "release_emulator").cause,
+                         TerminalCause.COMPLETED)
+        self.assertEqual(self._last(record, "ledger").cause,
+                         TerminalCause.COMPLETED)
+
+    def test_matrix_console_ko_restore(self):
+        # The console's lie class from attempt 1 (run 20260819T203941Z):
+        # a rejected snapshot load answers KO on stdout with returncode
+        # 0. The restore step must read the verdict from stdout, record
+        # CLEANUP_PARTIAL instead of a false COMPLETED, and the
+        # un-restored device must still fail the restoration verdict.
+        result = self._run({"FAKE_ADB_RESTORE_KO": "1"})
+        self.assertNotEqual(result.returncode, 0)
+        _, record = self._record()
+        self._assert_common(record)
+        restore = self._last(record, "restore")
+        self.assertEqual(restore.cause, TerminalCause.CLEANUP_PARTIAL)
+        self.assertEqual(restore.result.returncode, 1)
+        self.assertIn(b"console rejected restore", restore.result.stderr)
         verify = self._last(record, "verify_restore")
         self.assertEqual(verify.cause, TerminalCause.RESTORATION_MISMATCH)
         self.assertEqual(self._last(record, "release_emulator").cause,

--- a/android/scripts/tests/m2_device/test_adb_harness.py
+++ b/android/scripts/tests/m2_device/test_adb_harness.py
@@ -155,21 +155,40 @@ class _DeviceModel:
                 "  mVisibleBound=true\n")
 
     def dumpsys_window(self):
+        # Real API-34 shape (probe 2026-08-20): no mFrame lines; the
+        # InputMethod block's touchable region carries the panel state.
         if self.window_missing or not self.bound():
             return ("  Window #1 Window{abc u0 Notification Shade}:\n"
                     "    package=com.android.systemui\n    HAS_DRAWN\n")
         if self.panel == "LOADING":
             self.panel = "REVIEW"
         expanded = self.panel in ("REVIEW", "APPLIED", "STALE")
-        top = 1260 if (expanded and not self.never_expands) else 1378
+        top = 1283 if (expanded and not self.never_expands) else 1378
         return (
-            "  Window #1 Window{abc u0 com.android.settings/com.android.settings.Settings}:\n"
-            "    mOwnerUid=1000 package=com.android.settings\n"
-            f"    mFrame=[0,0][1080,2400]\n    HAS_DRAWN\n"
-            "  Window #4 Window{d4e5f6 u0 InputMethod}:\n"
-            "    mOwnerUid=10198 package=biz.pixelperfectstudios.personaspeak userId=0\n"
-            "    mViewVisibility=0x0\n    isReadyForDisplay()=true\n"
-            f"    mFrame=[0,{top}][1080,2400]\n    HAS_DRAWN\n"
+            "  Window #7 Window{213d245 u0 com.android.settings/com.android.settings.Settings}:\n"
+            "    mOwnerUid=1000 showForAllUsers=false package=com.android.settings appop=NONE\n"
+            "    mViewVisibility=0x0 mHaveFrame=true mObscured=false\n"
+            "    mHasSurface=true isReadyForDisplay()=true mWindowRemovalAllowed=false\n"
+            "    Frames: parent=[0,128][1080,2400] display=[0,128][1080,2400] frame=[0,128][1080,2400] last=[0,128][1080,2400] insetsChanged=false\n"
+            "    touchable region=SkRegion((0,0,1080,2400))\n"
+            "    WindowStateAnimator{b1c2d3 Settings}:\n"
+            "      Surface: shown=true layer=0 alpha=1.0 rect=(0.0,0.0)  transform=(1.0, 0.0, 0.0, 0.0)\n"
+            "      mDrawState=HAS_DRAWN       mLastHidden=false\n"
+            "  Window #8 Window{d035f22 u0 InputMethod}:\n"
+            "    mDisplayId=0 rootTaskId=1 mSession=Session{38d43d5 4903:u0a10192} mClient=android.os.BinderProxy@2b264ed\n"
+            "    mOwnerUid=10192 showForAllUsers=false package=biz.pixelperfectstudios.personaspeak appop=NONE\n"
+            "    mAttrs={(0,0)(fillxfill) gr=BOTTOM CENTER_VERTICAL sim={adjust=pan} ty=INPUT_METHOD fmt=TRANSPARENT wanim=0x1030056 receive insets ignoring z-order\n"
+            "    Requested w=1080 h=2272 mLayoutSeq=176\n"
+            "    mIsImWindow=true mIsWallpaper=false mIsFloatingLayer=true\n"
+            "    mViewVisibility=0x0 mHaveFrame=true mObscured=false\n"
+            "    mGivenContentInsets=[0,1250][0,0] mGivenVisibleInsets=[0,1250][0,0]\n"
+            f"    touchable region=SkRegion((0,{top},1080,2400))\n"
+            "    mHasSurface=true isReadyForDisplay()=true mWindowRemovalAllowed=false\n"
+            "    Frames: parent=[0,128][1080,2400] display=[0,128][1080,2400] frame=[0,128][1080,2400] last=[0,128][1080,2400] insetsChanged=false\n"
+            "    WindowStateAnimator{a8b0090 InputMethod}:\n"
+            "      mSurface=Surface(name=InputMethod)/@0x6bb4d89\n"
+            "      Surface: shown=true layer=0 alpha=1.0 rect=(0.0,0.0)  transform=(1.0, 0.0, 0.0, 0.0)\n"
+            "      mDrawState=HAS_DRAWN       mLastHidden=false\n"
         )
 
     # -- interactions ---------------------------------------------------
@@ -1003,6 +1022,73 @@ class TestAdbHarness(unittest.TestCase):
         self.assertEqual(window[0].cause, TerminalCause.JOURNEY_FAILED)
         self.assertFalse([s for s in steps if s.operation.startswith("tap_key")])
 
+    # Real InputMethod window blocks as the pinned fixture prints them
+    # (API 34, emulator 36.6.11 — capability probe 2026-08-20; trimmed
+    # of animation noise, every surviving line verbatim). The real dump
+    # carries no mFrame line: the window frame is fill-parent in both
+    # panel states and the touchable region carries the panel geometry.
+    _PROBE_IM_BLOCK_COMPACT = (
+        "  Window #8 Window{d035f22 u0 InputMethod}:\n"
+        "    mDisplayId=0 rootTaskId=1 mSession=Session{38d43d5 4903:u0a10192} mClient=android.os.BinderProxy@2b264ed\n"
+        "    mOwnerUid=10192 showForAllUsers=false package=biz.pixelperfectstudios.personaspeak appop=NONE\n"
+        "    mViewVisibility=0x0 mHaveFrame=true mObscured=false\n"
+        "    mGivenContentInsets=[0,1250][0,0] mGivenVisibleInsets=[0,1250][0,0]\n"
+        "    touchable region=SkRegion((0,1378,1080,2400))\n"
+        "    mHasSurface=true isReadyForDisplay()=true mWindowRemovalAllowed=false\n"
+        "    Frames: parent=[0,128][1080,2400] display=[0,128][1080,2400] frame=[0,128][1080,2400] last=[0,128][1080,2400] insetsChanged=false\n"
+        "    WindowStateAnimator{a8b0090 InputMethod}:\n"
+        "      Surface: shown=true layer=0 alpha=1.0 rect=(0.0,0.0)  transform=(1.0, 0.0, 0.0, 0.0)\n"
+        "      mDrawState=HAS_DRAWN       mLastHidden=false\n"
+    )
+    _PROBE_IM_BLOCK_EXPANDED = (
+        "  Window #8 Window{d035f22 u0 InputMethod}:\n"
+        "    mDisplayId=0 rootTaskId=1 mSession=Session{38d43d5 4903:u0a10192} mClient=android.os.BinderProxy@2b264ed\n"
+        "    mOwnerUid=10192 showForAllUsers=false package=biz.pixelperfectstudios.personaspeak appop=NONE\n"
+        "    mViewVisibility=0x0 mHaveFrame=true mObscured=false\n"
+        "    mGivenContentInsets=[0,1155][0,0] mGivenVisibleInsets=[0,1155][0,0]\n"
+        "    touchable region=SkRegion((0,1283,1080,2400))\n"
+        "    mHasSurface=true isReadyForDisplay()=true mWindowRemovalAllowed=false\n"
+        "    Frames: parent=[0,128][1080,2400] display=[0,128][1080,2400] frame=[0,128][1080,2400] last=[0,128][1080,2400] insetsChanged=false\n"
+        "    WindowStateAnimator{a8b0090 InputMethod}:\n"
+        "      Surface: shown=true layer=0 alpha=1.0 rect=(0.0,0.0)  transform=(1.0, 0.0, 0.0, 0.0)\n"
+        "      mDrawState=HAS_DRAWN       mLastHidden=false\n"
+    )
+
+    def _window_res(self, block):
+        return RemoteResult(
+            remote_rc=0,
+            transport=CommandResult(
+                argv=["dumpsys", "window", "windows"],
+                start_utc="", end_utc="", returncode=0,
+                stdout=block.encode(), stderr=b"",
+            ),
+        )
+
+    def test_window_frame_reads_real_probe_bytes(self):
+        # The parser is pinned to the device's own bytes, not to the
+        # fake's rendering of them: compact 1378, expanded 1283 — the
+        # 95px upward growth that is the review signal.
+        for block, want in ((self._PROBE_IM_BLOCK_COMPACT, (1378, 2400)),
+                            (self._PROBE_IM_BLOCK_EXPANDED, (1283, 2400))):
+            with patch.object(self.harness, "_shell",
+                              return_value=self._window_res(block)):
+                self.assertEqual(
+                    self.harness._ime_window_frame([], "probe"), want)
+
+    def test_window_failure_preserves_raw_block(self):
+        # Attempt 1 (run 20260819T203941Z) failed with "frame absent"
+        # and discarded the bytes, leaving the real format unpinnable
+        # from the record. A failed check now carries the raw block.
+        block = self._PROBE_IM_BLOCK_COMPACT.replace(
+            "touchable region=SkRegion((0,1378,1080,2400))\n", "")
+        steps = []
+        with patch.object(self.harness, "_shell",
+                          return_value=self._window_res(block)):
+            self.assertIsNone(self.harness._ime_window_frame(steps, "s1"))
+        stderr = steps[0].result.stderr.decode("utf-8", "replace")
+        self.assertIn("touchable region absent", stderr)
+        self.assertIn("WindowStateAnimator", stderr)
+
     def test_run_journey_detects_review_that_never_expands(self):
         # A rewrite that stays compact is a review that never happened;
         # the window-geometry check must fail closed before any apply.
@@ -1098,9 +1184,34 @@ class TestAdbHarness(unittest.TestCase):
         res = self.harness.restore()
         self.assertEqual(res.returncode, 0)
         self.mock_runner.assert_called_once_with(
-            ["adb", "-s", "emulator-5554", "emu", "snapshot", "load", SNAPSHOT_NAME],
+            ["adb", "-s", "emulator-5554", "emu", "avd", "snapshot",
+             "load", SNAPSHOT_NAME],
             timeout=30.0,
         )
+
+    def test_restore_detects_console_ko_despite_rc_zero(self):
+        # The real 36.x console answers a rejected snapshot load with a
+        # KO line on stdout AND returncode 0 (attempt 1, run
+        # 20260819T203941Z). rc alone would record a restore that never
+        # happened; stdout is the verdict.
+        self.mock_runner.return_value = CommandResult(
+            argv=["adb", "-s", "emulator-5554", "emu", "avd", "snapshot",
+                  "load", SNAPSHOT_NAME],
+            start_utc="", end_utc="", returncode=0,
+            stdout=b"KO: unknown command, try 'help'\r\n", stderr=b"",
+        )
+        res = self.harness.restore()
+        self.assertEqual(res.returncode, 1)
+        self.assertIn(b"console rejected restore", res.stderr)
+        self.assertIn(b"KO: unknown command", res.stderr)
+
+    def test_restore_ok_line_passes_through(self):
+        self.mock_runner.return_value = CommandResult(
+            argv=[], start_utc="", end_utc="", returncode=0,
+            stdout=b"OK", stderr=b"",
+        )
+        res = self.harness.restore()
+        self.assertEqual(res.returncode, 0)
 
     def test_release_emulator_process(self):
         mock_process = MagicMock()


### PR DESCRIPTION
## What this is

The two instrument defects that ended qualification attempt 1 under the replacement (run 20260819T203941Z, tracker issue 69 entry 32), both fixed against real bytes pinned by the owner-authorized capability probe of 2026-08-20. Count under the replacement: this PR is the correction step before attempt 2 — the last one this architecture gets.

## Defect 1 — the window parser listened for a line the device never says

The harness regex expected an mFrame=[a,b][c,d] line inside the InputMethod window block — the line the fake adb prints. The real API-34 dump has no such line anywhere: the window frame is fill-parent in both panel states, and the visible keyboard geometry lives in the touchable region, which moves with the panel. Attempt 1 failed with the sole error "frame absent" while the owned, drawn, and shown checks all passed against real bytes.

The probe pinned both states:

- compact (editor focused, keyboard up): touchable region=SkRegion((0,1378,1080,2400)) — top 1378, equal to the existing IME_COMPACT_TOP pin, exact.
- Review expanded (after the Rewrite tap): SkRegion((0,1283,1080,2400)) — a 95px upward growth, inside the existing past-1330 expectation.

So the constants do not move; only the source line does. The parser now reads the touchable region, and a failed window check embeds the raw block (truncated) in the step record — attempt 1 discarded those bytes and left the real format unpinnable from the record, which is why a probe was needed at all. Future format drifts will be diagnosable from the run dir alone.

## Defect 2 — the console grammar moved and its errors ride a success exit code

restore() sent the bare top-level form, emu snapshot load. The emulator 36.x console has no top-level snapshot command — the family lives under avd — and its rejection arrives as a KO line on stdout with returncode 0. Attempt 1 recorded the restore step as COMPLETED while nothing was restored; the verify_restore pristine assertion caught the lie (search editor still present), which is the fail-closed design working.

The probe proved the working form live: emu avd snapshot load m2_pristine answered OK and the device returned to pristine — package absent, search screen gone. restore() now sends the avd form and treats a KO line on stdout as failure regardless of rc, so a rejected restore records CLEANUP_PARTIAL, never a false COMPLETED.

## Honest fakes

The fake adb mirrors the real formats instead of inventing its own:

- Window blocks are byte-shaped from the probe capture (settings and InputMethod blocks, Frames lines, mDrawState=HAS_DRAWN, Surface shown=true), with the InputMethod touchable region parametrized by panel state.
- The fake's Review expansion moved from the invented 1260 to the real 1283; compact stays 1378.
- The fake console accepts the avd grammar and rejects the bare form with the real KO line and rc 0 — the same lie class the production code must survive.

## Tests and evidence

- New regressions: the parser is pinned to the probe's actual bytes (compact and expanded blocks embedded verbatim, trimmed of animation noise), raw-block preservation on failure, KO detection despite rc 0, OK passthrough, and a full CLI matrix variant for the rc-0 KO class (FAKE_ADB_RESTORE_KO) asserting restore CLEANUP_PARTIAL, restoration mismatch, release and ledger still completing.
- Goldens: the restore contact and the ledgered argv gain the avd token; no count changes.
- Suite 352/352 twice locally (was 347; +5). Budgets 1049/1100 and 2667/2700 (was 1030 and 2648), limits unchanged, no amendment.
- Probe artifacts live outside the repo at ~/m2-probe-20260820/ with a SUMMARY.md; the load-bearing bytes are embedded in the regressions.

## Definition of done

- [x] Code + tests ride together (five new regressions, one new matrix knob variant)
- [x] Goldens updated, not deleted (avd token added; explained above)
- [x] Evidence attached (suite output above; probe provenance in the section of the same name)
- [ ] Graded by a non-author — requested; skip will be stated loudly if silent
- [x] Docs: instrument correction within the #79-ruled replacement design — no schema or privacy-posture movement; patchnote committed
- [x] Patch note committed to PATCHNOTES.md
- [ ] CI green (will attach the run)
