### PR TITLE
fix(m2): device-journey harness version pins to the v0.1.0/1000 identity

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -8,6 +8,10 @@ while the context is hot.
 
 Newest first, like all respectable patch notes.
 
+## 2026-09-02 — The Journey Harness Meets the New Name on the Door
+
+- The M2 device-journey harness still expected the vendored keyboard's versionName 1.13.1 (and a versionCode of 1 that passed only as a substring of 1000); every qualification run since the Milestone 8 v0.1.0/1000 identity failed at install. Pins updated to 0.1.0/1000 — the harness now checks the package the app actually ships as. 74/74 harness unit tests green.
+
 ## 2026-08-27 — The Name on the Door: App and IME rebranded to PersonaSpeak
 
 - Rebranded the application label and system IME display name from AnySoftKeyboard defaults to PersonaSpeak:

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -124,9 +124,11 @@ KEYEVENT_BACK = "4"
 KEYEVENT_DEL = "67"
 
 # Package identity as the device reports it (2026-08-19 capability probe on
-# the pinned fixture; versionName is the vendored keyboard's own numbering).
-EXPECTED_VERSION_NAME = "1.13.1"
-EXPECTED_VERSION_CODE = "1"
+# the pinned fixture; version identity is PersonaSpeak's own numbering since
+# the Milestone 8 release identity — v0.1.0/1000 — replacing the vendored
+# keyboard's 1.13.1/1, which every post-M8 run would otherwise fail on).
+EXPECTED_VERSION_NAME = "0.1.0"
+EXPECTED_VERSION_CODE = "1000"
 # On-device PackageSignatures digest of the canonical APK's signing
 # cert, as dumpsys prints it. Corroboration only: this is a 32-bit
 # Signature.hashCode, not a cryptographic digest, so it can never be

--- a/android/scripts/tests/m2_device/fixtures/bin/adb
+++ b/android/scripts/tests/m2_device/fixtures/bin/adb
@@ -486,8 +486,8 @@ elif "install" in cmd and "pull" not in cmd:
     if os.environ.get("FAKE_ADB_INSTALL_FAIL"):
         sys.exit(1)
 elif "dumpsys package" in cmd and "personaspeak" in cmd:
-    print("versionName=1.13.1")
-    print("versionCode=1")
+    print("versionName=0.1.0")
+    print("versionCode=1000")
     print("signatures=PackageSignatures{c441f2a version:2, signatures:[847f3baa], past signatures:[]}")
 elif "wait-for-device" in cmd:
     pass


### PR DESCRIPTION
## What

One bug, one fix: `android/scripts/m2_device/adb_harness.py` pinned the package identity the install step verifies to the vendored keyboard's `versionName 1.13.1` / `versionCode 1`. Milestone 8 (PR #116) moved the app to the PersonaSpeak release identity **v0.1.0 / 1000**, and every device-journey capture since has failed at `install_apk` with `versionName mismatch: expected 1.13.1` — reproduced twice today on `feat/florisboard-host`'s head (runs `20260902T154337Z` preflight tool gap, `20260902T154539Z` this failure), and the same constants fail identically on current `main`. This is pre-existing main breakage, surfaced because the FlorisBoard PR (#122) has to re-run the ASK-host journey per ADR-0010's readiness bar.

The old `versionCode=1` pin had been passing **only as a substring of `versionCode=1000`** — pinned to the real value now rather than the accident.

## Evidence

- `python3 -m unittest android.scripts.tests.m2_device.test_adb_harness -v` → **74/74 OK** on this branch (fixtures import the constants, so the tests follow the change).
- Full battery on the branch that surfaced it (feat/florisboard-host @ 0a0a4c1): m2_device suite **361/361**, `:ime:app:testDebugUnitTest` **1269/1269**, `:personaspeak-ime:testDebugUnitTest` **39/39**, closure/ledger/single-APK verifiers ✓.
- The follow-up ASK-host journey re-run on the fixed harness lands on PR #122 with its receipt.

## Loud skip

**Non-author review skipped: no non-author agent available at execution time (owner AFK, single-agent run). Owner review pending.**

## Patchnote

PATCHNOTES.md updated ("The Journey Harness Meets the New Name on the Door").