### PR TITLE
feat(floris): device journey harness + ADR-0003 composing instrumentation (P2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,13 @@ jobs:
       - name: Milestone 8 verification gate
         shell: bash
         run: bash android/scripts/verify-milestone-8.sh android
+      # ADR-0003's real-InputConnection composing tests run on a device
+      # (evidence job, no emulator here), but they must never stop
+      # compiling — this step builds the instrumentation APK so drift
+      # is a red CI step, not a surprise during the next journey.
+      - name: Build the real-InputConnection instrumentation APK
+        working-directory: android
+        run: ./gradlew :personaspeak-ime:assembleDebugAndroidTest --console=plain
       - name: Canonical APK identity
         shell: bash
         run: |

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -8,6 +8,13 @@ while the context is hot.
 
 Newest first, like all respectable patch notes.
 
+## 2026-09-03 — The Guest Wing Gets Its Own Driving Test
+
+- The M2 device-journey machinery now runs the FlorisBoard host end to end: `--host floris` on the capture CLI drives a six-session journey (idle/cancel, review/apply, dismiss, stale, composing, settings surface) against the same pinned fixture, the same signer gate, and the same restore obligations as the ASK journey — 376/376 fake-toolchain suite green, every tap pin effect-verified on the fixture. The second host no longer qualifies by anecdote.
+- The composing-text regression now has on-device teeth per ADR-0003: a real-InputConnection instrumentation test in `:personaspeak-ime` builds a live composing span on a real editor and proves the replace consumes it whole (2/2 green on the fixture, both the API-34 `replaceText` path and the legacy one), plus a journey leg that types the draft without its final period through real Floris keys. The pre-fix failure shape is a fake-toolchain knob, so the catch itself is tested.
+- Calibration found a real bug on the way in (#131): the Floris host paints its review card ~300px above where the card's buttons actually respond — the P0 proof verified through the accessibility dump, which reports layout positions, so the desync was invisible to it. The journey drives the working layout positions and documents the trap; the fix moves the pins.
+- CI builds the instrumentation APK on every ready PR so the ADR-0003 tests can't silently stop compiling.
+
 ## 2026-09-03 — ADR-0010: Accepted
 
 - The FlorisBoard second-host decision is now Accepted (was Proposed): PR #122 merged with all five CI gates green — including the new `floris-host-build` job, which compiles four ABIs of Rust on every ready PR — the ASK-host device journey re-run 145/145 green on the branch head, and the structural gate (`verify-floris-host.sh`) following in the stack. The evaluation itself (promote, keep, or delete by 2026-12-01) remains governed by the addendum; the furniture is just no longer provisional.

--- a/android/florisboard/gradle/libs.versions.toml
+++ b/android/florisboard/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ personaspeak-android-lifecycle = "2.9.0"
 personaspeak-androidx-annotation = "1.9.1"
 personaspeak-androidx-datastore = "1.1.7"
 personaspeak-androidx-test-core = "1.7.0"
+personaspeak-androidx-test-runner = "1.7.0"
 personaspeak-junit = "4.13.2"
 personaspeak-robolectric = "4.16.1"
 personaspeak-snakeyaml = "2.3"
@@ -103,6 +104,7 @@ coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", ve
 datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "personaspeak-androidx-datastore" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "personaspeak-androidx-annotation" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "personaspeak-androidx-test-core" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "personaspeak-androidx-test-runner" }
 junit = { group = "junit", name = "junit", version.ref = "personaspeak-junit" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "personaspeak-android-lifecycle" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ androidxViewpager2 = "1.1.0"
 androidxTestCore = "1.7.0"
 androidxTestCoreOld = "1.7.0"
 androidxTestJunit = "1.3.0"
+androidxTestRunner = "1.7.0"
 androidxFragmentTesting = "1.8.9"
 
 # Google Libraries
@@ -121,6 +122,7 @@ androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref =
 
 # AndroidX Testing
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
 androidx-test-core-old = { module = "androidx.test:core", version.ref = "androidxTestCoreOld" }
 androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestJunit" }
 androidx-fragment-testing = { module = "androidx.fragment:fragment-testing", version.ref = "androidxFragmentTesting" }

--- a/android/personaspeak-ime/build.gradle.kts
+++ b/android/personaspeak-ime/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 
     defaultConfig {
         minSdk = 26
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
@@ -47,4 +48,10 @@ dependencies {
     // installation path.
     testImplementation(platform(libs.compose.bom))
     testImplementation(libs.compose.ui)
+
+    // ADR-0003: the capture -> transform -> replace path needs a
+    // real-InputConnection test, not just unit tests against fakes.
+    androidTestImplementation(libs.kotlin.test)
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.androidx.test.runner)
 }

--- a/android/personaspeak-ime/src/androidTest/AndroidManifest.xml
+++ b/android/personaspeak-ime/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Instrumentation-only surface for the ADR-0003 real-InputConnection
+     tests. Never merged into any host app. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name="biz.pixelperfectstudios.personaspeak.ime.testing.ComposingTestActivity"
+            android:exported="false"
+            android:label="PersonaSpeak composing instrumentation" />
+    </application>
+</manifest>

--- a/android/personaspeak-ime/src/androidTest/kotlin/biz/pixelperfectstudios/personaspeak/ime/editor/RealInputConnectionComposingTest.kt
+++ b/android/personaspeak-ime/src/androidTest/kotlin/biz/pixelperfectstudios/personaspeak/ime/editor/RealInputConnectionComposingTest.kt
@@ -1,0 +1,101 @@
+package biz.pixelperfectstudios.personaspeak.ime.editor
+
+import android.content.Intent
+import android.text.InputType
+import android.text.Spanned
+import android.view.inputmethod.EditorInfo
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import biz.pixelperfectstudios.personaspeak.ime.testing.ComposingTestActivity
+import biz.pixelperfectstudios.personaspeak.ui.editor.CaptureResult
+import biz.pixelperfectstudios.personaspeak.ui.editor.ReplaceResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * ADR-0003's suite requirement: the capture -> transform -> replace path
+ * gets a real-InputConnection test, not only unit tests against fakes.
+ * The fork spike found every worker's pure-logic tests green while the
+ * on-device runs failed: a draft ending in a live composing span survived
+ * the replace because commitText prefers the composing region over the
+ * selection. Fakes cannot see that; a real EditText with a real
+ * composing span can.
+ */
+class RealInputConnectionComposingTest {
+
+    private val candidate = "I have taken the liberty, sir, of rephrasing your words."
+
+    private fun composingSpanCount(text: Spanned): Int =
+        text.getSpans(0, text.length, Any::class.java).count {
+            (text.getSpanFlags(it) and Spanned.SPAN_COMPOSING) != 0
+        }
+
+    /** One full replace pass on the main thread over a real editor whose
+     *  trailing word sits in a live composing span. Returns the final
+     *  buffer text, the composing-span count after the replace, and the
+     *  port's verdict. */
+    private fun replaceOverLiveComposingSpan(
+        sdkIntSupplier: () -> Int,
+    ): Triple<String, Int, ReplaceResult> {
+        val intent = Intent(
+            ApplicationProvider.getApplicationContext(), ComposingTestActivity::class.java)
+        ActivityScenario.launch<ComposingTestActivity>(intent).use { scenario ->
+            lateinit var outcome: Triple<String, Int, ReplaceResult>
+            scenario.onActivity { activity ->
+                val editor = activity.editor
+                editor.inputType = InputType.TYPE_CLASS_TEXT
+                val info = EditorInfo()
+                val connection = editor.onCreateInputConnection(info)
+                checkNotNull(connection) { "editor returned no InputConnection" }
+
+                connection.commitText("Tea at ", 1)
+                connection.setComposingText("six", 1)
+
+                // The precondition the unit fakes cannot model: a live
+                // composing span inside a real editor's buffer.
+                assertEquals("Tea at six", editor.text.toString())
+                assertTrue(composingSpanCount(editor.text) > 0, "expected a live composing span")
+
+                val state = EditorSessionState()
+                state.start(info)
+                val port = InputConnectionEditorPort(
+                    state,
+                    connectionSupplier = { connection },
+                    editorInfoSupplier = { info },
+                    sdkIntSupplier = sdkIntSupplier,
+                )
+                outcome = runBlocking {
+                    val snapshot = assertIs<CaptureResult.Captured>(
+                        port.captureSnapshot()).snapshot
+                    assertEquals("Tea at six", snapshot.draft)
+                    val verdict = port.attemptReplace(snapshot, candidate)
+                    Triple(
+                        editor.text.toString(),
+                        composingSpanCount(editor.text),
+                        verdict,
+                    )
+                }
+            }
+            return outcome
+        }
+    }
+
+    @Test
+    fun replaceOverLiveComposingSpanReplacesWholeDraft_Api34Path() {
+        val (finalText, spanCount, verdict) = replaceOverLiveComposingSpan(sdkIntSupplier = { 34 })
+        assertIs<ReplaceResult.AppliedVerified>(verdict)
+        assertEquals(candidate, finalText)
+        assertEquals(0, spanCount, "a composing span survived the replace")
+    }
+
+    @Test
+    fun replaceOverLiveComposingSpanReplacesWholeDraft_LegacyPath() {
+        val (finalText, spanCount, verdict) = replaceOverLiveComposingSpan(sdkIntSupplier = { 33 })
+        assertIs<ReplaceResult.AppliedVerified>(verdict)
+        assertEquals(candidate, finalText)
+        assertEquals(0, spanCount, "a composing span survived the replace")
+    }
+}

--- a/android/personaspeak-ime/src/androidTest/kotlin/biz/pixelperfectstudios/personaspeak/ime/testing/ComposingTestActivity.kt
+++ b/android/personaspeak-ime/src/androidTest/kotlin/biz/pixelperfectstudios/personaspeak/ime/testing/ComposingTestActivity.kt
@@ -1,0 +1,26 @@
+package biz.pixelperfectstudios.personaspeak.ime.testing
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.LinearLayout
+
+/** Hosts the real editor the ADR-0003 instrumentation drives. */
+class ComposingTestActivity : Activity() {
+    lateinit var editor: EditText
+        private set
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        editor = EditText(this).apply {
+            layoutParams = LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+            )
+        }
+        val root = LinearLayout(this).apply { addView(editor) }
+        setContentView(root)
+        editor.requestFocus()
+    }
+}

--- a/android/scripts/m2_device/adb_harness.py
+++ b/android/scripts/m2_device/adb_harness.py
@@ -184,6 +184,23 @@ FIXTURE_FILES = {
 
 
 class AdbHarness:
+    # Host facts as overridable class attributes (defaults = the ASK
+    # host's module pins above, which stay authoritative for imports
+    # and the ASK golden argv sequence). The FlorisBoard second-host
+    # harness subclasses this and swaps exactly these; every shared
+    # phase then checks the second host's identity with the same code.
+    KEYBOARD_PACKAGE = KEYBOARD_PACKAGE
+    IME_COMPONENT = IME_COMPONENT
+    EXPECTED_VERSION_NAME = EXPECTED_VERSION_NAME
+    EXPECTED_VERSION_CODE = EXPECTED_VERSION_CODE
+    EXPECTED_SIGNER = EXPECTED_SIGNER
+    EXPECTED_SIGNER_CERT_SHA256 = EXPECTED_SIGNER_CERT_SHA256
+    KEY_COORDS = ASK_KEY_COORDS
+    SHIFT_TAP = SHIFT_TAP
+    IME_COMPACT_TOP = IME_COMPACT_TOP
+    IME_EXPANDED_MAX_TOP = IME_EXPANDED_MAX_TOP
+    SCREENSHOT_NAMES = SCREENSHOT_NAMES
+    HIERARCHY_LABELS = tuple(evidence.CANONICAL_HIERARCHY_LABELS)
 
     def __init__(
         self,
@@ -492,7 +509,7 @@ class AdbHarness:
             # error (the fake toolkit used to exit 0 here, hiding the
             # difference). rc=1 with output stays unknown state, which
             # must stop the run rather than guess.
-            pkg_res = self._shell("pm", "path", KEYBOARD_PACKAGE)
+            pkg_res = self._shell("pm", "path", self.KEYBOARD_PACKAGE)
             if pkg_res.remote_rc is None:
                 raise commands.RemoteAmbiguousError("pm path")
             pkg_out = pkg_res.transport.stdout.decode(
@@ -539,7 +556,7 @@ class AdbHarness:
         if prior.screen_width != SCREEN_WIDTH or prior.screen_height != SCREEN_HEIGHT:
             errors.append(f"screen size mismatch: got {prior.screen_width}x{prior.screen_height}")
         if prior.package_present:
-            errors.append(f"{KEYBOARD_PACKAGE} present before test")
+            errors.append(f"{self.KEYBOARD_PACKAGE} present before test")
 
         if prior.enabled_imes != EXPECTED_ENABLED_IMES:
             errors.append(f"IME list mismatch: got {prior.enabled_imes}")
@@ -616,7 +633,7 @@ class AdbHarness:
                 "install_apk", f"apksigner rc={certs.returncode}".encode())
         expected_line = (
             "Signer #1 certificate SHA-256 digest: "
-            f"{EXPECTED_SIGNER_CERT_SHA256}")
+            f"{self.EXPECTED_SIGNER_CERT_SHA256}")
         if expected_line not in certs.stdout.decode(
                 "utf-8", errors="replace").splitlines():
             return self._fail(
@@ -626,25 +643,25 @@ class AdbHarness:
         res = self._host("install", "-r", self.apk_path, timeout=120.0)
         if res.returncode != 0:
             return res
-        dump = self._shell("dumpsys", "package", KEYBOARD_PACKAGE)
+        dump = self._shell("dumpsys", "package", self.KEYBOARD_PACKAGE)
         if self._ambiguous(dump):
             return dump
         if self._rc_of(dump) != 0:
             return self._fail("install_apk", f"dumpsys rc={self._rc_of(dump)}".encode())
         out = dump.transport.stdout.decode("utf-8", errors="replace")
         errors = []
-        if f"versionName={EXPECTED_VERSION_NAME}" not in out:
-            errors.append(f"versionName mismatch: expected {EXPECTED_VERSION_NAME}")
-        if f"versionCode={EXPECTED_VERSION_CODE}" not in out:
-            errors.append(f"versionCode mismatch: expected {EXPECTED_VERSION_CODE}")
-        if EXPECTED_SIGNER not in out:
+        if f"versionName={self.EXPECTED_VERSION_NAME}" not in out:
+            errors.append(f"versionName mismatch: expected {self.EXPECTED_VERSION_NAME}")
+        if f"versionCode={self.EXPECTED_VERSION_CODE}" not in out:
+            errors.append(f"versionCode mismatch: expected {self.EXPECTED_VERSION_CODE}")
+        if self.EXPECTED_SIGNER not in out:
             errors.append("signer certificate mismatch")
         if errors:
             return self._fail("install_apk", "\n".join(errors).encode())
         return self._ok("install_apk", b"APK installed and identity verified.")
 
     def _dump_hierarchy(self, label: str) -> tuple[CommandResult, Any]:
-        if label not in evidence.CANONICAL_HIERARCHY_LABELS:
+        if label not in self.HIERARCHY_LABELS:
             # The code cannot express a non-canonical hierarchy name.
             raise RuntimeError(
                 f"hierarchy label {label!r} is not in the canonical set")
@@ -707,11 +724,11 @@ class AdbHarness:
         return str(x), str(y)
 
     def _enable_ime(self, steps) -> bool:
-        res = self._shell("ime", "enable", IME_COMPONENT)
+        res = self._shell("ime", "enable", self.IME_COMPONENT)
         return self._step(steps, "enable_ime", res)
 
     def _set_ime(self, steps) -> bool:
-        res = self._shell("ime", "set", IME_COMPONENT)
+        res = self._shell("ime", "set", self.IME_COMPONENT)
         return self._step(steps, "set_ime", res)
 
     def _verify_binding(self, steps, tag: str) -> bool:
@@ -726,7 +743,7 @@ class AdbHarness:
         out = res.transport.stdout.decode("utf-8", errors="replace")
         m = re.search(r"mCurMethodId=(\S+)", out)
         errors = []
-        if m is None or m.group(1) != IME_COMPONENT:
+        if m is None or m.group(1) != self.IME_COMPONENT:
             errors.append(f"mCurMethodId: {m.group(1) if m else 'absent'}")
         for flag in ("mHaveConnection", "mBoundToMethod", "mVisibleBound"):
             if f"{flag}=true" not in out:
@@ -753,7 +770,7 @@ class AdbHarness:
             if "InputMethod}" not in block.split("\n", 1)[0]:
                 continue
             errors = []
-            if f"package={KEYBOARD_PACKAGE}" not in block:
+            if f"package={self.KEYBOARD_PACKAGE}" not in block:
                 errors.append("window not owned by personaspeak package")
             if "HAS_DRAWN" not in block:
                 errors.append("window not drawn")
@@ -799,11 +816,11 @@ class AdbHarness:
             return False
         top = frame[0]
         if expanded:
-            ok = top <= IME_EXPANDED_MAX_TOP
-            detail = f"frame top {top} never rose above {IME_EXPANDED_MAX_TOP}"
+            ok = top <= self.IME_EXPANDED_MAX_TOP
+            detail = f"frame top {top} never rose above {self.IME_EXPANDED_MAX_TOP}"
         else:
-            ok = top == IME_COMPACT_TOP
-            detail = f"frame top {top} != compact {IME_COMPACT_TOP}"
+            ok = top == self.IME_COMPACT_TOP
+            detail = f"frame top {top} != compact {self.IME_COMPACT_TOP}"
         if not ok:
             self._step(steps, f"verify_ime_window_{tag}",
                        self._fail("window", detail.encode()))
@@ -893,7 +910,7 @@ class AdbHarness:
 
     def _tap_ask_key(self, steps, ch):
         key = ch.upper() if ch.isalpha() else ch
-        coord = ASK_KEY_COORDS.get(key)
+        coord = self.KEY_COORDS.get(key)
         if coord is None:
             self._step(steps, f"tap_key_{ch}",
                        self._fail(f"tap_{ch}", f"no coord for {ch}".encode()))
@@ -910,7 +927,7 @@ class AdbHarness:
             if ch.isupper():
                 if not self._step(steps, "tap_key_shift",
                                   self._shell("input", "tap",
-                                              *map(str, SHIFT_TAP))):
+                                              *map(str, self.SHIFT_TAP))):
                     return False
             if not self._tap_ask_key(steps, ch):
                 return False
@@ -1132,7 +1149,7 @@ class AdbHarness:
                 if not evidence.validate_mp4(vfh.read()):
                     errors.append("journey.mp4 invalid")
 
-        for name in SCREENSHOT_NAMES:
+        for name in self.SCREENSHOT_NAMES:
             path = os.path.join(evidence_dir, f"{name}.png")
             if not os.path.isfile(path):
                 errors.append(f"missing screenshot: {name}.png")
@@ -1143,8 +1160,8 @@ class AdbHarness:
 
         pngs = sorted(f for f in os.listdir(evidence_dir) if f.endswith(".png"))
         mp4s = sorted(f for f in os.listdir(evidence_dir) if f.endswith(".mp4"))
-        if len(pngs) != len(SCREENSHOT_NAMES):
-            errors.append(f"expected {len(SCREENSHOT_NAMES)} PNGs, found {len(pngs)}")
+        if len(pngs) != len(self.SCREENSHOT_NAMES):
+            errors.append(f"expected {len(self.SCREENSHOT_NAMES)} PNGs, found {len(pngs)}")
         if len(mp4s) != 1:
             errors.append(f"expected 1 MP4, found {len(mp4s)}")
 

--- a/android/scripts/m2_device/cli.py
+++ b/android/scripts/m2_device/cli.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 
 from android.scripts.m2_device import evidence
 from android.scripts.m2_device.adb_harness import AdbHarness
+from android.scripts.m2_device.floris_harness import FlorisAdbHarness
 from android.scripts.m2_device.orchestrator import Orchestrator
 from android.scripts.m2_device.records import (
     ApprovalRecord,
@@ -21,6 +22,11 @@ from android.scripts.m2_device.records import (
     encode,
     record_digest,
 )
+
+_HOSTS = {
+    "ask": (AdbHarness, evidence.CANONICAL_ARTIFACTS),
+    "floris": (FlorisAdbHarness, evidence.FLORIS_CANONICAL_ARTIFACTS),
+}
 
 
 def _utc() -> str:
@@ -37,7 +43,8 @@ def cmd_capture(args: argparse.Namespace) -> int:
     if args.fixture_digests:
         with open(args.fixture_digests) as f:
             fixture_digests = json.load(f)
-    harness = AdbHarness(
+    harness_cls, canonical_artifacts = _HOSTS[args.host]
+    harness = harness_cls(
         run_dir=run_dir, apk_path=args.apk_path, repo_root=args.repo_root,
         fixture_root=args.fixture_root, fixture_digests=fixture_digests,
         headless=args.headless,
@@ -83,7 +90,7 @@ def cmd_capture(args: argparse.Namespace) -> int:
         print(f"qualification failed: {reason}", file=sys.stderr)
         return 1
     try:
-        evidence.enforce_canonical_set(manifest)
+        evidence.enforce_canonical_set(manifest, canonical_artifacts)
     except ValueError as e:
         print(f"qualification failed: {e}", file=sys.stderr)
         return 1
@@ -125,6 +132,7 @@ def cmd_finalize(args: argparse.Namespace) -> int:
     receipt = evidence.finalize(
         capture, approval, manifest, evidence_subdir,
         evidence_commit=args.evidence_commit,
+        canonical_artifacts=_HOSTS[args.host][1],
     )
     out = encode(receipt)
     if args.output:
@@ -170,6 +178,9 @@ def build_parser() -> argparse.ArgumentParser:
     cap.add_argument("--repo-root", required=True)
     cap.add_argument("--apk-path", required=True)
     cap.add_argument("--apk-sha256", required=True)
+    cap.add_argument("--host", choices=sorted(_HOSTS), default="ask",
+                     help="which IME host's journey to run "
+                          "(default: ask, the M2 journey)")
     cap.add_argument("--expected-head", default="")
     cap.add_argument("--fixture-root", default="",
                      help="AVD root holding M2_Qual_Fixture.avd "
@@ -191,6 +202,9 @@ def build_parser() -> argparse.ArgumentParser:
     fin.add_argument("--manifest", required=True)
     fin.add_argument("--run-dir", required=True)
     fin.add_argument("--evidence-commit", default="")
+    fin.add_argument("--host", choices=sorted(_HOSTS), default="ask",
+                     help="which host's canonical artifact set the "
+                          "manifest must match (default: ask)")
     fin.add_argument("--output", default=None)
     fin.set_defaults(func=cmd_finalize)
 

--- a/android/scripts/m2_device/evidence.py
+++ b/android/scripts/m2_device/evidence.py
@@ -62,12 +62,54 @@ CANONICAL_ARTIFACTS = frozenset(
 } | {CANONICAL_LEDGER_NAME, CANONICAL_EMULATOR_LOG_NAME}
 
 
-def enforce_canonical_set(manifest: dict[str, str]) -> None:
-    """The manifest must be exactly the canonical artifact set — no
-    missing, extra, renamed, or nested entries."""
+def _build_canonical_artifacts(png_names, hierarchy_labels) -> frozenset:
+    return (
+        frozenset(f"{n}.png" for n in png_names)
+        | {f"{CANONICAL_MP4_NAME}.mp4"}
+        | {f"{label}.xml" for label in hierarchy_labels}
+        | {CANONICAL_LEDGER_NAME, CANONICAL_EMULATOR_LOG_NAME}
+    )
+
+
+# FlorisBoard second-host journey (ADR-0010 P2): four product sessions
+# mirroring the ASK journey, plus the composing leg (draft typed
+# without the final period, per ADR-0003) and the settings-surface
+# session (the row's settings button launching the ported activity).
+FLORIS_CANONICAL_PNG_NAMES = (
+    "01-idle-typed", "02-loading-cancel", "03-review",
+    "04-applied", "05-dismissed", "06-stale",
+    "07-composing-typed", "08-composing-applied", "09-floris-settings",
+)
+FLORIS_CANONICAL_HIERARCHY_LABELS = (
+    "home_1", "focus_1", "typed_1", "after_cancel",
+    "home_2", "focus_2", "typed_2", "after_apply",
+    "home_3", "focus_3", "typed_3", "after_dismiss",
+    "home_4", "focus_4", "typed_4", "typed_stale", "after_stale",
+    "home_5", "focus_5", "typed_5", "after_composing",
+    "home_6", "focus_6", "floris_settings",
+    "verify_restore",
+)
+FLORIS_CANONICAL_ARTIFACTS = _build_canonical_artifacts(
+    FLORIS_CANONICAL_PNG_NAMES, FLORIS_CANONICAL_HIERARCHY_LABELS)
+# The mirrored sessions keep the ASK artifact names (01-idle-typed and
+# friends) so a shared step reads the same in both hosts' records; the
+# sets must still differ — a floris manifest carries the composing and
+# settings artifacts the ASK journey never produces, and finalize is
+# told the host explicitly, so overlap is unambiguous.
+assert FLORIS_CANONICAL_ARTIFACTS != CANONICAL_ARTIFACTS
+
+
+def enforce_canonical_set(
+    manifest: dict[str, str],
+    artifacts: frozenset = CANONICAL_ARTIFACTS,
+) -> None:
+    """The manifest must be exactly the given canonical artifact set —
+    no missing, extra, renamed, or nested entries. The default is the
+    ASK-journey set (byte-frozen by the #62/#64 acceptance matrix); the
+    floris journey passes its own."""
     actual = set(manifest)
-    missing = sorted(CANONICAL_ARTIFACTS - actual)
-    extra = sorted(actual - CANONICAL_ARTIFACTS)
+    missing = sorted(artifacts - actual)
+    extra = sorted(actual - artifacts)
     if missing:
         raise ValueError(f"canonical artifacts missing: {missing}")
     if extra:
@@ -318,6 +360,7 @@ def finalize(
     evidence_dir: str,
     *,
     evidence_commit: str = "",
+    canonical_artifacts: frozenset = CANONICAL_ARTIFACTS,
 ) -> FinalReceipt:
     """Produce the final receipt with every dimension derived from the
     exact bytes and the named capture steps. No caller-supplied verdict,
@@ -335,7 +378,7 @@ def finalize(
         raise ValueError("capture record has no manifest digest")
     if capture.manifest_digest != man_d:
         raise ValueError("capture-record manifest_digest does not match supplied manifest")
-    enforce_canonical_set(manifest)
+    enforce_canonical_set(manifest, canonical_artifacts)
     reject_nonflat(evidence_dir)
     for name in manifest:
         if "/" in name or ".." in name or os.path.isabs(name):

--- a/android/scripts/m2_device/floris_harness.py
+++ b/android/scripts/m2_device/floris_harness.py
@@ -1,0 +1,298 @@
+"""FlorisBoard second-host device journey harness (ADR-0010, P2).
+
+Reuses the M2 machinery end to end: same fixture transaction, same
+install signer gate, same binding/window/editor-text channels, same
+restore obligations. Only the host facts move — they were all
+calibrated live on the M2_Qual_Fixture on 2026-09-03 with the
+effect-verified probe method (raw-RGBA cluster scans for geometry,
+editor-text bridge for every tap's effect).
+
+The row-tap coordinates below are the panel's LAYOUT positions, not
+where the review card paints. The Floris host draws the expanded card
+above the IME window's pre-expansion top while its touch targets stay
+in the row's layout slot, so a tap on the painted "Use this" is a
+no-op and the layout-position tap is the one that applies (verified
+both ways on the fixture; tracked in issue #131). When that bug is
+fixed, these pins move to the painted positions and the fake
+toolchain follows.
+"""
+
+from __future__ import annotations
+
+import time
+
+from android.scripts.m2_device.adb_harness import (
+    AdbHarness,
+    CANDIDATE_REPHRASING,
+    REVIEW_SETTLE_SECONDS,
+    SOURCE_TEXT,
+    STALE_TEXT,
+)
+from android.scripts.m2_device.evidence import (
+    FLORIS_CANONICAL_HIERARCHY_LABELS,
+    FLORIS_CANONICAL_PNG_NAMES,
+)
+from android.scripts.m2_device.records import StepRecord
+
+FLORIS_KEY_COORDS: dict[str, tuple[int, int]] = {
+    "E": (273, 1760), "T": (486, 1760), "I": (808, 1760),
+    "A": (109, 1904), "S": (218, 1904),
+    "X": (330, 2054), "V": (541, 2054), "N": (752, 2054),
+    " ": (592, 2200), ".": (853, 2200),
+}
+FLORIS_SHIFT_TAP = (88, 2054)
+# Panel row taps (layout positions — see module docstring).
+FLORIS_REWRITE_TAP = (824, 1605)
+FLORIS_CANCEL_TAP = (824, 1605)
+FLORIS_APPLY_TAP = (120, 1605)
+FLORIS_DISMISS_TAP = (560, 1605)
+FLORIS_SETTINGS_TAP = (997, 1605)
+# InputMethod window touchable-region geometry: compact row tops at
+# 1413; the review card expands the window past 1365 (measured 1148).
+FLORIS_IME_COMPACT_TOP = 1413
+FLORIS_IME_EXPANDED_MAX_TOP = 1365
+# Rewrite -> Cancel rides one transport with an embedded sleep: the
+# taps must land inside the fixture provider's 400 ms loading window
+# but AFTER the row recomposes from Resting to Loading (back-to-back
+# taps hit the still-Resting Rewrite twice; 150 ms clears both bounds
+# on the fixture).
+FLORIS_CANCEL_INTER_TAP_SLEEP = "0.15"
+
+# The composing leg's draft deliberately omits the trailing period so
+# the last word is un-finalized when Rewrite captures it (ADR-0003).
+FLORIS_COMPOSING_SOURCE = "Tea at six"
+
+
+def floris_candidate(draft: str) -> str:
+    """The fixture FakeProvider's rephrasing contract: it echoes the
+    captured draft inside the butler sentence. The composing leg's
+    expected candidate differs from SOURCE's only in the echoed text
+    (no trailing period)."""
+    return (
+        "I have taken the liberty, sir, of rephrasing your words: "
+        f"\u201c{draft}\u201d \u2014 though I must confess the genuine article is still en route."
+    )
+
+
+FLORIS_COMPOSING_CANDIDATE = floris_candidate(FLORIS_COMPOSING_SOURCE)
+
+# The ported settings activity is a normal app window, so uiautomator
+# sees it — unlike every keyboard surface. These exact text facts are
+# what the journey requires from the dump.
+FLORIS_SETTINGS_TITLE_TEXT = "PersonaSpeak Settings"
+FLORIS_SETTINGS_SECTION_TEXT = "THE BRAIN"
+
+
+class FlorisAdbHarness(AdbHarness):
+    KEYBOARD_PACKAGE = "biz.pixelperfectstudios.personaspeak.floris.debug"
+    IME_COMPONENT = (
+        "biz.pixelperfectstudios.personaspeak.floris.debug"
+        "/dev.patrickgold.florisboard.FlorisImeService")
+    # Vendored FlorisBoard v0.5.2 debug build (applicationId suffix
+    # .debug; BUILD_COMMIT_HASH placeholder because the vendored tree
+    # has no .git). Signer is the same local debug certificate as the
+    # ASK debug builds, so the cert gate pins the identical digest.
+    EXPECTED_VERSION_NAME = "0.5.2-debug+null"
+    EXPECTED_VERSION_CODE = "117"
+    KEY_COORDS = FLORIS_KEY_COORDS
+    SHIFT_TAP = FLORIS_SHIFT_TAP
+    IME_COMPACT_TOP = FLORIS_IME_COMPACT_TOP
+    IME_EXPANDED_MAX_TOP = FLORIS_IME_EXPANDED_MAX_TOP
+    SCREENSHOT_NAMES = list(FLORIS_CANONICAL_PNG_NAMES)
+    HIERARCHY_LABELS = FLORIS_CANONICAL_HIERARCHY_LABELS
+
+    def _rewrite_cancel_shell(self) -> list[str]:
+        return [
+            "input", "tap", *map(str, FLORIS_REWRITE_TAP),
+            ";", "sleep", FLORIS_CANCEL_INTER_TAP_SLEEP,
+            ";", "input", "tap", *map(str, FLORIS_CANCEL_TAP),
+        ]
+
+    def _tap(self, steps, op, coord) -> bool:
+        res = self._shell("input", "tap", str(coord[0]), str(coord[1]))
+        return self._step(steps, op, res)
+
+    def _verify_floris_settings(self, steps, root) -> bool:
+        nodes = [elem for elem in root.iter()
+                 if elem.attrib.get("package", "") == self.KEYBOARD_PACKAGE]
+        texts = {n.attrib.get("text", "") for n in nodes}
+        errors = []
+        if not nodes:
+            errors.append("no floris-package nodes in dump")
+        if FLORIS_SETTINGS_TITLE_TEXT not in texts:
+            errors.append(f"title {FLORIS_SETTINGS_TITLE_TEXT!r} absent")
+        if FLORIS_SETTINGS_SECTION_TEXT not in texts:
+            errors.append(f"section {FLORIS_SETTINGS_SECTION_TEXT!r} absent")
+        if errors:
+            self._step(steps, "verify_floris_settings",
+                       self._fail("settings", "; ".join(errors).encode()))
+            return False
+        self._step(steps, "verify_floris_settings", self._ok("settings"))
+        return True
+
+    def run_journey(self) -> list[StepRecord]:
+        steps: list[StepRecord] = []
+
+        self.screenrecord_process = self._shell_start(
+            "screenrecord", "--time-limit", "30", "/sdcard/journey.mp4")
+
+        if not self._enable_ime(steps):
+            return steps
+        if not self._set_ime(steps):
+            return steps
+
+        # Session 1 — Idle, Loading/cancel: type through real Floris
+        # keys, trigger a rewrite, cancel it while loading. Zero
+        # mutations; the row's controls answer at their layout slots.
+        if not self._open_search_session(steps, 1):
+            return steps
+        if not self._type_text(steps, SOURCE_TEXT):
+            return steps
+        if not self._verify_editor_by_dump(steps, "typed_1", SOURCE_TEXT):
+            return steps
+        if not self._take_screenshot(steps, "01-idle-typed"):
+            return steps
+        res = self._shell(*self._rewrite_cancel_shell())
+        if not self._step(steps, "rewrite_and_cancel", res):
+            return steps
+        if not self._verify_editor_by_dump(
+                steps, "after_cancel", SOURCE_TEXT):
+            return steps
+        if not self._verify_window_state(steps, "after_cancel", expanded=False):
+            return steps
+        if not self._take_screenshot(steps, "02-loading-cancel"):
+            return steps
+        if not self._exit_session(steps, 1):
+            return steps
+
+        # Session 2 — Review, Applied: rewrite, wait out the provider
+        # latency, apply, and prove the exactly-one mutation.
+        if not self._open_search_session(steps, 2):
+            return steps
+        if not self._type_text(steps, SOURCE_TEXT):
+            return steps
+        if not self._verify_editor_by_dump(steps, "typed_2", SOURCE_TEXT):
+            return steps
+        if not self._tap(steps, "request_rewrite_2", FLORIS_REWRITE_TAP):
+            return steps
+        time.sleep(REVIEW_SETTLE_SECONDS)
+        if not self._verify_window_state(steps, "review_2", expanded=True):
+            return steps
+        if not self._take_screenshot(steps, "03-review"):
+            return steps
+        if not self._tap(steps, "apply_rephrasing", FLORIS_APPLY_TAP):
+            return steps
+        if not self._verify_editor_by_dump(
+                steps, "after_apply", CANDIDATE_REPHRASING):
+            return steps
+        if not self._take_screenshot(steps, "04-applied"):
+            return steps
+        if not self._exit_session(steps, 2):
+            return steps
+
+        # Session 3 — Dismiss: zero mutations, panel back to idle.
+        if not self._open_search_session(steps, 3):
+            return steps
+        if not self._type_text(steps, SOURCE_TEXT):
+            return steps
+        if not self._verify_editor_by_dump(steps, "typed_3", SOURCE_TEXT):
+            return steps
+        if not self._tap(steps, "request_rewrite_3", FLORIS_REWRITE_TAP):
+            return steps
+        time.sleep(REVIEW_SETTLE_SECONDS)
+        if not self._verify_window_state(steps, "review_3", expanded=True):
+            return steps
+        if not self._tap(steps, "dismiss_rephrasing", FLORIS_DISMISS_TAP):
+            return steps
+        if not self._verify_editor_by_dump(
+                steps, "after_dismiss", SOURCE_TEXT):
+            return steps
+        if not self._verify_window_state(steps, "after_dismiss", expanded=False):
+            return steps
+        if not self._take_screenshot(steps, "05-dismissed"):
+            return steps
+        if not self._exit_session(steps, 3):
+            return steps
+
+        # Session 4 — Stale: change the source under a pending
+        # candidate; the apply must make zero mutations.
+        if not self._open_search_session(steps, 4):
+            return steps
+        if not self._type_text(steps, SOURCE_TEXT):
+            return steps
+        if not self._verify_editor_by_dump(steps, "typed_4", SOURCE_TEXT):
+            return steps
+        if not self._tap(steps, "request_rewrite_4", FLORIS_REWRITE_TAP):
+            return steps
+        time.sleep(REVIEW_SETTLE_SECONDS)
+        if not self._verify_window_state(steps, "review_4", expanded=True):
+            return steps
+        if not self._clear_text(steps, SOURCE_TEXT):
+            return steps
+        if not self._type_text(steps, STALE_TEXT, "type_stale"):
+            return steps
+        if not self._verify_editor_by_dump(steps, "typed_stale", STALE_TEXT):
+            return steps
+        if not self._tap(steps, "apply_stale", FLORIS_APPLY_TAP):
+            return steps
+        if not self._verify_editor_by_dump(
+                steps, "after_stale", STALE_TEXT):
+            return steps
+        if not self._take_screenshot(steps, "06-stale"):
+            return steps
+        if not self._exit_session(steps, 4):
+            return steps
+
+        # Session 5 — Composing (ADR-0003): the draft omits the final
+        # period so the last word is un-finalized when Rewrite captures
+        # it; apply must still replace the entire draft. Span liveness
+        # itself is proven deterministically by the
+        # :personaspeak-ime real-InputConnection instrumentation test;
+        # this leg is the product-path proof through real Floris keys.
+        if not self._open_search_session(steps, 5):
+            return steps
+        if not self._type_text(steps, FLORIS_COMPOSING_SOURCE, "type_composing"):
+            return steps
+        if not self._verify_editor_by_dump(
+                steps, "typed_5", FLORIS_COMPOSING_SOURCE):
+            return steps
+        if not self._take_screenshot(steps, "07-composing-typed"):
+            return steps
+        if not self._tap(steps, "request_rewrite_5", FLORIS_REWRITE_TAP):
+            return steps
+        time.sleep(REVIEW_SETTLE_SECONDS)
+        if not self._verify_window_state(steps, "review_5", expanded=True):
+            return steps
+        if not self._tap(steps, "apply_composing", FLORIS_APPLY_TAP):
+            return steps
+        if not self._verify_editor_by_dump(
+                steps, "after_composing", FLORIS_COMPOSING_CANDIDATE):
+            return steps
+        if not self._take_screenshot(steps, "08-composing-applied"):
+            return steps
+        if not self._exit_session(steps, 5):
+            return steps
+
+        # Session 6 — Settings surface: the row's settings button
+        # launches the ported activity; uiautomator sees it (a normal
+        # app window) and the journey pins its identity facts.
+        if not self._open_search_session(steps, 6):
+            return steps
+        if not self._tap(steps, "tap_settings_button", FLORIS_SETTINGS_TAP):
+            return steps
+        res, root = self._dump_hierarchy("floris_settings")
+        if root is None:
+            self._step(steps, "dump_floris_settings", res)
+            return steps
+        self._step(steps, "dump_floris_settings", res)
+        if not self._verify_floris_settings(steps, root):
+            return steps
+        if not self._take_screenshot(steps, "09-floris-settings"):
+            return steps
+        res = self._shell("input", "keyevent", "4")
+        if not self._step(steps, "close_settings", res):
+            return steps
+        if not self._exit_session(steps, 6):
+            return steps
+
+        return steps

--- a/android/scripts/tests/m2_device/fixtures/bin/adb
+++ b/android/scripts/tests/m2_device/fixtures/bin/adb
@@ -42,8 +42,56 @@ CANDIDATE = os.environ.get("FAKE_ADB_REPHRASING", "")
 SOURCE = "Tea at six."
 STALE = "Tea at seven."
 
-COMPONENT = "biz.pixelperfectstudios.personaspeak/com.menny.android.anysoftkeyboard.SoftKeyboard"
-KEYBOARD_PACKAGE = "biz.pixelperfectstudios.personaspeak"
+# Host selection: the floris journey runs the same fake toolchain with
+# the FlorisBoard host's mirrored pins (calibrated on the fixture
+# 2026-09-03; see floris_harness.py). Default stays the ASK host.
+HOST = os.environ.get("FAKE_ADB_HOST", "ask")
+
+if HOST == "floris":
+    COMPONENT = (
+        "biz.pixelperfectstudios.personaspeak.floris.debug"
+        "/dev.patrickgold.florisboard.FlorisImeService")
+    KEYBOARD_PACKAGE = "biz.pixelperfectstudios.personaspeak.floris.debug"
+    KEY_COORDS = {
+        "t": (486, 1760), "e": (273, 1760), "a": (109, 1904),
+        "s": (218, 1904), "i": (808, 1760), "x": (330, 2054),
+        "v": (541, 2054), "n": (752, 2054),
+        " ": (592, 2200), ".": (853, 2200),
+    }
+    SHIFT_COORDS = (88, 2054)
+    # Layout-position taps: the floris host draws the review card
+    # above the row while its touch targets stay in the row slot
+    # (visual/touch desync, P2 probe 2026-09-03), so the pins — and
+    # this fake — answer at the layout positions.
+    REWRITE_TAP = (824, 1605)
+    CANCEL_TAP = (824, 1605)
+    APPLY_TAP = (120, 1605)
+    DISMISS_TAP = (560, 1605)
+    SETTINGS_TAP = (997, 1605)
+    COMPACT_TOP = 1413
+    EXPANDED_TOP = 1148
+    VERSION_NAME = "0.5.2-debug+null"
+    VERSION_CODE = "117"
+else:
+    COMPONENT = "biz.pixelperfectstudios.personaspeak/com.menny.android.anysoftkeyboard.SoftKeyboard"
+    KEYBOARD_PACKAGE = "biz.pixelperfectstudios.personaspeak"
+    KEY_COORDS = {
+        "t": (486, 1794), "e": (270, 1794), "a": (108, 1932),
+        "s": (216, 1932), "i": (810, 1794), "x": (324, 2072),
+        "v": (540, 2072), "n": (756, 2072),
+        " ": (567, 2210), ".": (756, 2210),
+    }
+    SHIFT_COORDS = (81, 2072)
+    REWRITE_TAP = (823, 1414)
+    CANCEL_TAP = (822, 1414)
+    APPLY_TAP = (120, 1390)
+    DISMISS_TAP = (560, 1390)
+    SETTINGS_TAP = None
+    COMPACT_TOP = 1378
+    EXPANDED_TOP = 1166
+    VERSION_NAME = "0.1.0"
+    VERSION_CODE = "1000"
+
 EDITOR_RES_ID = "com.google.android.settings.intelligence:id/open_search_view_edit_text"
 EDITOR_HINT = "Search settings"
 SEARCH_BAR_RES_ID = "com.android.settings:id/search_action_bar"
@@ -53,27 +101,19 @@ SEARCH_BAR_RES_ID = "com.android.settings:id/search_action_bar"
 # real keyboard has.
 SEARCH_BAR_BOUNDS = (42, 591, 1038, 728)
 EDITOR_BOUNDS = (126, 149, 1080, 275)
-KEY_COORDS = {
-    "t": (486, 1794), "e": (270, 1794), "a": (108, 1932),
-    "s": (216, 1932), "i": (810, 1794), "x": (324, 2072),
-    "v": (540, 2072), "n": (756, 2072),
-    " ": (567, 2210), ".": (756, 2210),
-}
-# Row-3 sticky shift: one shot, releases after the next letter. The
-# editor does not auto-capitalize (attempt-2 raw bytes, #82) — capitals
-# ride exactly this latch.
-SHIFT_COORDS = (81, 2072)
-# 2026-09-02 recalibration against the #87/#88 strip layout: Rewrite
-# and Cancel share the compact row's right end; Use this and Dismiss
-# sit in Review's expanded action row — separate slots now, so the
-# shared-slot shortcut of the pre-redesign row is gone.
-REWRITE_TAP = (823, 1414)
-CANCEL_TAP = (822, 1414)
-APPLY_TAP = (120, 1390)
-DISMISS_TAP = (560, 1390)
 TAP_SLOP = 54  # half a 108px key cell
-COMPACT_TOP = 1378
-EXPANDED_TOP = 1166
+
+
+def _candidate_for(source):
+    """The fixture FakeProvider's contract, as the floris journey pins
+    it: echo the captured draft inside the butler sentence. The ASK
+    fake keeps its fixed constant (and env override) untouched."""
+    if HOST != "floris":
+        return CANDIDATE
+    return (
+        "I have taken the liberty, sir, of rephrasing your words: "
+        "\u201c" + source + "\u201d \u2014 though I must confess "
+        "the genuine article is still en route.")
 
 
 def _read(path):
@@ -136,7 +176,24 @@ def _write_mp4(path):
 def _render_hierarchy(duplicate_editor=False):
     """Host-app nodes only. The IME window — keys, panel, candidate —
     is structurally invisible to uiautomator on API 34 and must never
-    appear here (issue #79)."""
+    appear here (issue #79). The Floris settings activity is a normal
+    app window, so it does appear (floris journey session 6)."""
+    if _read(SCREEN_FILE) == "floris_settings":
+        pkg = KEYBOARD_PACKAGE
+        return (
+            '<hierarchy rotation="0">'
+            f'<node index="0" text="PersonaSpeak Settings" resource-id="" '
+            f'class="android.widget.TextView" package="{pkg}" bounds="[42,171][700,255]"/>'
+            f'<node index="1" text="Get started" resource-id="" '
+            f'class="android.widget.TextView" package="{pkg}" bounds="[42,300][400,360]"/>'
+            f'<node index="2" text="CHARACTERS" resource-id="" '
+            f'class="android.widget.TextView" package="{pkg}" bounds="[42,700][500,755]"/>'
+            f'<node index="3" text="THE BRAIN" resource-id="" '
+            f'class="android.widget.TextView" package="{pkg}" bounds="[42,1300][400,1355]"/>'
+            f'<node index="4" text="AI Brain" resource-id="" '
+            f'class="android.widget.TextView" package="{pkg}" bounds="[42,1400][300,1455]"/>'
+            '</hierarchy>'
+        )
     if _read(SCREEN_FILE) == "search":
         text = _read(STATE_FILE)
         shown = text if text else EDITOR_HINT
@@ -311,9 +368,19 @@ def _run_tap(x, y):
         _write(KB_FILE, "")
         return
     if panel == "REVIEW" and _near(*APPLY_TAP):
-        if _read(STATE_FILE) == _read(CAND_SRC_FILE):
-            # Fresh candidate: exactly one mutation.
-            _write(STATE_FILE, CANDIDATE)
+        src = _read(CAND_SRC_FILE)
+        if _read(STATE_FILE) == src:
+            # Fresh candidate: exactly one mutation. The floris fake
+            # mirrors the fixture provider's echo-the-draft contract;
+            # the composing-bug knob replays the pre-fix failure shape
+            # (the live composing word survives the replace), which the
+            # journey must catch through the editor-text bridge.
+            replacement = _candidate_for(src)
+            if (HOST == "floris"
+                    and os.environ.get("FAKE_FLORIS_COMPOSING_BUG")
+                    and not src.endswith(".")):
+                replacement = src.split()[-1] + replacement
+            _write(STATE_FILE, replacement)
             _write(KB_FILE, "APPLIED")
         else:
             # Stale: zero mutations, candidate retained in Review.
@@ -321,6 +388,12 @@ def _run_tap(x, y):
         return
     if panel == "REVIEW" and _near(*DISMISS_TAP):
         _write(KB_FILE, "")
+        return
+    # The row's settings button (floris journey session 6): launches
+    # the ported activity, a normal app window uiautomator can see.
+    if (SETTINGS_TAP is not None and panel == ""
+            and _near(*SETTINGS_TAP) and _read(SCREEN_FILE) == "search"):
+        _write(SCREEN_FILE, "floris_settings")
         return
     # Key taps: the only insertion path, exactly the pinned geometry.
     shift = 60 if os.environ.get("FAKE_ADB_KEY_LAYOUT_SHIFTED") else 0
@@ -347,6 +420,11 @@ def _run_tap(x, y):
 
 def _run_keyevent(code):
     if code == "4":  # BACK
+        if _read(SCREEN_FILE) == "floris_settings":
+            # First BACK closes the ported settings activity; the
+            # search screen (and its editor state) survives beneath.
+            _write(SCREEN_FILE, "search")
+            return
         if _read(SCREEN_FILE) == "search":
             n = int(_read(BACK_COUNT_FILE) or "0") + 1
             if n == 1:
@@ -493,8 +571,8 @@ elif "install" in cmd and "pull" not in cmd:
     if os.environ.get("FAKE_ADB_INSTALL_FAIL"):
         sys.exit(1)
 elif "dumpsys package" in cmd and "personaspeak" in cmd:
-    print("versionName=0.1.0")
-    print("versionCode=1000")
+    print("versionName=" + VERSION_NAME)
+    print("versionCode=" + VERSION_CODE)
     print("signatures=PackageSignatures{c441f2a version:2, signatures:[847f3baa], past signatures:[]}")
 elif "wait-for-device" in cmd:
     pass

--- a/android/scripts/tests/m2_device/test_architecture.py
+++ b/android/scripts/tests/m2_device/test_architecture.py
@@ -39,6 +39,7 @@ class TestArchitecture(unittest.TestCase):
             'orchestrator.py',
             'records.py',
             'adb_harness.py',
+            'floris_harness.py',
         }
 
     def test_allowed_modules_only(self):
@@ -86,23 +87,33 @@ class TestArchitecture(unittest.TestCase):
             module_counts[name] = count
             total_lines += count
 
-        # adb_harness.py <= 1100 lines (2026-08-16: round-number raise at
-        # review suggestion — 997/1000 had no headroom; buys the #64/#62
-        # stages instead of one amendment per change)
+        # adb_harness.py <= 1120 lines (2026-09-03: +12 for the
+        # overridable host-fact class attributes that the FlorisBoard
+        # second-host journey subclasses — the 2026-08-16 1100 budget
+        # had 12 lines of headroom and the host-fact hooks consumed it)
         self.assertLessEqual(
             module_counts.get('adb_harness.py', 0),
-            1100,
-            f"adb_harness.py exceeds 1100 lines: {module_counts.get('adb_harness.py', 0)}"
+            1120,
+            f"adb_harness.py exceeds 1120 lines: {module_counts.get('adb_harness.py', 0)}"
         )
 
-        # total <= 2750 lines (2026-08-23: round-number raise for the
-        # #82 dry-run corrections — engine-log capture, post-restore
-        # settle, shift protocol, and diagnostic headless mode consume
-        # the 2026-08-16 headroom; stated in the correction PR)
+        # floris_harness.py <= 320 lines (2026-09-03: the FlorisBoard
+        # second-host journey — six sessions incl. the ADR-0003
+        # composing leg and the settings surface; identity pins and
+        # journey only, all shared phases inherited)
+        self.assertLessEqual(
+            module_counts.get('floris_harness.py', 0),
+            320,
+            f"floris_harness.py exceeds 320 lines: {module_counts.get('floris_harness.py', 0)}"
+        )
+
+        # total <= 3120 lines (2026-09-03: 2750 + the floris journey
+        # module (236) + the host-fact hooks (12) + the floris
+        # canonical-set block in evidence.py, rounded to headroom)
         self.assertLessEqual(
             total_lines,
-            2750,
-            f"Total production line count exceeds 2750 lines: {total_lines} ({module_counts})"
+            3120,
+            f"Total production line count exceeds 3120 lines: {total_lines} ({module_counts})"
         )
 
 

--- a/android/scripts/tests/m2_device/test_floris_acceptance.py
+++ b/android/scripts/tests/m2_device/test_floris_acceptance.py
@@ -1,0 +1,180 @@
+"""Fake-only acceptance test for the Floris second-host journey (P2).
+
+Drives the REAL CLI as a child process with the isolated fake
+toolchain and FAKE_ADB_HOST=floris: the full capture pipeline —
+fixture transaction, install identity gate, six journey sessions
+(idle/cancel, review/apply, dismiss, stale, composing, settings
+surface), evidence capture, snapshot restore, and release — must
+complete green with exactly the floris canonical artifact set.
+
+The composing-bug variant replays the pre-fix failure shape (the live
+composing word surviving the replace) through the fake and asserts the
+journey CATCHES it via the editor-text bridge: the ADR-0003 regression
+contract, executed device-free.
+"""
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+
+from android.scripts.m2_device import evidence
+from android.scripts.m2_device.records import CaptureRecord, TerminalCause, decode
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+BIN_DIR = os.path.join(HERE, "fixtures", "bin")
+REPO_ROOT_ABS = os.path.abspath(os.path.join(HERE, "..", "..", "..", ".."))
+
+
+class TestFlorisAcceptance(unittest.TestCase):
+
+    def setUp(self):
+        self.test_dir = os.path.abspath(
+            os.path.join(HERE, "fixtures", "scratch_workspace_floris"))
+        self.evidence_root = os.path.join(self.test_dir, "evidence")
+        self.repo_root = os.path.join(self.test_dir, "repo")
+        os.makedirs(self.evidence_root, exist_ok=True)
+        os.makedirs(self.repo_root, exist_ok=True)
+
+        self.fixture_root = os.path.join(self.test_dir, "avd")
+        self.fixture_digests_path = os.path.join(
+            self.test_dir, "fixture_digests.json")
+        digests = {}
+        for rel in ("M2_Qual_Fixture.avd/snapshots/m2_pristine/hardware.ini",
+                    "M2_Qual_Fixture.avd/snapshots/m2_pristine/ram.bin",
+                    "M2_Qual_Fixture.avd/snapshots/m2_pristine/textures.bin"):
+            path = os.path.join(self.fixture_root, *rel.split("/"))
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            content = f"fake-fixture:{rel}".encode()
+            with open(path, "wb") as f:
+                f.write(content)
+            digests[rel] = hashlib.sha256(content).hexdigest()
+        with open(self.fixture_digests_path, "w") as f:
+            json.dump(digests, f)
+
+        for args in (["git", "init"], ["git", "config", "user.email", "t@t"],
+                     ["git", "config", "user.name", "T"], ["git", "add", "-A"],
+                     ["git", "commit", "-m", "init"]):
+            subprocess.run(args, cwd=self.repo_root, capture_output=True)
+
+        self.apk_path = os.path.join(self.test_dir, "mock_floris.apk")
+        with open(self.apk_path, "wb") as f:
+            f.write(b"mock_floris_apk_binary")
+        self.apk_sha256 = hashlib.sha256(b"mock_floris_apk_binary").hexdigest()
+
+        self.state_files = {
+            "FAKE_ADB_STATE": os.path.join(self.test_dir, "edittext.state"),
+            "FAKE_ADB_KEYBOARD": os.path.join(self.test_dir, "keyboard.state"),
+            "FAKE_ADB_FOCUS": os.path.join(self.test_dir, "focus.state"),
+            "FAKE_ADB_SCREEN": os.path.join(self.test_dir, "screen.state"),
+            "FAKE_ADB_IME": os.path.join(self.test_dir, "ime.state"),
+            "FAKE_ADB_CANDIDATE_SOURCE": os.path.join(
+                self.test_dir, "candidate_source.state"),
+            "FAKE_ADB_SHIFT": os.path.join(self.test_dir, "shift.state"),
+            "FAKE_ADB_BACK": os.path.join(self.test_dir, "back.state"),
+            "FAKE_ADB_BOOT_POLLS_LEFT": os.path.join(
+                self.test_dir, "boot_polls_left.state"),
+        }
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    def _run_cli(self, extra_env=None):
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=self.repo_root, capture_output=True).stdout.decode().strip()
+        python_dir = os.path.dirname(sys.executable)
+        env = {
+            "PATH": BIN_DIR + os.pathsep + python_dir,
+            "HOME": os.environ.get("HOME", "/tmp"),
+            "PYTHONPATH": REPO_ROOT_ABS,
+            "FAKE_GIT_HEAD": head,
+            "FAKE_ADB_HOST": "floris",
+            **self.state_files,
+        }
+        for path in self.state_files.values():
+            with open(path, "w") as f:
+                f.write("")
+        if extra_env:
+            env.update(extra_env)
+        return subprocess.run(
+            [sys.executable, "-m", "android.scripts.m2_device.cli",
+             "capture",
+             "--host", "floris",
+             "--evidence-root", self.evidence_root,
+             "--repo-root", self.repo_root,
+             "--apk-path", self.apk_path,
+             "--apk-sha256", self.apk_sha256,
+             "--fixture-root", self.fixture_root,
+             "--fixture-digests", self.fixture_digests_path],
+            env=env, capture_output=True, cwd=REPO_ROOT_ABS, timeout=60,
+        )
+
+    def _latest_run_dir(self):
+        runs = sorted(os.listdir(self.evidence_root))
+        self.assertTrue(runs, "no evidence run produced")
+        return os.path.join(self.evidence_root, runs[-1])
+
+    def test_floris_journey_completes_green_with_canonical_set(self):
+        result = self._run_cli()
+        self.assertEqual(
+            result.returncode, 0,
+            f"CLI failed: {result.stderr.decode()}")
+
+        run_dir = self._latest_run_dir()
+        with open(os.path.join(run_dir, "capture-record.json"), "rb") as f:
+            record = decode(f.read())
+        self.assertIsInstance(record, CaptureRecord)
+        failed = [s for s in record.steps
+                  if s.cause != TerminalCause.COMPLETED]
+        self.assertEqual(failed, [], f"non-completed steps: {failed}")
+
+        phases = [s.phase for s in record.steps]
+        for phase in ("install", "journey", "capture", "restore",
+                      "verify_restore", "release_emulator", "verify_release"):
+            self.assertIn(phase, phases)
+
+        # The floris host's identity rode the install gate.
+        install = [s for s in record.steps if s.phase == "install"][0]
+        self.assertIn(
+            b"installed and identity verified",
+            install.result.stdout.lower())
+
+        # The six sessions' signature steps exist and completed.
+        ops = [s.operation for s in record.steps if s.phase == "journey"]
+        for op in ("rewrite_and_cancel", "apply_rephrasing",
+                   "dismiss_rephrasing", "apply_stale",
+                   "apply_composing", "tap_settings_button",
+                   "verify_floris_settings"):
+            self.assertIn(op, ops)
+
+        # The manifest is exactly the floris canonical set.
+        with open(os.path.join(run_dir, "manifest.json")) as f:
+            manifest = json.load(f)
+        evidence.enforce_canonical_set(
+            set(manifest), evidence.FLORIS_CANONICAL_ARTIFACTS)
+
+    def test_composing_bug_is_caught_by_the_editor_text_bridge(self):
+        result = self._run_cli(
+            extra_env={"FAKE_FLORIS_COMPOSING_BUG": "1"})
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("qualification failed", result.stderr.decode())
+
+        run_dir = self._latest_run_dir()
+        with open(os.path.join(run_dir, "capture-record.json"), "rb") as f:
+            record = decode(f.read())
+        failed = [s for s in record.steps
+                  if s.cause != TerminalCause.COMPLETED]
+        self.assertTrue(failed, "expected a failed step under the bug knob")
+        # The composing readback — the ADR-0003 regression signal — is
+        # the step that fails, with the remnant visible in its record.
+        self.assertEqual(failed[0].phase, "journey")
+        self.assertIn("after_composing", failed[0].operation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/android/scripts/tests/m2_device/test_floris_harness.py
+++ b/android/scripts/tests/m2_device/test_floris_harness.py
@@ -1,0 +1,154 @@
+"""Unit tests for the FlorisBoard second-host journey harness pins.
+
+The pins were calibrated live on the M2_Qual_Fixture (2026-09-03) with
+effect-verified taps; these tests pin the structural contract — the
+host identity facts, the provider echo formula shared with the fake
+toolchain, and the canonical artifact set separation — so drift fails
+device-free.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from android.scripts.m2_device.adb_harness import (
+    AdbHarness,
+    ASK_KEY_COORDS,
+    CANDIDATE_REPHRASING,
+    EXPECTED_VERSION_CODE as ASK_VC,
+    EXPECTED_VERSION_NAME as ASK_VN,
+    IME_COMPACT_TOP as ASK_COMPACT,
+    IME_COMPONENT as ASK_COMPONENT,
+    KEYBOARD_PACKAGE as ASK_PACKAGE,
+)
+from android.scripts.m2_device import evidence
+from android.scripts.m2_device.floris_harness import (
+    FLORIS_APPLY_TAP,
+    FLORIS_CANCEL_TAP,
+    FLORIS_COMPOSING_CANDIDATE,
+    FLORIS_COMPOSING_SOURCE,
+    FLORIS_DISMISS_TAP,
+    FLORIS_IME_COMPACT_TOP,
+    FLORIS_IME_EXPANDED_MAX_TOP,
+    FLORIS_KEY_COORDS,
+    FLORIS_REWRITE_TAP,
+    FLORIS_SETTINGS_TAP,
+    FLORIS_SHIFT_TAP,
+    FlorisAdbHarness,
+    floris_candidate,
+)
+
+
+class TestFlorisHostFacts(unittest.TestCase):
+
+    def setUp(self):
+        self.h = FlorisAdbHarness(run_dir="/tmp/x", apk_path="/tmp/a.apk")
+
+    def test_identity_is_the_floris_debug_build(self):
+        self.assertEqual(
+            self.h.KEYBOARD_PACKAGE,
+            "biz.pixelperfectstudios.personaspeak.floris.debug")
+        self.assertEqual(
+            self.h.IME_COMPONENT,
+            "biz.pixelperfectstudios.personaspeak.floris.debug"
+            "/dev.patrickgold.florisboard.FlorisImeService")
+        self.assertNotEqual(self.h.KEYBOARD_PACKAGE, ASK_PACKAGE)
+        self.assertNotEqual(self.h.IME_COMPONENT, ASK_COMPONENT)
+
+    def test_version_pins_are_florisboard_v052_debug(self):
+        self.assertEqual(self.h.EXPECTED_VERSION_NAME, "0.5.2-debug+null")
+        self.assertEqual(self.h.EXPECTED_VERSION_CODE, "117")
+        self.assertNotEqual(self.h.EXPECTED_VERSION_NAME, ASK_VN)
+        self.assertNotEqual(self.h.EXPECTED_VERSION_CODE, ASK_VC)
+
+    def test_signer_gate_pins_the_shared_debug_certificate(self):
+        # Both hosts' debug builds sign with the same local debug
+        # certificate (verified on the fixture 2026-09-03), so the
+        # floris gate inherits the ASK digest byte-for-byte.
+        self.assertEqual(
+            self.h.EXPECTED_SIGNER_CERT_SHA256,
+            AdbHarness.EXPECTED_SIGNER_CERT_SHA256)
+
+    def test_geometry_pins_differ_from_ask(self):
+        self.assertNotEqual(FLORIS_KEY_COORDS, ASK_KEY_COORDS)
+        self.assertNotEqual(FLORIS_IME_COMPACT_TOP, ASK_COMPACT)
+        # Every needed glyph for both drafts and the composing variant.
+        for ch in "TEASIXVN .":
+            self.assertIn(ch, FLORIS_KEY_COORDS, f"missing key {ch!r}")
+        # Compact/expanded discrimination window: the measured expanded
+        # top (1148) must sit well inside the bound, and the bound must
+        # stay clear of the compact top.
+        self.assertLess(FLORIS_IME_EXPANDED_MAX_TOP, FLORIS_IME_COMPACT_TOP)
+        self.assertGreater(FLORIS_IME_EXPANDED_MAX_TOP, 1200)
+
+    def test_row_taps_are_layout_positions(self):
+        # Rewrite and Cancel share the compact row slot (state-first
+        # dispatch, like the redesigned ASK strip); Apply and Dismiss
+        # are separate slots.
+        self.assertEqual(FLORIS_REWRITE_TAP, FLORIS_CANCEL_TAP)
+        self.assertNotEqual(FLORIS_APPLY_TAP, FLORIS_DISMISS_TAP)
+        for tap in (FLORIS_REWRITE_TAP, FLORIS_APPLY_TAP,
+                    FLORIS_DISMISS_TAP, FLORIS_SETTINGS_TAP,
+                    FLORIS_SHIFT_TAP):
+            self.assertEqual(len(tap), 2)
+
+    def test_rewrite_cancel_shell_embeds_inter_tap_sleep(self):
+        argv = self.h._rewrite_cancel_shell()
+        joined = " ".join(argv)
+        self.assertIn("sleep", joined)
+        # Two taps, three shell segments, one transport.
+        self.assertEqual(argv.count(";"), 2)
+        self.assertEqual(sum(1 for a in argv if a == "input"), 2)
+
+
+class TestProviderEchoFormula(unittest.TestCase):
+
+    def test_source_draft_reproduces_the_ask_candidate(self):
+        # The fixture FakeProvider echoes the captured draft; the ASK
+        # constant is the "Tea at six." instance of that contract, so
+        # the floris fake and harness stay byte-consistent with it.
+        self.assertEqual(floris_candidate("Tea at six."), CANDIDATE_REPHRASING)
+
+    def test_composing_candidate_quotes_the_unfinalized_draft(self):
+        self.assertEqual(FLORIS_COMPOSING_SOURCE, "Tea at six")
+        self.assertNotIn("\u201cTea at six.\u201d", FLORIS_COMPOSING_CANDIDATE)
+        self.assertIn("\u201cTea at six\u201d", FLORIS_COMPOSING_CANDIDATE)
+
+
+class TestFlorisCanonicalSet(unittest.TestCase):
+
+    def test_counts_match_the_journey_design(self):
+        self.assertEqual(len(evidence.FLORIS_CANONICAL_PNG_NAMES), 9)
+        self.assertEqual(len(evidence.FLORIS_CANONICAL_HIERARCHY_LABELS), 25)
+        self.assertEqual(
+            len(FlorisAdbHarness.SCREENSHOT_NAMES), 9)
+        self.assertEqual(
+            len(FlorisAdbHarness.HIERARCHY_LABELS), 25)
+
+    def test_floris_manifest_enforced_against_its_own_set(self):
+        evidence.enforce_canonical_set(
+            set(evidence.FLORIS_CANONICAL_ARTIFACTS),
+            evidence.FLORIS_CANONICAL_ARTIFACTS)
+
+    def test_floris_manifest_rejected_by_the_ask_default(self):
+        with self.assertRaises(ValueError):
+            evidence.enforce_canonical_set(
+                set(evidence.FLORIS_CANONICAL_ARTIFACTS))
+
+    def test_ask_manifest_rejected_by_the_floris_set(self):
+        with self.assertRaises(ValueError):
+            evidence.enforce_canonical_set(
+                set(evidence.CANONICAL_ARTIFACTS),
+                evidence.FLORIS_CANONICAL_ARTIFACTS)
+
+    def test_composing_and_settings_artifacts_present(self):
+        floris = set(evidence.FLORIS_CANONICAL_ARTIFACTS)
+        for name in ("07-composing-typed.png", "08-composing-applied.png",
+                     "09-floris-settings.png", "after_composing.xml",
+                     "floris_settings.xml"):
+            self.assertIn(name, floris)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

The M2 device-journey machinery now runs the **FlorisBoard second host** end to end (`--host floris` on the capture CLI): a six-session journey — idle/loading-cancel, review/apply, dismiss, stale, **composing** (ADR-0003), and the **settings surface** — through the same pinned fixture transaction, signer gate, binding/window channels, editor-text bridge, and snapshot-restore obligations as the ASK journey. Plus the ADR-0003 composing obligation done properly:

- A real-InputConnection **instrumentation test** in `:personaspeak-ime` (`RealInputConnectionComposingTest`): builds a live composing span on a real EditText via its real InputConnection, runs `captureSnapshot` → `attemptReplace`, asserts the whole buffer becomes the candidate with zero composing spans remaining — for both the API-34 `replaceText` path and the legacy finish/select/commit path. 2/2 green on the M2_Qual_Fixture.
- A journey leg that types the draft **without the trailing period** through real Floris keys and proves apply still replaces the entire draft.
- The pre-fix failure shape is a fake-toolchain knob (`FAKE_FLORIS_COMPOSING_BUG`) the fake adb replays; a dedicated acceptance test proves the journey **catches** it at `after_composing` through the editor-text bridge. The regression contract itself is tested.

## Found on the way: a real bug (#131)

Calibration discovered the Floris host paints the review card ~300px above where its buttons respond (drawn vs layout desync). Taps on the *painted* "Use this"/"Again"/"Dismiss" are no-ops; the controls answer at the row's layout positions. The P0 proof verified via the accessibility dump, which reports layout positions — the same positions the taps used — so the desync was invisible to it. The journey drives the working layout positions and documents the trap in `floris_harness.py`; the fix (tracked in #131) moves the pins. This is exactly the class of finding the ADR-0010 journey gates exist to surface.

## Evidence (evidence branch: `evidence` @ f7ff38f, `floris-journey/20260903T170746Z`)

- **Real device journey, counted run `20260903T170746Z`**: 180 steps, 167 journey steps, zero non-completed, `verify_restore`/`release_emulator`/`verify_release` all COMPLETED, canonical artifact set exact (9 PNG, 1 MP4, 25 XML) at repo head `6016da90`, APK `961bf957…` (same debug certificate as the ASK debug builds — verified on the fixture).
- **ADR-0003 instrumentation**: `:personaspeak-ime:connectedDebugAndroidTest` → `Finished 2 tests on M2_Qual_Fixture(AVD) - 14`, BUILD SUCCESSFUL (receipt XML rides the evidence branch). Cannot run in CI (no emulator in runners); CI instead **compiles** the instrumentation APK on every ready PR so it cannot silently rot.
- **Fake-toolchain suite**: `python -m unittest discover -s android/scripts/tests/m2_device` → **376/376 OK** (361 pre-existing untouched-green + 15 new; ASK golden argv sequence byte-identical).
- Every tap pin was effect-verified on the fixture (editor-text readback per key/button; window touchable-region geometry compact 1413 / expanded 1148).

## Notes for reviewers

- `adb_harness.py` host facts became overridable class attributes (defaults = the ASK module pins); no ASK behavior or argv byte changed — the golden contact ledger test proves it.
- The evidence canonical set is now per-host (`FLORIS_CANONICAL_ARTIFACTS`); `finalize`/`approve` take `--host`, default `ask`. The ASK set is frozen; the two sets are asserted non-identical.
- Architecture budgets amended with stated reasons (new `floris_harness.py` ≤ 320, adb_harness 1100 → 1120 for the host-fact hooks, total 2750 → 3120).
- Version-catalog addition: `androidx.test:runner` (the standard instrumentation harness; no 30-line substitute exists for on-device tests).

Non-author review skipped: no non-author agent available at execution time (owner AFK, single-agent run). Owner review pending.
