### PR TITLE
ci: harden Gradle wrapper checksum, checkout creds, and upgrade Actions to Node 24 (#31, #32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     name: Validate personas & smoke-test CLI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -37,7 +37,7 @@ jobs:
           echo "::notice::Patch-note gate intentionally skipped — this PR carries the 'no-patchnote' label. A loud skip, not a silent one."
       - name: Checkout (full history so we can diff against the base)
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-patchnote') }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Require PATCHNOTES.md in the diff
@@ -60,8 +60,8 @@ jobs:
     name: M2 device qualification suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Run m2_device focused suite
@@ -77,9 +77,13 @@ jobs:
     # Android qualification when the PR is ready, and always on main pushes.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       # it has to be a CI step and not something we notice on a laptop.
       - name: Restore the ASK Robolectric jar cache
         id: robolectric-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: android/keyboard/.robolectric-android-all-jars
           key: robolectric-jars-${{ hashFiles('android/keyboard/scripts/robolectric_jars_versions.txt') }}
@@ -154,7 +154,7 @@ jobs:
       # Only the canonical APK. Uploading a second one would recreate, in the
       # artifact tab, exactly the ambiguity the cutover removed from the tree.
       - name: Upload canonical APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: personaspeak-debug-apk
           path: android/keyboard/ime/app/build/outputs/apk/debug/app-debug.apk
@@ -162,7 +162,7 @@ jobs:
           retention-days: 14
       - name: Upload non-APK reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: milestone-2-reports
           path: |

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -10,6 +10,19 @@ Newest first, like all respectable patch notes.
 
 ---
 
+## 2026-08-24 — CI supply chain gets adult supervision
+
+- Added the official verified SHA-256 (`distributionSha256Sum`) to
+  `android/gradle/wrapper/gradle-wrapper.properties` for Gradle 9.2.1-all, so
+  the wrapper actually checks what it downloads instead of trusting the wire.
+- Hardened the Android CI job's token posture to explicit `permissions:
+  contents: read` with `persist-credentials: false` on checkout.
+- Bumped GitHub Actions (`actions/checkout` v5, `actions/setup-python` v6,
+  `actions/setup-java` v5) to Node 24 majors, banishing the Node 20
+  deprecation calendar invitations from our CI logs.
+
+---
+
 ## 2026-08-23 — The roadmap learns what happened
 
 - ROADMAP.md stopped describing milestone 2 as awaiting qualification;

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -18,8 +18,9 @@ Newest first, like all respectable patch notes.
 - Hardened the Android CI job's token posture to explicit `permissions:
   contents: read` with `persist-credentials: false` on checkout.
 - Bumped GitHub Actions (`actions/checkout` v5, `actions/setup-python` v6,
-  `actions/setup-java` v5) to Node 24 majors, banishing the Node 20
-  deprecation calendar invitations from our CI logs.
+  `actions/setup-java` v5, `actions/cache` v5, `actions/upload-artifact` v6)
+  to Node 24 majors, banishing the Node 20 deprecation calendar invitations
+  from our CI logs.
 
 ---
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-all.zip
+distributionSha256Sum=f86344275d1b194688dd330abf9f6f2344cd02872ffee035f2d1ea2fd60cf7f3
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## What

- **Gradle distribution checksum**: Added `distributionSha256Sum` for `gradle-9.2.1-all.zip` (`f86344275d1b194688dd330abf9f6f2344cd02872ffee035f2d1ea2fd60cf7f3`) in `android/gradle/wrapper/gradle-wrapper.properties`, verified against Gradle's official `.sha256` endpoint.
- **Credential posture**: Configured explicit `permissions: contents: read` and `persist-credentials: false` on checkout for the `android-build` job in `.github/workflows/ci.yml`.
- **Node 24 action majors**: Bumped `actions/checkout` to `v5`, `actions/setup-python` to `v6`, and `actions/setup-java` to `v5` across `.github/workflows/ci.yml` to eliminate the Node 20 deprecation warnings.

Closes #31, closes #32.

## Why

Follow-up hardening from PR #30 review and post-merge CI findings:
- #31: Supply-chain protection for the Gradle wrapper binary and limiting token access on hosted runners.
- #32: GitHub Actions deprecation shim retirement notice for Node 20 runtimes.

## Evidence

- **Gradle SHA-256 official endpoint verification:**
  ```
  $ curl -sSL https://services.gradle.org/distributions/gradle-9.2.1-all.zip.sha256
  f86344275d1b194688dd330abf9f6f2344cd02872ffee035f2d1ea2fd60cf7f3
  ```
- **CLI & persona validation:**
  ```
  $ python3 desktop/validate_personas.py
  4 personas validated. Impeccable, sir.
  $ python3 desktop/personaspeak.py --list
  amitabh-bachchan     Amitabh Bachchan
  dr-schultz           Dr. King Schultz
  jeeves               Jeeves
  sir-humphrey         Sir Humphrey Appleby
  $ python3 -m unittest desktop/test_validate_personas.py
  Ran 6 tests in 0.004s -> OK
  ```
- **m2_device test suite:**
  ```
  $ python3 -m unittest discover -s android/scripts/tests/m2_device -v
  Ran 361 tests in 137.218s -> OK
  ```
- **Verifier fixture suites:**
  ```
  PASS: exact ASK closure accepted; unexpected project rejected
  PASS: dictionary license mapping exact; unlicensed input rejected
  PASS: pristine ledger exact; unledgered rent rejected
  PASS: verify-single-apk contract, 12 cases
  PASS: unified-build copy suppression, 6 assertions
  PASS: verify-milestone-2 contract, 44 assertions
  ```
- **Graded by:** Non-author different-model-family review requested from @seraph-yolo, @sigrid-yolo, and @cassie-yolo.

## Patch note

```markdown
## 2026-08-24 — CI supply chain gets adult supervision

- Added the official verified SHA-256 (`distributionSha256Sum`) to
  `android/gradle/wrapper/gradle-wrapper.properties` for Gradle 9.2.1-all, so
  the wrapper actually checks what it downloads instead of trusting the wire.
- Hardened the Android CI job's token posture to explicit `permissions:
  contents: read` with `persist-credentials: false` on checkout.
- Bumped GitHub Actions (`actions/checkout` v5, `actions/setup-python` v6,
  `actions/setup-java` v5) to Node 24 majors, banishing the Node 20
  deprecation calendar invitations from our CI logs.
```

## Checklist

- [x] Tests ride with the code (regression test, if this fixes a bug)
- [x] Goldens updated and explained (never silently changed)
- [x] Docs in this PR (ADR if architectural; schema consumers if schema moved)
- [x] `desktop/personaspeak.py --list` + golden tests pass, if `personas/` or prompt code was touched
- [x] Patch-note entry committed to `PATCHNOTES.md` (not just pasted above)
- [ ] Graded by a non-author (or "review skipped: <reason>" stated above)
- [ ] CI is green
- [x] Nothing here stores what a user typed