### PR TITLE
docs(roadmap): milestone 2 qualified — close out the stale pending text

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,15 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-08-23 — The roadmap learns what happened
+
+- ROADMAP.md stopped describing milestone 2 as awaiting qualification;
+  the qualification receipt is now cited where the caveat used to be.
+  Documentation's least glamorous job, done anyway: the map now
+  matches the territory.
+
+---
+
 ## 2026-08-23 — Milestone 2 qualified on real hardware
 
 - The unified PersonaSpeak build has, at last, been formally qualified

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,11 +57,11 @@ persona strip above the keys that rewrites what you've typed.
       [ADR-0007](docs/adr/0007-dedicated-personaspeak-row.md) dedicated-row
       geometry on an emulator. The source and build cutover is implemented and
       passes the host gate, and the dedicated-row geometry is proven by host
-      tests. Final real-device qualification is not done: mutation against a
-      real `InputConnection`, the height cap on a real screen, and restoration
-      after real mutation all remain pending in a follow-up PR under issue #47,
-      together with the device orchestrator that runs them. The earlier device
-      receipt was not accepted and is no longer tracked in this repository.
+      tests. Real-device qualification is **done** (2026-08-23, issue #47
+      closed): the device orchestrator ran the full journey on the pinned
+      snapshot fixture — 145/145 steps, exact mutation counts, verified
+      restoration (run 20260823T122133Z, receipt PR #84, evidence on the
+      protected `evidence` branch).
 - [ ] Persona strip grafted onto the chosen base as its own row above ASK's
       untouched suggestions and keys: persona chip + mood chip + transform,
       reading the draft and replacing it in place


### PR DESCRIPTION
Stage-6 housekeeping after #47 closed (owner-approved in #personaspeak, 2026-08-23).

Docs-only, two lines of substance:

- ROADMAP.md: the unify-the-build item (already checked) still carried its pre-qualification caveat — "Final real-device qualification is not done: mutation against a real InputConnection, the height cap on a real screen, and restoration after real mutation all remain pending." All three are now proven (run `20260823T122133Z`, PR #84). The item now records the receipt instead of the intention.
- Issue #38 body: milestone-2 box checked with the receipt pointer (done in the issue, no repo change).

No code. No evidence changes. The qualification itself is untouched — this PR only stops the roadmap from describing last week's weather.