### PR TITLE
docs: record v0.1.0 release deferral handoff

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -8,6 +8,13 @@ while the context is hot.
 
 Newest first, like all respectable patch notes.
 
+## 2026-08-27 — The Ship Is Packed, But the Key Is Still at Reception
+
+- Deferred the public `v0.1.0` release after M8 landed: code, evidence, and required CI checks are ready; no official signing keystore means no signed APK, immutable tag, or GitHub release yet.
+- Added `handoff.md` with the exact resume path. The release key stays outside git, chat, and anyone's bright ideas.
+
+---
+
 ## 2026-08-27 — The Final Ship: Production usefulness proof, CI required-checks & v0.1.0 release packaging
 
 - Shipped Milestone 8 Slice B (Production Usefulness Proof, Sanitized Error Surfacing, CI Required Checks & Release Packaging):

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ go to be misunderstood.
 | `personas/*.yaml` | ✅ Works | The persona library. One YAML per character: speech patterns, vocabulary, sample lines. This is the single source of truth for everything below. |
 | `desktop/personaspeak.py` | ✅ Works | CLI. `personaspeak.py --as jeeves "grab me a coffee"` → butler-grade coffee request. Brings your own API key. |
 | `.claude/skills/personaspeak/` | ✅ Works | Claude Code skill — same trick, in your editor session, on your subscription, no API bill. |
-| `android/` | 🚧 Phase 1 | The keyboard. A full daily driver — autocorrect, glide, layouts, the lot — forked from an established open-source keyboard, with a persona strip above the keys. Type as normal; tap a character when the reply needs *style*. |
+| `android/` | 🚧 Release candidate | The keyboard. A full daily driver — autocorrect, glide, layouts, the lot — forked from an established open-source keyboard, with a persona strip above the keys. Feature work and release checks landed; the public APK waits on official signing material. |
 
 ## The cast
 
@@ -43,8 +43,9 @@ export ANTHROPIC_API_KEY=sk-ant-...
 The full roadmap lives in [ROADMAP.md](ROADMAP.md). The short version:
 
 1. **Phase 0** *(you are here)* — repo goes public, docs get funny, CI gets serious.
-2. **Phase 1** — PersonaBoard MVP: the keyboard itself, pluggable AI providers
-   (bring your own key, use a free tier, or — later — run a model on your phone).
+2. **Phase 1** — PersonaBoard MVP: feature-complete and release-ready in code.
+   The public `v0.1.0` APK is deferred pending official release signing material;
+   see [handoff.md](handoff.md).
 3. **Phase 2** — Suggested replies: opt in, and the keyboard reads the message
    you're replying to (from the notification, on-device, forgotten immediately)
    and drafts three responses before you've typed a word.
@@ -52,14 +53,15 @@ The full roadmap lives in [ROADMAP.md](ROADMAP.md). The short version:
 
 ## Privacy, briefly
 
-The Android keyboard is still in development. The accepted design encrypts
+The Android keyboard is a release candidate, not a published APK. The accepted design encrypts
 provider credentials with a key held by Android Keystore and sends a draft only
 when the user explicitly requests a rewrite, to the provider they selected.
 ASK also keeps normal keyboard data such as learned words on the device; that
 data must remain user-clearable and excluded from backup and device transfer
 before release. Drafts, prompts, and provider results are not product history.
-Public privacy claims remain gated on release-APK and on-device verification;
-the current evidence and open gates are recorded in
+On-device and static audit evidence is recorded, but public release claims remain
+gated on an officially signed release APK. The current release deferral and
+resume steps are in [handoff.md](handoff.md); privacy design remains in
 [ADR-0005](docs/adr/0005-privacy-posture-fork-audit.md).
 
 ## Maintained by robots (supervised)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,20 +62,24 @@ persona strip above the keys that rewrites what you've typed.
       snapshot fixture — 145/145 steps, exact mutation counts, verified
       restoration (run 20260823T122133Z, receipt PR #84, evidence on the
       protected `evidence` branch).
-- [ ] Persona strip grafted onto the chosen base as its own row above ASK's
+- [x] Persona strip grafted onto the chosen base as its own row above ASK's
       untouched suggestions and keys: persona chip + mood chip + transform,
-      reading the draft and replacing it in place
-- [ ] **Milestone 4 — Secure provider configuration & persistence** (issue #89):
+      reading the draft and replacing it in place (PR #87/#88).
+- [x] **Milestone 4 — Secure provider configuration & persistence** (issue #89,
+      closed with deferred live gates):
       `ProviderConfigStore` port, Preferences DataStore metadata + AndroidKeyStore
       AES-GCM ciphertext persistence, backup exclusion configured for API 26/27
       and API 31+, `AnthropicMessagesAdapter` in `:personaspeak-providers` with closed error taxonomy
       over HTTPS, and memory zeroing assertions. Shipped **structurally disabled by default** (`FakeProvider` active default in rewrite
-      coordinator; real adapters unselected in DI; live cloud egress gated on Milestone 5 user opt-in).
-      Device qualification (API 27 backup, ART runner, & Mode B live egress) pending external fixture execution.
-- [ ] app: onboarding (enable → set default → pick provider → try it),
-      persona browser, settings (Milestone 5)
-- [ ] CI: assembleDebug + unit tests per PR; APK artifact on tags
-- [ ] **Installable M8 (Release Readiness)**: signing, cert-fingerprint pinning, version `v0.1.0`/`versionCode=1000`/immutable tag, fail-closed release build (rejected if active provider is fake/stub — test active composition, not ban class), usefulness receipt (one deterministic rewrite through production path + one failure as user-presentable message), R8/minification risk (release-only first-party reachability with no keep policy), dependency-lock state as reproducibility input.
+       coordinator; real adapters unselected in DI; live cloud egress gated on Milestone 5 user opt-in).
+       The API 27 backup, ART runner, and Mode B live-egress gates were formally deferred by owner decision; they are not qualified.
+- [x] app: onboarding (enable → set default → pick provider → try it),
+      persona browser, settings (Milestone 5, PR #104/#105)
+- [x] CI: assembleDebug + unit tests per PR; strict required checks on `main`
+      (M8, ruleset `main required CI`).
+- [ ] Release APK artifact on tags — deferred pending official release signing material.
+- [ ] **Installable M8 (Release Readiness)**: code, CI, signing configuration,
+      fail-closed composition gate, usefulness receipt, R8 release build, and dependency snapshot landed in PR #116/#117. The immutable `v0.1.0` tag and signed APK are deferred until an official keystore is provisioned; see [handoff.md](handoff.md).
 
 **Exit demo:** in WhatsApp, type "running late" on your normal keyboard —
 which is now ours — tap 🎩, send something Wodehouse would sign off on. No

--- a/docs/evidence/milestone-8/README.md
+++ b/docs/evidence/milestone-8/README.md
@@ -1,6 +1,6 @@
 # Milestone 8 — Release Readiness Evidence
 
-**Status: QUALIFIED (Slice A Build & Signing Baseline).**  
+**Status: QUALIFIED (code and signing baseline; public release deferred).**
 **Milestone:** Milestone 8 ([#114](https://github.com/apexcloudwise/personaspeak/issues/114))  
 **Evidence Class:** `build_and_signing_harness`  
 **Run ID:** `20260827T093000Z-m8-slice-a`  
@@ -20,6 +20,8 @@ Milestone 8 Slice A establishes the complete release packaging, signing configur
 
 ---
 
-## 2. Slice B Gating
+## 2. Release Deferral
 
-Slice B (final ship proof, usefulness receipt, CI required-checks transition, and `v0.1.0` immutable annotated git tag) is gated on PR #115 (the #111 live emulator journey run by `opencode-glm-flash`) merging into `main`.
+The emulator journey (PR #115), usefulness receipt, and strict required-checks ruleset all landed. The public `v0.1.0` tag and GitHub release are deferred because no official release keystore is provisioned. Local builds without `PERSONASPEAK_RELEASE_KEYSTORE` produce an unsigned APK; the developer keystore generator is not a production signing identity.
+
+The remaining steps are in [`handoff.md`](../../../handoff.md): provision the key outside git, build and verify the signed artifact, attach it to the GitHub release, then cut the immutable tag at a green `main` head.

--- a/docs/plans/m8-release-readiness-plan.md
+++ b/docs/plans/m8-release-readiness-plan.md
@@ -15,7 +15,7 @@ Milestone 8 is the final code milestone for PersonaSpeak. It transitions Persona
 ### Decisions of Record
 - **M4 Formally Deferred**: As decided by repository owner `zaphodis42` on 2026-08-27 (agentchattr msg 1839), no real Anthropic API key will be provisioned in CI/repo. The mock-only ruling stands permanently. The credential-dependent device gates (#96/#89) remain deferred, not satisfied.
 - **#111 Emulator Journey**: The live AVD emulator journey (Milestone 7 live receipt) is assigned separately to `opencode-glm-flash` under issue [#111](https://github.com/apexcloudwise/personaspeak/issues/111) and draft PR [#115](https://github.com/apexcloudwise/personaspeak/pull/115), building against `de797ba`.
-- **Milestone 8 Final Gate**: The `v0.1.0` immutable annotated git tag cut in Slice B is strictly gated on #111 merging into `main`.
+- **Milestone 8 Final Gate**: The `v0.1.0` immutable annotated git tag cut in Slice B is strictly gated on #111 merging into `main`, an active required-checks ruleset, and an officially provisioned release keystore. The first two landed; official signing material is deferred. See `handoff.md`.
 
 ---
 

--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,35 @@
+# Handoff — Release Deferred After M8
+
+**Date:** 2026-08-27  
+**Main head:** `c453f0f` (`feat(m8): slice B — production usefulness proof, sanitized error surfacing & CI required checks (#114) (#117)`)  
+**Product state:** feature-complete release candidate. No `v0.1.0` tag, GitHub release, or official APK exists.
+
+## What Landed
+
+- M2: unified AnySoftKeyboard APK and device qualification receipt (PR #84).
+- M3: strip, pickers, settings, typed rewrite states (PR #87/#88).
+- M4: secure provider persistence and disabled adapters landed; credential-dependent device gates were formally deferred by the owner (issues #89/#90/#96 closed with that record).
+- M5: BYOK provider setup, OpenRouter model browser, onboarding, and per-use secret resolution (PR #104/#105).
+- M6: asset-rights manifest, dark/light theme, accessibility, landscape, and RTL readiness (PR #107/#108).
+- M7: JVM harness, privacy/egress/backup audit, and the pinned M2-fixture emulator journey (PR #110/#113/#115).
+- M8: version `0.1.0`/`versionCode 1000`, release signing configuration, R8 release build proof, usefulness/error harnesses, dependency snapshot, and CI aggregation (PR #116/#117).
+
+## Release Deferral
+
+The owner deferred the public release because no official release signing keystore is provisioned. The repository contains only the signing configuration and a developer test-keystore generator. Without `PERSONASPEAK_RELEASE_KEYSTORE` and its password/alias environment variables, `:ime:app:assembleRelease` produces an unsigned APK. Do not tag a developer or unsigned build as `v0.1.0`.
+
+The CI merge gate is active: GitHub ruleset `main required CI` (id `21630771`) requires strict, up-to-date success for `PATCHNOTES.md touched`, `Validate personas & smoke-test CLI`, `M2 device qualification suite`, and `Milestone 2 gate`. Issues #15 and #16 are closed with API receipts.
+
+## Resume Release
+
+1. Provision the official keystore outside the repository and set `PERSONASPEAK_RELEASE_KEYSTORE`, `PERSONASPEAK_RELEASE_KEYSTORE_PASSWORD`, `PERSONASPEAK_RELEASE_KEY_ALIAS`, and `PERSONASPEAK_RELEASE_KEY_PASSWORD` locally or in protected CI secrets. Never put values in chat, git, issues, screenshots, or receipts.
+2. Build `cd android && ./gradlew :ime:app:assembleRelease` from current `main` with those variables.
+3. Verify the signed APK and record its SHA-256 certificate fingerprint with `apksigner verify --print-certs <apk>`.
+4. Attach the signed APK and provenance to a GitHub release, then create annotated immutable tag `v0.1.0` at the reviewed `main` head. The required CI checks must be green on that exact head.
+5. Reopen/close issue #114 only to record the final release artifact, tag, and fingerprint. Update `ROADMAP.md` M8 to complete only after step 4.
+
+## Carry-Forwards
+
+- `personaspeak-proto/` stays on disk as owner-requested reference only; it is not a merge base.
+- M4 live credential/device gates remain deferred, not satisfied. Revisit requires explicit owner approval and a new reviewed scope.
+- If release copy changes, retain ADR-0009's accurate OpenRouter proxy disclosure: prompts transit OpenRouter before its downstream provider.


### PR DESCRIPTION
Records the owner-approved public release deferral after M8.

- Adds root handoff.md: exact signed-release resume sequence; current main head; required-CI ruleset; M4 deferral; proto reference status.
- Aligns ROADMAP, README, M8 plan/evidence, and PATCHNOTES with reality: feature-complete release candidate, no official signing keystore, therefore no signed APK / immutable v0.1.0 tag / GitHub release.
- GitHub tracking already updated: #114 reopened as the release artifact/tag tracker; #38 status comment; #15/#16 closed after ruleset API verification.

No production code or ASK tree touched. git diff --check passes. Reviewer: any non-author; exact-head docs accuracy only.