### PR TITLE
feat(floris): verify-floris-host.sh structural gate + contract test (ADR-0010)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
           for suite in verify-ask-closure-test verify-dictionary-licenses-test \
                        verify-upstream-ledger-test verify-single-apk-test \
                        verify-unified-build-flag-test verify-no-secret-logging-test \
+                       verify-floris-host-test \
                        verify-milestone-2-test verify-milestone-4-test \
                        verify-milestone-7-test verify-milestone-8-test; do
             echo "::group::$suite"

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -12,6 +12,10 @@ Newest first, like all respectable patch notes.
 
 - The FlorisBoard second-host decision is now Accepted (was Proposed): PR #122 merged with all five CI gates green — including the new `floris-host-build` job, which compiles four ABIs of Rust on every ready PR — the ASK-host device journey re-run 145/145 green on the branch head, and the structural gate (`verify-floris-host.sh`) following in the stack. The evaluation itself (promote, keep, or delete by 2026-12-01) remains governed by the addendum; the furniture is just no longer provisional.
 
+## 2026-09-02 — The Guest Wing Gets a Checklist
+
+- New `verify-floris-host.sh` gate pins the FlorisBoard second host's structural contract: provenance tag/commit recorded, every rent-ledger line names a real file, PersonaSpeak code stays inside its two recorded locations, the two Gradle roots stay isolated (six first-party modules mapped in, build dirs redirected, nothing floris in the unified root), and the property-less build keeps the pristine upstream applicationId. Nine-case contract test rides along, wired into CI's verifier fixture suite. The guest wing now has a smoke alarm, not just a heater.
+
 ## 2026-09-01 — The Other Keyboard Moved In (Guest Wing, Not Master Bedroom)
 
 - Vendored FlorisBoard v0.5.2 as a second, evaluation IME host under `android/florisboard/` (ADR-0010): its own Gradle root, its own rent ledger, one `./gradlew` away from an installable APK. The ASK host remains the default and the only release path — suggestions still live only on one of the two.

--- a/android/scripts/tests/verify-floris-host-test.sh
+++ b/android/scripts/tests/verify-floris-host-test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Contract test for verify-floris-host.sh.
+#
+# Drives the verifier against fixture trees through its documented
+# FLORIS_ROOT / UNIFIED_SETTINGS test seams:
+#   1. a contract-clean fixture must be accepted (exit 0);
+#   2. each ADR-0010 invariant, broken one at a time, must be rejected
+#      with its named finding: provenance pin drift, stale rent ledger
+#      entry, stray PersonaSpeak file outside the recorded locations,
+#      missing first-party module mapping, florisboard leakage into the
+#      unified root, lost pristine applicationId default, missing ledger.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+verifier="$script_dir/../verify-floris-host.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+failures=0
+check() { # check <description> <expect-pass|expect-fail> <output> <rc> <must-contain>
+  local desc="$1" want="$2" out="$3" rc="$4" needle="$5"
+  if [ "$want" = pass ] && [ "$rc" -ne 0 ]; then
+    echo "FAIL: $desc — expected acceptance, got rc=$rc" >&2
+    failures=$((failures + 1)); return
+  fi
+  if [ "$want" = fail ] && [ "$rc" -eq 0 ]; then
+    echo "FAIL: $desc — expected rejection, verifier accepted the fixture" >&2
+    failures=$((failures + 1)); return
+  fi
+  if [ "$want" = fail ] && ! grep -qF "$needle" <<<"$out"; then
+    echo "FAIL: $desc — rejection lacked '$needle'; got: $out" >&2
+    failures=$((failures + 1)); return
+  fi
+  echo "PASS: $desc"
+}
+
+# build_fixture <dir>: a contract-clean minimal floris tree + unified root.
+build_fixture() {
+  local dir="$1"
+  rm -rf "$dir"
+  mkdir -p "$dir/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/floris" \
+           "$dir/app/src/main/res/xml"
+
+  cat > "$dir/UPSTREAM.md" <<'EOF'
+# FlorisBoard vendored snapshot provenance
+- Upstream: https://github.com/florisboard/florisboard
+- Tag: `v0.5.2`
+- Commit: `2e82060251897226c0739b9f52d1d051b02305fb`
+- Upstream license: Apache-2.0
+- Vendored: 2026-09-01
+EOF
+
+  cat > "$dir/UPSTREAM-MODIFIED.md" <<'EOF'
+# FlorisBoard upstream-modification ledger
+
+Format:
+```text
+- <path-from-android/florisboard> — <reason for the current modification>
+```
+
+## Files modified against pristine
+
+- settings.gradle.kts — include mapping (replay recorded).
+EOF
+  touch "$dir/settings.gradle.kts"
+
+  cat > "$dir/settings.gradle.kts" <<'EOF'
+include(":app")
+EOF
+  local module
+  for module in core-personas core-providers personaspeak-ui \
+                personaspeak-data personaspeak-providers personaspeak-ime; do
+    echo "personaspeakProject(\":$module\", \"$module\")" >> "$dir/settings.gradle.kts"
+  done
+
+  cat > "$dir/build.gradle.kts" <<'EOF'
+allprojects {
+  if (name.startsWith("personaspeak")) buildDir = file("build/personaspeak-build/\$name")
+}
+EOF
+
+  cat > "$dir/app/build.gradle.kts" <<'EOF'
+applicationId = (findProperty("personaspeakFlorisAppId") as String?)
+    ?: "dev.patrickgold.florisboard"
+EOF
+
+  echo "package biz.pixelperfectstudios.personaspeak.floris" \
+    > "$dir/app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/floris/Host.kt"
+  touch "$dir/app/src/main/res/xml/personaspeak_host_data_extraction_rules.xml"
+}
+
+unified="$tmp/settings.gradle.kts"
+echo 'include(":keyboard:ime:app")' > "$unified"
+
+run_case() { # run_case <floris-dir> -> stdout+stderr; exits with verifier rc
+  FLORIS_ROOT="$1" UNIFIED_SETTINGS="$unified" \
+    bash "$verifier" "$tmp" 2>&1
+}
+
+# 1. Contract-clean fixture accepted.
+good="$tmp/good"
+build_fixture "$good"
+rc=0; out="$(run_case "$good")" || rc=$?
+check "contract-clean floris tree accepted" pass "$out" "$rc" ""
+
+# 2. Provenance pin drift.
+pin="$tmp/pin"
+build_fixture "$pin"
+sed -i.bak 's/- Tag: `v0\.5\.2`/- Tag: `v0.6.0`/' "$pin/UPSTREAM.md"
+rc=0; out="$(run_case "$pin")" || rc=$?
+check "provenance tag drift rejected" fail "$out" "$rc" "does not pin tag v0.5.2"
+
+# 3. Stale ledger entry.
+stale="$tmp/stale"
+build_fixture "$stale"
+echo '- vanished/file.kt — removed upstream.' >> "$stale/UPSTREAM-MODIFIED.md"
+rc=0; out="$(run_case "$stale")" || rc=$?
+check "stale ledger entry rejected" fail "$out" "$rc" "stale ledger entry: vanished/file.kt"
+
+# 4. Ledger missing.
+noledger="$tmp/noledger"
+build_fixture "$noledger"
+rm "$noledger/UPSTREAM-MODIFIED.md"
+rc=0; out="$(run_case "$noledger")" || rc=$?
+check "missing ledger rejected" fail "$out" "$rc" "missing file: "
+
+# 5. Stray PersonaSpeak file outside the recorded locations.
+stray="$tmp/stray"
+build_fixture "$stray"
+mkdir -p "$stray/lib/kotlin/dev/patrickgold/florisboard/personaspeak"
+echo "package dev.patrickgold.florisboard.personaspeak" \
+  > "$stray/lib/kotlin/dev/patrickgold/florisboard/personaspeak/Leak.kt"
+rc=0; out="$(run_case "$stray")" || rc=$?
+check "stray personaspeak file rejected" fail "$out" "$rc" \
+  "PersonaSpeak files outside the recorded first-party locations"
+
+# 6. Missing first-party module mapping.
+nomap="$tmp/nomap"
+build_fixture "$nomap"
+sed -i.bak '/personaspeakProject(":personaspeak-ime"/d' "$nomap/settings.gradle.kts"
+rc=0; out="$(run_case "$nomap")" || rc=$?
+check "missing module mapping rejected" fail "$out" "$rc" \
+  "does not map ../personaspeak-ime"
+
+# 7. Build-dir redirection lost.
+nodivert="$tmp/nodivert"
+build_fixture "$nodivert"
+sed -i.bak 's/personaspeak-build/elsewhere/' "$nodivert/build.gradle.kts"
+rc=0; out="$(run_case "$nodivert")" || rc=$?
+check "build-dir redirection loss rejected" fail "$out" "$rc" \
+  "does not redirect first-party build dirs"
+
+# 8. florisboard leakage into the unified root.
+leak="$tmp/leak"
+build_fixture "$leak"
+echo 'include(":florisboard:app")' > "$unified"
+rc=0; out="$(run_case "$leak")" || rc=$?
+check "unified-root leakage rejected" fail "$out" "$rc" \
+  "unified root settings.gradle includes a florisboard project"
+echo 'include(":keyboard:ime:app")' > "$unified"
+
+# 9. Lost pristine identity default.
+identity="$tmp/identity"
+build_fixture "$identity"
+sed -i.bak 's/dev\.patrickgold\.florisboard/com.example.other/' "$identity/app/build.gradle.kts"
+rc=0; out="$(run_case "$identity")" || rc=$?
+check "lost pristine applicationId default rejected" fail "$out" "$rc" \
+  "pristine upstream applicationId default"
+
+if [ "$failures" -ne 0 ]; then
+  echo "verify-floris-host-test: $failures case(s) failed" >&2
+  exit 1
+fi
+echo "verify-floris-host-test: all contract cases passed"

--- a/android/scripts/verify-floris-host.sh
+++ b/android/scripts/verify-floris-host.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Verify the structural contract of the FlorisBoard second host (ADR-0010).
+#
+# usage: verify-floris-host.sh <android-root>
+#
+# The ASK tree has verify-upstream-ledger.sh (pristine-diff reconstruction,
+# scoped to keyboard/); the FlorisBoard host gets this verifier instead.
+# Its job is the invariants ADR-0010 promises, checked read-only:
+#
+#   1. Provenance: florisboard/UPSTREAM.md records the pinned source
+#      (tag v0.5.2, commit 2e82060251897226c0739b9f52d1d051b02305fb,
+#      Apache-2.0) — the snapshot is attributable or the gate fails.
+#   2. Rent ledger: florisboard/UPSTREAM-MODIFIED.md exists, every
+#      `- <path> — <reason>` bullet names exactly one existing file under
+#      the vendored tree (a ledger line for a vanished file is stale rent),
+#      and no path is ledgered twice.
+#   3. Separation: PersonaSpeak-owned source inside the vendored tree
+#      lives only under the recorded first-party locations (the
+#      biz.pixelperfectstudios.personaspeak package under app/src/main and
+#      the personaspeak_host_* backup rules). A stray PersonaSpeak file
+#      anywhere else in the vendored tree is unbounded rent.
+#   4. Two-root isolation: the floris Gradle root maps the six first-party
+#      modules from ../ (settings.gradle.kts) and redirects their build
+#      directories under its own build/ (build.gradle.kts), and the
+#      unified root (settings.gradle) includes no florisboard project.
+#   5. Identity guard: app/build.gradle.kts reads applicationId from the
+#      personaspeakFlorisAppId property with the pristine upstream default
+#      (dev.patrickgold.florisboard) — a property-less build must stay
+#      pristine-identical in identity.
+#
+# Test seams: FLORIS_ROOT overrides the vendored tree, UNIFIED_SETTINGS the
+# unified root's settings.gradle, so the contract test can drive fixture
+# trees without touching the real ones.
+#
+# Exit codes: 0 pass; 1 contract violation; 2 usage or tool failure.
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: verify-floris-host.sh <android-root>" >&2
+  exit 2
+fi
+root="$1"
+if [ ! -d "$root" ]; then
+  echo "verify-floris-host: not a directory: $root" >&2
+  exit 2
+fi
+root="$(cd "$root" && pwd)"
+floris="${FLORIS_ROOT:-$root/florisboard}"
+unified_settings="${UNIFIED_SETTINGS:-$root/settings.gradle.kts}"
+
+fail=0
+violation() {
+  echo "verify-floris-host: $1" >&2
+  fail=1
+}
+need_file() {
+  if [ ! -f "$1" ]; then
+    violation "missing file: ${1#"$root"/}"
+    return 1
+  fi
+  return 0
+}
+
+# grep seam: 0 match, 1 no-match, 2+ tool failure — never silently pass.
+grep_probes() {
+  local pattern="$1" file="$2" what="$3"
+  local rc=0
+  grep -qE "$pattern" "$file" 2>/dev/null || rc=$?
+  if [ "$rc" -ge 2 ]; then
+    echo "verify-floris-host: grep failed on ${file#"$root"/}" >&2
+    exit 2
+  fi
+  if [ "$rc" -eq 1 ]; then
+    violation "$what"
+  fi
+}
+
+if [ ! -d "$floris" ]; then
+  echo "verify-floris-host: not a directory: $floris" >&2
+  exit 2
+fi
+
+# --- 1. Provenance ---------------------------------------------------------
+if need_file "$floris/UPSTREAM.md"; then
+  grep_probes '^- Tag: `v0\.5\.2`$' "$floris/UPSTREAM.md" \
+    "UPSTREAM.md does not pin tag v0.5.2"
+  grep_probes '^- Commit: `2e82060251897226c0739b9f52d1d051b02305fb`$' \
+    "$floris/UPSTREAM.md" "UPSTREAM.md does not pin commit 2e82060"
+  grep_probes 'Apache-2\.0' "$floris/UPSTREAM.md" \
+    "UPSTREAM.md does not record the Apache-2.0 upstream license"
+fi
+
+# --- 2. Rent ledger --------------------------------------------------------
+ledger="$floris/UPSTREAM-MODIFIED.md"
+if need_file "$ledger"; then
+  # Bullets look like: "- <path> — <reason>" (em dash, per the file's own
+  # format note). The fenced example block inside the note uses a
+  # placeholder path in angle brackets — not a real entry — so bullets
+  # with '<' are skipped. Ledgered paths must exist exactly once.
+  entries="$(grep -E '^- [^ ]+ — ' "$ledger" 2>/dev/null | sed -E 's/^- ([^ ]+) — .*/\1/' | grep -v '<' || true)"
+  if [ -z "$entries" ]; then
+    violation "UPSTREAM-MODIFIED.md records no ledgered files"
+  fi
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    if [ ! -f "$floris/$path" ]; then
+      violation "stale ledger entry: $path does not exist in the vendored tree"
+    fi
+  done <<< "$entries"
+  dupes="$(printf '%s\n' "$entries" | sort | uniq -d)"
+  if [ -n "$dupes" ]; then
+    violation "duplicate ledger entries: $(echo "$dupes" | tr '\n' ' ')"
+  fi
+fi
+
+# --- 3. Separation ---------------------------------------------------------
+# PersonaSpeak-owned files inside the vendored tree: our Kotlin package
+# under app/src/main and our merged backup rules. Anything else with a
+# personaspeak identity is scattered rent. The find runs RELATIVE to the
+# vendored root on purpose: an absolute -path pattern would also match
+# the checkout directory's own name (it contains "personaspeak" both in
+# this worktree and on a standard GitHub runner).
+stray="$(cd "$floris" && find . -type f \( -name '*.kt' -o -name '*.java' -o -name '*.xml' \) \
+  -path '*personaspeak*' \
+  -not -path './app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/*' \
+  -not -path './app/src/main/res/xml/personaspeak_host_*' \
+  -not -path '*/build/*' -print 2>/dev/null || true)"
+if [ -n "$stray" ]; then
+  violation "PersonaSpeak files outside the recorded first-party locations:
+$stray"
+fi
+
+# --- 4. Two-root isolation -------------------------------------------------
+if need_file "$floris/settings.gradle.kts"; then
+  for module in core-personas core-providers personaspeak-ui \
+                personaspeak-data personaspeak-providers personaspeak-ime; do
+    mapping="personaspeakProject(\":$module\", \"$module\")"
+    if ! grep -qF "$mapping" "$floris/settings.gradle.kts" 2>/dev/null; then
+      violation "settings.gradle.kts does not map ../$module into the floris root (expected: $mapping)"
+    fi
+  done
+fi
+if need_file "$floris/build.gradle.kts"; then
+  grep_probes 'personaspeak-build' "$floris/build.gradle.kts" \
+    "build.gradle.kts does not redirect first-party build dirs under personaspeak-build/"
+fi
+if [ -f "$unified_settings" ]; then
+  if grep -n "florisboard" "$unified_settings" 2>/dev/null; then
+    violation "unified root settings.gradle includes a florisboard project — the two roots must stay separate"
+  fi
+else
+  echo "verify-floris-host: missing file: ${unified_settings#"$root"/}" >&2
+  fail=1
+fi
+
+# --- 5. Identity guard -----------------------------------------------------
+if need_file "$floris/app/build.gradle.kts"; then
+  grep_probes 'personaspeakFlorisAppId' "$floris/app/build.gradle.kts" \
+    "app/build.gradle.kts does not read the personaspeakFlorisAppId property"
+  grep_probes 'dev\.patrickgold\.florisboard' "$floris/app/build.gradle.kts" \
+    "app/build.gradle.kts lost the pristine upstream applicationId default"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+echo "floris host contract verified: provenance pinned, rent ledgered and present, first-party code separated, roots isolated, identity default pristine"


### PR DESCRIPTION
## Stack position

**P1 of the FlorisBoard follow-up stack** — parent PR #122 merged 2026-09-02; this branch was rebased onto main before #122 merged and its contents are unchanged. Now the stack head against main. One concern: the structural gate for the vendored tree.

## What

`verify-floris-host.sh <android-root>` — the FlorisBoard-tree counterpart of the ASK tree's `verify-upstream-ledger.sh` scope (which covers `keyboard/` only). Read-only, fail-closed, exit 0/1/2, five invariant groups per ADR-0010:

1. **Provenance** — `UPSTREAM.md` pins tag `v0.5.2`, commit `2e82060…`, Apache-2.0.
2. **Rent ledger** — every `- <path> — <reason>` bullet names an existing file, exactly once; the format-note's fenced placeholder is not an entry.
3. **Separation** — PersonaSpeak files exist only under `app/src/main/kotlin/biz/pixelperfectstudios/personaspeak/` and `personaspeak_host_*` rules. The scan runs **relative to the vendored root**: an absolute `-path '*personaspeak*'` would also match the checkout directory's own name (true both in worktrees and on a standard GitHub runner).
4. **Two-root isolation** — the six first-party modules mapped via `personaspeakProject(…)` from `../`, their build dirs redirected under `build/personaspeak-build/`, and the unified root's `settings.gradle.kts` mentions no florisboard project.
5. **Identity guard** — `personaspeakFlorisAppId` property read with the pristine `dev.patrickgold.florisboard` default intact.

## Evidence

- Real tree: `bash android/scripts/verify-floris-host.sh android` → **verified** (all five groups).
- Contract test `verify-floris-host-test.sh`: **9/9 cases** — clean fixture accepted; tag drift, stale ledger entry, missing ledger, stray personaspeak file, missing module mapping, lost build-dir redirection, unified-root leakage, and lost identity default each rejected with the named finding. Driven through the documented `FLORIS_ROOT` / `UNIFIED_SETTINGS` seams.
- Wired into the android-build job's Verifier fixture suites loop in `.github/workflows/ci.yml` (runs in CI once this stack lands on main; runs for this PR only after retarget, since drafts take the cheap gates).
- Full verifier contract battery on the branch: 10/10 existing suites + this one green.

## Loud skip

**Non-author review skipped: no non-author agent available at execution time (owner AFK, single-agent run). Owner review pending.**

## Patchnote

PATCHNOTES.md — "The Guest Wing Gets a Checklist."