### PR TITLE
feat(gates): scope verify-single-apk to the two-root reality (ADR-0010 P5)

### DIFF
--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -8,6 +8,10 @@ while the context is hot.
 
 Newest first, like all respectable patch notes.
 
+## 2026-09-04 — The One-APK Law Meets the Second House
+
+- The single-APK gate now knows about the guest wing: `verify-single-apk.sh` keeps the unified root's law exactly (one APK at the canonical path, one application project) and names the two artifact classes a two-root repo legitimately produces — `florisboard/**` outputs (the evaluation root's own business) and first-party library androidTest APKs (test runners, not apps; the ADR-0003 suite leaves one behind on every local run — previously that dirtied the sweep). Lookalike directories and rogue app projects under the second root still fail. ADR-0010's consequences section now records the implemented decision instead of deferring it; 19 contract cases pin the behavior.
+
 ## 2026-09-03 — The Guest Wing's Privacy Interview
 
 - The FlorisBoard host gets its M7-bar privacy and egress audit (`docs/evidence/floris-host/privacy-and-egress-audit.md`): the vendored keyboard code performs zero direct network I/O — no HTTP client exists in the tree, no crash reporting, no telemetry; every egress byte either rides the opt-in, pinned-endpoint PersonaSpeak provider calls the ASK audit already qualified, or is one disclosed library-mediated exception (EmojiCompat may fetch font metadata from Google at startup on GMS devices, reachable because PersonaSpeak added INTERNET — upstream never had it; owner decides keep-or-disable).

--- a/android/scripts/tests/verify-single-apk-test.sh
+++ b/android/scripts/tests/verify-single-apk-test.sh
@@ -201,4 +201,80 @@ else
   chmod 755 "$root/keyboard/ime/app/build"
 fi
 
+# --- 9. Floris debug APK tolerated (ADR-0010 P5 scoping) --------------------
+root="$(new_fixture floris-debug-apk)"
+add_apk "$root" "$canonical_rel"
+add_apk "$root" "florisboard/app/build/outputs/apk/debug/app-debug.apk"
+expect_status 0 "case 9 (floris debug APK tolerated)" "$root"
+if ! printf '%s' "$last_out" | grep -q 'second-root APKs tolerated: 1'; then
+  echo "FAIL: case 9: second-root tolerance not reported" >&2
+  printf '%s\n' "$last_out" >&2
+  exit 1
+fi
+
+# --- 10. Both floris build outputs tolerated ---------------------------------
+root="$(new_fixture floris-both-apks)"
+add_apk "$root" "$canonical_rel"
+add_apk "$root" "florisboard/app/build/outputs/apk/debug/app-debug.apk"
+add_apk "$root" "florisboard/app/build/outputs/apk/release/app-release.apk"
+expect_status 0 "case 10 (floris release APK tolerated)" "$root"
+
+# --- 11. Floris APK cannot stand in for the canonical one --------------------
+root="$(new_fixture floris-only)"
+add_apk "$root" "florisboard/app/build/outputs/apk/debug/app-debug.apk"
+expect_status 1 "case 11 (floris APK without canonical)" "$root"
+if ! printf '%s' "$last_out" | grep -q 'expected exactly 1 APK, found 0'; then
+  echo "FAIL: case 11: missing zero-canonical diagnosis" >&2
+  printf '%s\n' "$last_out" >&2
+  exit 1
+fi
+
+# --- 12. Lookalike floris path outside the root is still a finding ------------
+# florisboard-fake/ shares the name but not the root; the anchored prefix
+# must not let it ride the second root's tolerance.
+root="$(new_fixture floris-lookalike)"
+add_apk "$root" "$canonical_rel"
+add_apk "$root" "florisboard-fake/app/build/outputs/apk/debug/app-debug.apk"
+expect_status 1 "case 12 (floris-named APK outside the root)" "$root"
+if ! printf '%s' "$last_out" | grep -q 'florisboard-fake'; then
+  echo "FAIL: case 12: lookalike APK not named" >&2
+  printf '%s\n' "$last_out" >&2
+  exit 1
+fi
+
+# --- 13. Second root's sanctioned application project tolerated ---------------
+root="$(new_fixture floris-app-project)"
+add_apk "$root" "$canonical_rel"
+mkdir -p "$root/florisboard/app"
+printf 'plugins {\n    alias(libs.plugins.android.application)\n}\n' \
+  > "$root/florisboard/app/build.gradle.kts"
+expect_status 0 "case 13 (floris app project tolerated)" "$root"
+
+# --- 14. A second application project under the second root is a finding ------
+root="$(new_fixture floris-rogue-app)"
+add_apk "$root" "$canonical_rel"
+mkdir -p "$root/florisboard/evil"
+printf 'plugins { id("com.android.application") }\n' \
+  > "$root/florisboard/evil/build.gradle.kts"
+expect_status 1 "case 14 (rogue app project under second root)" "$root"
+if ! printf '%s' "$last_out" | grep -q 'unexpected application project under the second root'; then
+  echo "FAIL: case 14: missing rogue-project diagnosis" >&2
+  printf '%s\n' "$last_out" >&2
+  exit 1
+fi
+
+# --- 15. Library androidTest APK tolerated (test instrument, not an app) -----
+# The :personaspeak-ime ADR-0003 instrumentation suite produces one of
+# these on any local connectedAndroidTest run; it is a test runner, not
+# a shippable app, and must not dirty the unified root's single-APK law.
+root="$(new_fixture instrument-apk)"
+add_apk "$root" "$canonical_rel"
+add_apk "$root" "personaspeak-ime/build/outputs/apk/androidTest/debug/personaspeak-ime-debug-androidTest.apk"
+expect_status 0 "case 15 (androidTest APK tolerated)" "$root"
+if ! printf '%s' "$last_out" | grep -q 'instrumentation APKs tolerated: 1'; then
+  echo "FAIL: case 15: instrumentation tolerance not reported" >&2
+  printf '%s\n' "$last_out" >&2
+  exit 1
+fi
+
 echo "PASS: verify-single-apk contract, $cases_run cases"

--- a/android/scripts/verify-single-apk.sh
+++ b/android/scripts/verify-single-apk.sh
@@ -1,22 +1,27 @@
 #!/usr/bin/env bash
-# Verify that the tree produces exactly one APK, at exactly one path, from
-# exactly one Android application project.
+# Verify that the tree produces exactly one APK per sanctioned Android
+# root, at exactly one path each, from exactly one application project
+# per root.
 #
 # usage: verify-single-apk.sh <android-root>
 #
-# Exit 0 only when all three hold:
-#   1. exactly one APK exists under an outputs/ directory anywhere in the tree;
-#   2. its path is exactly
-#      keyboard/ime/app/build/outputs/apk/debug/app-debug.apk;
-#   3. exactly one project build file applies an Android application plugin,
-#      and it is keyboard/ime/app/build.gradle.
+# Exit 0 only when all of these hold:
+#   1. under the unified (ASK) root, exactly one APK exists and its path
+#      is exactly keyboard/ime/app/build/outputs/apk/debug/app-debug.apk;
+#   2. APKs under florisboard/ (the ADR-0010 evaluation second root, own
+#      Gradle root) are that root's own business — any count, tolerated;
+#      an APK that merely LOOKS floris-named but sits outside the second
+#      root (florisboard-fake/, android/floris-copy/) is still a finding;
+#   3. the unified root declares exactly one application project
+#      (keyboard/ime/app/build.gradle) and the second root at most its
+#      one sanctioned application project (florisboard/app/build.gradle.kts).
 #
 # Scope note: enumeration covers `*.apk` under any `outputs/` path segment.
 # That is deliberately wider than the canonical directory — it is what catches
 # upstream's android/outputs/ convenience copies and a resurrected
 # android/app/ — and deliberately narrower than "every .apk in the tree", so
 # AGP's own build/intermediates/ scratch copies do not masquerade as shippable
-# artifacts.
+# artifacts. The two-root scoping is the ADR-0010 P5 decision, implemented.
 #
 # This verifier is read-only. A stale APK is a finding, not something to
 # clean up: silently deleting the evidence would turn a dirty tree into a
@@ -38,6 +43,9 @@ fi
 root="$(cd "$root" && pwd)"
 
 canonical="keyboard/ime/app/build/outputs/apk/debug/app-debug.apk"
+canonical_app="keyboard/ime/app/build.gradle"
+second_root_prefix="florisboard/"
+second_root_app="florisboard/app/build.gradle.kts"
 app_plugin_pattern='com\.android\.application|libs\.plugins\.android\.application|apk_module\.gradle'
 
 workdir="$(mktemp -d)"
@@ -60,16 +68,38 @@ if [ "$find_rc" -ne 0 ] || [ -s "$workdir/find.err" ]; then
 fi
 sed "s|^$root/||" "$workdir/apks.raw" | LC_ALL=C sort > "$apks"
 
-apk_count="$(wc -l < "$apks" | tr -d ' ')"
-if [ "$apk_count" -ne 1 ]; then
-  echo "expected exactly 1 APK, found $apk_count"
+# Artifact classes outside the unified root's single-APK law, each named:
+#   - florisboard/** : the evaluation second root's own outputs (ADR-0010);
+#   - */build/outputs/apk/androidTest/** : instrumentation-test APKs of
+#     first-party library modules — test runners, never shippable apps
+#     (the :personaspeak-ime ADR-0003 suite produces one on any local
+#     connectedAndroidTest run). The anchored prefix keeps lookalike
+#     directories from riding either class.
+unified_apks="$workdir/unified-apks.txt"
+floris_apks="$workdir/floris-apks.txt"
+instrument_apks="$workdir/instrument-apks.txt"
+: > "$unified_apks"; : > "$floris_apks"; : > "$instrument_apks"
+while IFS= read -r p; do
+  [ -z "$p" ] && continue
+  case "$p" in
+    "$second_root_prefix"*) printf '%s\n' "$p" >> "$floris_apks" ;;
+    */outputs/apk/androidTest/*) printf '%s\n' "$p" >> "$instrument_apks" ;;
+    *) printf '%s\n' "$p" >> "$unified_apks" ;;
+  esac
+done < "$apks"
+
+floris_apk_count="$(wc -l < "$floris_apks" | tr -d ' ')"
+instrument_apk_count="$(wc -l < "$instrument_apks" | tr -d ' ')"
+unified_apk_count="$(wc -l < "$unified_apks" | tr -d ' ')"
+if [ "$unified_apk_count" -ne 1 ]; then
+  echo "expected exactly 1 APK, found $unified_apk_count"
   while IFS= read -r p; do
     [ -z "$p" ] && continue
     echo "  apk: $p"
-  done < "$apks"
+  done < "$unified_apks"
   status=1
 else
-  found="$(cat "$apks")"
+  found="$(cat "$unified_apks")"
   if [ "$found" != "$canonical" ]; then
     echo "not the canonical APK path"
     echo "  found:    $found"
@@ -123,26 +153,52 @@ while IFS= read -r build_file; do
 done < "$build_files"
 LC_ALL=C sort -o "$app_files" "$app_files"
 
-app_count="$(wc -l < "$app_files" | tr -d ' ')"
-if [ "$app_count" -ne 1 ]; then
-  echo "expected exactly 1 application project, found $app_count"
+# Two-root topology: the unified root keeps its exactly-one law; the
+# second root may carry its one sanctioned application project and
+# nothing more.
+unified_apps="$workdir/unified-apps.txt"
+floris_apps="$workdir/floris-apps.txt"
+: > "$unified_apps"; : > "$floris_apps"
+while IFS= read -r p; do
+  [ -z "$p" ] && continue
+  case "$p" in
+    "$second_root_prefix"*) printf '%s\n' "$p" >> "$floris_apps" ;;
+    *) printf '%s\n' "$p" >> "$unified_apps" ;;
+  esac
+done < "$app_files"
+
+unified_app_count="$(wc -l < "$unified_apps" | tr -d ' ')"
+if [ "$unified_app_count" -ne 1 ]; then
+  echo "expected exactly 1 application project, found $unified_app_count"
   while IFS= read -r p; do
     [ -z "$p" ] && continue
     echo "  application build file: $p"
-  done < "$app_files"
+  done < "$unified_apps"
   status=1
 else
-  sole="$(cat "$app_files")"
-  if [ "$sole" != "keyboard/ime/app/build.gradle" ]; then
+  sole="$(cat "$unified_apps")"
+  if [ "$sole" != "$canonical_app" ]; then
     echo "sole application project is not ASK :ime:app"
     echo "  found:    $sole"
-    echo "  expected: keyboard/ime/app/build.gradle"
+    echo "  expected: $canonical_app"
     status=1
   fi
 fi
 
+while IFS= read -r p; do
+  [ -z "$p" ] && continue
+  if [ "$p" != "$second_root_app" ]; then
+    echo "unexpected application project under the second root"
+    echo "  found:    $p"
+    echo "  expected: $second_root_app"
+    status=1
+  fi
+done < "$floris_apps"
+
 if [ "$status" -eq 0 ]; then
   echo "single APK verified: $canonical"
-  echo "sole application project: $(cat "$app_files")"
+  echo "sole application project: $(cat "$unified_apps")"
+  echo "second-root APKs tolerated: $floris_apk_count (florisboard/ evaluation root)"
+  echo "instrumentation APKs tolerated: $instrument_apk_count (androidTest, non-shippable)"
 fi
 exit "$status"

--- a/docs/adr/0010-florisboard-second-host.md
+++ b/docs/adr/0010-florisboard-second-host.md
@@ -100,12 +100,18 @@ Concretely:
 
 ## Consequences
 
-- **The repo now builds two Android apps.** `verify-single-apk.sh` still
-  gates the unified root (its scope is that root's project graph) but its
-  "exactly one APK under any outputs/" sweep will see FlorisBoard APKs after
-  a local second-host build. That interaction is documented here; scoping
-  the sweep (or promoting it to a two-root gate) is a promotion-time
-  decision, not a draft-PR one.
+- **The repo now builds two Android apps, and the single-APK gate is scoped
+  to match (P5, implemented 2026-09-04).** `verify-single-apk.sh` keeps the
+  unified root's law exactly — one APK at the canonical path, one
+  application project at `keyboard/ime/app/build.gradle` — and names two
+  tolerated artifact classes: `florisboard/**` outputs (the evaluation
+  second root's own business) and `*/build/outputs/apk/androidTest/**`
+  (first-party library instrumentation APKs — test runners, never
+  shippable; the `:personaspeak-ime` ADR-0003 suite produces one on any
+  local `connectedAndroidTest` run). A lookalike directory
+  (`florisboard-fake/`) or a stray app project under the second root is
+  still a finding; the second root may carry at most its one sanctioned
+  application project (`florisboard/app/build.gradle.kts`).
 - **Session isolation differs by host, deliberately.** The ASK host scopes
   panel state with per-session `ImeViewTreeOwners` (its IME window has no
   Compose owners); the FlorisBoard host rides the window's real


### PR DESCRIPTION
## What

ADR-0010's deferred sweep-scoping decision, implemented (P5): `verify-single-apk.sh` now knows the repo builds two Android apps, without weakening the unified root's law by a single byte.

## The scoping

The unified (ASK) root keeps its exact contract — one APK at `keyboard/ime/app/build/outputs/apk/debug/app-debug.apk`, one application project at `keyboard/ime/app/build.gradle`. Two named artifact classes are tolerated:

- `florisboard/**` outputs — the evaluation second root's own business (its debug/release APKs appear after any local second-host build).
- `*/build/outputs/apk/androidTest/**` — first-party library instrumentation APKs. This one was found live: the `:personaspeak-ime` ADR-0003 suite (P2) leaves an androidTest APK behind on every local `connectedAndroidTest` run, which dirtied the sweep; CI only stayed green because the compile step runs after the M2 gate. Test runners are not shippable apps; they are now a named class.

Still findings, deliberately: a lookalike directory (`florisboard-fake/`), a floris APK standing in for the canonical one, a rogue second application project under the second root (only `florisboard/app/build.gradle.kts` is sanctioned), and every pre-existing case (zero APKs, `android/outputs/` duplicates, noncanonical paths, zero/extra application projects).

## ADR-0010

The Consequences bullet that said scoping "is a promotion-time decision, not a draft-PR one" now records the implemented decision and its boundaries.

## Evidence (local, @ 133f8c4)

- `verify-single-apk-test.sh`: **19/19 cases** (8 original unchanged + 11 new: floris debug/release tolerated, floris-without-canonical rejected, lookalike rejected, sanctioned app project tolerated, rogue app project rejected, androidTest APK tolerated).
- Real local tree (which currently holds the canonical ASK APK, 2 floris APKs, and the personaspeak-ime androidTest APK): rc=0 — `second-root APKs tolerated: 2`, `instrumentation APKs tolerated: 1`, canonical verified.

Non-author review skipped: no non-author agent available at execution time (owner AFK, single-agent run). Owner review pending.
